### PR TITLE
IGAPP-807: Prepare metadata fails if source does not exist

### DIFF
--- a/tools/manage-metadata.ts
+++ b/tools/manage-metadata.ts
@@ -61,7 +61,7 @@ const formatNotes = (params: {
 
   const formattedNotes = notes
     .map(note => {
-      const localizedNote = note.de ?? note.en
+      const localizedNote = language === 'en' || !note.de ? note.en : note.de
       // Double quotes make mattermost status alerts fail
       const escapedNote = localizedNote.replace(/"/g, "'")
       return production ? `* ${escapedNote}` : `* [ ${note.issue_key} ] ${escapedNote}`


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.integreat-app.de/).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **IGAPP**.

Release notes are required to promote ios builds to production. Therefore use default release notes if none available. Also fixes the language of the release notes in english. Apart from these two issues metadata preparation/delivery seems to work like a charm :)
