### PR TITLE
IGAPP-826: Second release fails

### DIFF
--- a/tools/create-jira-release
+++ b/tools/create-jira-release
@@ -75,9 +75,12 @@ const createRelease = async ({ newVersionName, accessToken, privateKey, consumer
   }, accessToken, privateKey, consumerKey)
 
   // Get the new and the last release
-  const { values: [newVersion, lastVersion] } = await getFromJira(
-    `/rest/api/2/project/${projectKey}/version?orderBy=-releaseDate&maxResults=2`
+  const { values: versions } = await getFromJira(
+    `/rest/api/2/project/${projectKey}/version?orderBy=-releaseDate&maxResults=5`
   )
+
+  const newVersion = versions.find(version => version.name === newVersionName)
+  const lastVersion = versions.find(version => version.name !== newVersionName)
 
   if (newVersion.name !== newVersionName) {
     throw Error(`There is already a release ${newVersion.name} with a later release date in the project!`)
@@ -86,7 +89,7 @@ const createRelease = async ({ newVersionName, accessToken, privateKey, consumer
   const lastDate = lastVersion ? lastVersion.releaseDate : '1970-01-01'
   // Get all issues which should be part of the new release
   const query =
-    `project = ${projectName} AND fixVersion IS EMPTY AND resolution = Done AND resolutiondate > ${lastDate}`
+    `project = ${projectName} AND fixVersion IS EMPTY AND resolution = Done AND resolutiondate >= ${lastDate}`
   // If 'maxResults' is bigger than 'jira.search.views.default.max', the results are truncated.
   // https://docs.atlassian.com/software/jira/docs/api/REST/8.9.0/#api/2/search-search
   // https://issues.tuerantuer.org/secure/admin/ViewSystemInfo.jspa


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.integreat-app.de/).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **IGAPP**.
