### PR TITLE
IGAPP-965: Ensure that inAppBrowser was closed before

### DIFF
--- a/native/src/utils/__tests__/openExternalUrl.spec.ts
+++ b/native/src/utils/__tests__/openExternalUrl.spec.ts
@@ -12,6 +12,7 @@ jest.mock('@sentry/react-native', () => ({
 }))
 jest.mock('react-native-inappbrowser-reborn', () => ({
   open: jest.fn(),
+  close: jest.fn(),
   isAvailable: jest.fn(() => true)
 }))
 jest.mock('../../utils/sendTrackingSignal')
@@ -28,6 +29,7 @@ describe('openExternalUrl', () => {
   it('should open http urls in inapp browser', async () => {
     const url = 'https://som.niceli.nk/mor/etext'
     await openExternalUrl(url)
+    expect(InAppBrowser.close).toHaveBeenCalled()
     expect(InAppBrowser.open).toHaveBeenLastCalledWith(url, expect.anything())
     expect(Linking.openURL).not.toHaveBeenCalled()
     expect(sendTrackingSignal).toHaveBeenCalledTimes(1)
@@ -39,7 +41,8 @@ describe('openExternalUrl', () => {
     })
     const url2 = 'http://som.niceli.nk/les/stext'
     await openExternalUrl(url2)
-    expect(InAppBrowser.open).toHaveBeenLastCalledWith(url2, expect.anything())
+    expect(InAppBrowser.close).toHaveBeenCalled()
+    expect(await InAppBrowser.open).toHaveBeenLastCalledWith(url2, expect.anything())
     expect(Linking.openURL).not.toHaveBeenCalled()
     expect(sendTrackingSignal).toHaveBeenCalledWith({
       signal: {

--- a/native/src/utils/openExternalUrl.ts
+++ b/native/src/utils/openExternalUrl.ts
@@ -20,6 +20,7 @@ const openExternalUrl = async (url: string): Promise<void> => {
           url
         }
       })
+      await InAppBrowser.close()
       await InAppBrowser.open(url, {
         toolbarColor: buildConfig().lightTheme.colors.themeColor
       })

--- a/release-notes/unreleased/IGAPP-965-inappbrowser-already-opened-error.yml
+++ b/release-notes/unreleased/IGAPP-965-inappbrowser-already-opened-error.yml
@@ -1,0 +1,6 @@
+issue_key: IGAPP-965
+show_in_stores: true
+platforms:
+  - ios
+en: Fix multiple inappbrowser opened.
+de: Fehler mit mehreren gleichzeitig geöffneten InAppBrowsern behoben.

--- a/release-notes/unreleased/IGAPP-965-inappbrowser-already-opened-error.yml
+++ b/release-notes/unreleased/IGAPP-965-inappbrowser-already-opened-error.yml
@@ -1,6 +1,5 @@
 issue_key: IGAPP-965
-show_in_stores: true
+show_in_stores: false
 platforms:
   - ios
 en: Fix multiple inappbrowser opened.
-de: Fehler mit mehreren gleichzeitig geöffneten InAppBrowsern behoben.


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.integreat-app.de/).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **IGAPP**.

Issue is really hard and random to reproduce. Couldn't reproduce after the fix. But i'm not 100% sure if it does the trick

Open IOS Emulator/ Device
1. GoTo Testumgebung --> Corona-Virus -> Information zum Corona Virus
2. open link --> swipe from left to right
3. open next link
