### PR TITLE
IGAPP-990: Open external map link opens directly apple maps on ios

### DIFF
--- a/web/src/utils/getNavigationDeepLinks.ts
+++ b/web/src/utils/getNavigationDeepLinks.ts
@@ -10,12 +10,8 @@ export const getNavigationDeepLinks = (location: LocationModel, title: string): 
   const long = location.coordinates[0]
   const lat = location.coordinates[1]
 
-  const isIos = /iPhone|iPad|iPod/i.test(navigator.userAgent)
   const isAndroid = /Android/i.test(navigator.userAgent)
 
-  if (isIos) {
-    return `maps:${lat},${long}?q=${location.location}`
-  }
   if (isAndroid) {
     return `geo:${lat},${long}?q=${location.location}`
   }


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.integreat-app.de/).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **IGAPP**.

1. Go to POIS and select a poi
2. click on open external link
3. if GMaps is installed the app gonna be open
4. if GMaps is not installed GMaps is opened in the browser
