### PR TITLE
IGAPP-941: split regex and don't allow . at the end of the string

### DIFF
--- a/api-client/src/__tests__/replaceLinks.spec.ts
+++ b/api-client/src/__tests__/replaceLinks.spec.ts
@@ -26,4 +26,9 @@ describe('replaceLinks', () => {
       'some content <a href="https://asdf.gh">https://asdf.gh</a> with the correct <a href="mailto:links@qwer.tz">mailto:links@qwer.tz</a>'
     )
   })
+  it('should not match trailing "."', () => {
+    replaceLinks('some content https://integreat.app/asdf.', replace)
+    expect(replace).toHaveBeenCalledTimes(1)
+    expect(replace).toHaveReturnedWith('https://integreat.app/asdf')
+  })
 })

--- a/api-client/src/replaceLinks.ts
+++ b/api-client/src/replaceLinks.ts
@@ -1,6 +1,10 @@
 // https://stackoverflow.com/a/3809435
-const regex =
-  /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[-;:&=+$,\w]+@)?[A-Za-z0-9.-]+|[-;:&=+$,\w]+@[A-Za-z0-9.-]+)((?:\/[+~%/.\w\-_]*)?\??(?:[-+=&;%@.\w_]*)#?(?:[.!/\\\w]*))?)/g
+const protocol = /([A-Za-z]{3,9}:(?:\/\/)?)/g
+const baseUrl =  /(?:[-;:&=+$,\w]+@)?([A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*)/g
+const path = /(?:\/(?:[+~%/.\w-]*[+~%/\w-]+)?)?/g
+const query = /(?:\?([-+=&;%@.\w]*[-+=&;%@\w]+)?)?/g
+const hash = /(?:#([.!/\\\w]*[!/\\\w]+)?)?/g
+const regex = new RegExp(protocol.source + baseUrl.source + path.source + query.source + hash.source, "g")
 type ReplaceType = (match: string) => string
 export const linkify = (link: string): string => `<a href="${link}">${link}</a>`
 export const replaceLinks = (content: string, replace: ReplaceType = linkify): string => content.replace(regex, replace)

--- a/api-client/src/replaceLinks.ts
+++ b/api-client/src/replaceLinks.ts
@@ -1,11 +1,14 @@
 // https://stackoverflow.com/a/3809435
 const protocol = /([A-Za-z]{3,9}:(?:\/\/)?)/
-const hostname =  /(?:[-;:&=+$,\w]+@)?([A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*)/
+const hostname = /(?:[-;:&=+$,\w]+@)?([A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*)/
 const path = /(?:\/(?:[+~%/.\w-]*[+~%/\w-]+)?)?/
 const query = /(?:\?([-+=&;%@.\w]*[-+=&;%@\w]+)?)?/
 const hash = /(?:#([.!/\\\w]*[!/\\\w]+)?)?/
 const mail = /[.\-;:&=+$,\w]+@([A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*)/
-const regex = new RegExp(`(${protocol.source}${hostname.source}${path.source}${query.source}${hash.source}|${mail.source})`, "g")
+const regex = new RegExp(
+  `(${protocol.source}${hostname.source}${path.source}${query.source}${hash.source}|${mail.source})`,
+  'g'
+)
 type ReplaceType = (match: string) => string
 export const linkify = (link: string): string => `<a href="${link}">${link}</a>`
 export const replaceLinks = (content: string, replace: ReplaceType = linkify): string => content.replace(regex, replace)

--- a/api-client/src/replaceLinks.ts
+++ b/api-client/src/replaceLinks.ts
@@ -1,11 +1,11 @@
 // https://stackoverflow.com/a/3809435
 const protocol = /([A-Za-z]{3,9}:(?:\/\/)?)/
-const baseUrl =  /(?:[-;:&=+$,\w]+@)?([A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*)/
+const hostname =  /(?:[-;:&=+$,\w]+@)?([A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*)/
 const path = /(?:\/(?:[+~%/.\w-]*[+~%/\w-]+)?)?/
 const query = /(?:\?([-+=&;%@.\w]*[-+=&;%@\w]+)?)?/
 const hash = /(?:#([.!/\\\w]*[!/\\\w]+)?)?/
 const mail = /[.\-;:&=+$,\w]+@([A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*)/
-const regex = new RegExp(`(${protocol.source}${baseUrl.source}${path.source}${query.source}${hash.source}|${mail.source})`, "g")
+const regex = new RegExp(`(${protocol.source}${hostname.source}${path.source}${query.source}${hash.source}|${mail.source})`, "g")
 type ReplaceType = (match: string) => string
 export const linkify = (link: string): string => `<a href="${link}">${link}</a>`
 export const replaceLinks = (content: string, replace: ReplaceType = linkify): string => content.replace(regex, replace)

--- a/api-client/src/replaceLinks.ts
+++ b/api-client/src/replaceLinks.ts
@@ -1,10 +1,11 @@
 // https://stackoverflow.com/a/3809435
-const protocol = /([A-Za-z]{3,9}:(?:\/\/)?)/g
-const baseUrl =  /(?:[-;:&=+$,\w]+@)?([A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*)/g
-const path = /(?:\/(?:[+~%/.\w-]*[+~%/\w-]+)?)?/g
-const query = /(?:\?([-+=&;%@.\w]*[-+=&;%@\w]+)?)?/g
-const hash = /(?:#([.!/\\\w]*[!/\\\w]+)?)?/g
-const regex = new RegExp(protocol.source + baseUrl.source + path.source + query.source + hash.source, "g")
+const protocol = /([A-Za-z]{3,9}:(?:\/\/)?)/
+const baseUrl =  /(?:[-;:&=+$,\w]+@)?([A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*)/
+const path = /(?:\/(?:[+~%/.\w-]*[+~%/\w-]+)?)?/
+const query = /(?:\?([-+=&;%@.\w]*[-+=&;%@\w]+)?)?/
+const hash = /(?:#([.!/\\\w]*[!/\\\w]+)?)?/
+const mail = /[.\-;:&=+$,\w]+@([A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*)/
+const regex = new RegExp(`(${protocol.source}${baseUrl.source}${path.source}${query.source}${hash.source}|${mail.source})`, "g")
 type ReplaceType = (match: string) => string
 export const linkify = (link: string): string => `<a href="${link}">${link}</a>`
 export const replaceLinks = (content: string, replace: ReplaceType = linkify): string => content.replace(regex, replace)


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.integreat-app.de/).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **IGAPP**.

Tested here https://regex101.com/r/ZfeAMj/1
If we also don't want to allow trailing , . / @ ... it is enough to set \b at the end of the regex. Opinions?
I also split the regex for a better overview. If you disagree with splitting it I can combine it again and keep the split part as a comment. 
