### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,4 +4,4 @@
 # the repo. Unless a later match takes precedence,
 # these owners will be requested for
 # review when someone opens a pull request.
-*       @maxammann @klinzo @nklug @a-kud @Taggotty @lulo4907 @SimonVortkamp @Znippet @SteffiStuffel  @f1sh1918
+*       @klinzo @sarahsporck @Znippet @SteffiStuffel  @f1sh1918


### PR DESCRIPTION
Fix also fixes warnings of github: 
![image](https://user-images.githubusercontent.com/905221/167639313-48e0aa14-11c4-417b-8dc4-5931bebe8b06.png)
