### PR TITLE
IGAPP-1004:  Hide disable previous next poi buttons if there is only one poi

### DIFF
--- a/release-notes/unreleased/IGAPP-1004-hide-nav-single-poi.yml
+++ b/release-notes/unreleased/IGAPP-1004-hide-nav-single-poi.yml
@@ -1,0 +1,6 @@
+issue_key: IGAPP-1004
+show_in_stores: true
+platforms:
+  - web
+en: Do not show poi navigation bar if only one location exists.
+de: Poi Navigation wird nicht angezeigt, wenn nur ein Ort existiert.

--- a/web/src/components/PoisDesktop.tsx
+++ b/web/src/components/PoisDesktop.tsx
@@ -46,6 +46,7 @@ type PoisDesktopProps = {
   switchFeature: (step: 1 | -1) => void
   selectFeature: (feature: PoiFeature | null) => void
   direction: UiDirectionType
+  showNavigation: boolean
 }
 
 const PoisDesktop: React.FC<PoisDesktopProps> = ({
@@ -57,7 +58,8 @@ const PoisDesktop: React.FC<PoisDesktopProps> = ({
   poi,
   switchFeature,
   selectFeature,
-  direction
+  direction,
+  showNavigation
 }: PoisDesktopProps): ReactElement => {
   const { t } = useTranslation('pois')
 
@@ -72,7 +74,7 @@ const PoisDesktop: React.FC<PoisDesktopProps> = ({
             poiList
           )}
         </ListViewWrapper>
-        {currentFeature ? (
+        {currentFeature && showNavigation ? (
           <PoiPanelNavigation switchFeature={switchFeature} direction={direction} />
         ) : (
           <ToolbarContainer>{toolbar}</ToolbarContainer>

--- a/web/src/routes/PoisPage.tsx
+++ b/web/src/routes/PoisPage.tsx
@@ -239,6 +239,7 @@ const PoisPage = ({ cityCode, languageCode, cityModel, pathname, languages }: Ci
             panelHeights={panelHeights}
             mapView={mapView}
             poiList={poiList}
+            showNavigation={data.features.length > 1}
             selectFeature={selectFeature}
             direction={direction}
           />


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.integreat-app.de/).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **IGAPP**.

http://localhost:9000/testumgebung/de/locations?name=berlin
