### PR TITLE
IGAPP-1005: Removed double separation line in location list view mobile

### DIFF
--- a/release-notes/unreleased/IGAPP-1005-double-separation-line-poi-list-bas.yml
+++ b/release-notes/unreleased/IGAPP-1005-double-separation-line-poi-list-bas.yml
@@ -3,4 +3,4 @@ show_in_stores: true
 platforms:
   - web
 en: Removed double separation line in location list view mobile.
-de: Doppelte Trennlinie in der mobilen Listenansicht der Lokationen entfernt.
+de: Doppelte Trennlinie in der mobilen Listenansicht der Orte entfernt.

--- a/release-notes/unreleased/IGAPP-1005-double-separation-line-poi-list-bas.yml
+++ b/release-notes/unreleased/IGAPP-1005-double-separation-line-poi-list-bas.yml
@@ -1,0 +1,6 @@
+issue_key: IGAPP-1005
+show_in_stores: true
+platforms:
+  - web
+en: Removed double separation line in location list view mobile.
+de: Doppelte Trennlinie in der mobilen Listenansicht der Lokationen entfernt.

--- a/web/src/components/PoiListItem.tsx
+++ b/web/src/components/PoiListItem.tsx
@@ -5,13 +5,20 @@ import styled from 'styled-components'
 import { PoiFeature } from 'api-client'
 
 import PoiPlaceholder from '../assets/PoiPlaceholderThumbnail.jpg'
+import dimensions from '../constants/dimensions'
 
 const ListItemContainer = styled.article`
   font-family: ${props => props.theme.fonts.web.contentFont};
   display: flex;
-  border-bottom: 1px solid ${props => props.theme.colors.poiBorderColor};
   padding: clamp(10px, 1vh, 20px) 0;
+  border-bottom: 1px solid ${props => props.theme.colors.poiBorderColor};
   cursor: pointer;
+
+  @media screen and ${dimensions.smallViewport} {
+    &:last-child {
+      border-bottom: none;
+    }
+  }
 
   &:first-child {
     padding-top: 0;


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.integreat-app.de/).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **IGAPP**.
