### PR TITLE
IGAPP-1059: Page title for tunews is wrong

### DIFF
--- a/release-notes/unreleased/IGAPP-1059-page-title-for-tunews-is-wrong.yml
+++ b/release-notes/unreleased/IGAPP-1059-page-title-for-tunews-is-wrong.yml
@@ -1,0 +1,7 @@
+issue_key: IGAPP-1059 # e.g. IGAPP-123 (NATIVE-587, WEBAPP-42)
+show_in_stores: true # whether this note should be shown in the stores, either true or false
+platforms: # relevant platforms, possible values: web, android and ios
+  - web
+en: Fixed broken page title for tünews # english version of the note
+# de is required for notes with show_in_stores set to true
+de: Falsch angezeigter Title der Seite tünews repariert # german version of the note

--- a/web/src/routes/TuNewsPage.tsx
+++ b/web/src/routes/TuNewsPage.tsx
@@ -129,7 +129,7 @@ const TuNewsPage = ({ cityCode, languageCode, cityModel, languages }: CityRouteP
     )
   }
 
-  const pageTitle = `${t('tuNews.pageTitle')} - ${cityModel.name}`
+  const pageTitle = `tünews INTERNATIONAL - ${cityModel.name}`
 
   return (
     <LocationLayout isLoading={false} {...locationLayoutParams} languageChangePaths={languageChangePaths}>


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.integreat-app.de/).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **IGAPP**.
