### PR TITLE
IGAPP-1076: show description of events in overview

### DIFF
--- a/native/src/components/EventListItem.tsx
+++ b/native/src/components/EventListItem.tsx
@@ -9,12 +9,15 @@ import EventPlaceholder1 from '../assets/EventPlaceholder1.jpg'
 import EventPlaceholder2 from '../assets/EventPlaceholder2.jpg'
 import EventPlaceholder3 from '../assets/EventPlaceholder3.jpg'
 import DateFormatterContext from '../contexts/DateFormatterContext'
+import { textTruncator } from '../utils/stringUtils'
 import ListItem from './ListItem'
 
 const Description = styled.Text`
   color: ${props => props.theme.colors.textColor};
   font-family: ${props => props.theme.fonts.native.contentFontRegular};
 `
+
+const NUM_OF_CHARS_ALLOWED = 90
 
 const getEventPlaceholder = (id: number): number => {
   const placeholders = [EventPlaceholder1, EventPlaceholder2, EventPlaceholder3]
@@ -48,7 +51,7 @@ const EventListItem = ({ event, cityCode, language, navigateTo, theme }: PropsTy
       navigateTo={navigateToEventInCity}
       theme={theme}>
       <Description>{event.date.toFormattedString(formatter)}</Description>
-      {event.location && <Description>{event.location.fullAddress}</Description>}
+      {event.excerpt && <Description>{textTruncator(event.excerpt, NUM_OF_CHARS_ALLOWED)}</Description>}
     </ListItem>
   )
 }

--- a/native/src/utils/stringUtils.ts
+++ b/native/src/utils/stringUtils.ts
@@ -1,0 +1,8 @@
+export const textTruncator = (text: string, numOfCharsAllowed: number, replaceLineBreaks = true): string => {
+  const ellipsis = '...'
+  const cleanText = replaceLineBreaks ? text.trim().replace(/\n/g, ' ') : text
+  if (cleanText.length < numOfCharsAllowed) {
+    return cleanText
+  }
+  return `${cleanText.substring(0, cleanText.lastIndexOf(' ', numOfCharsAllowed))}${ellipsis}`
+}

--- a/release-notes/unreleased/IGAPP-1076-show-description-of-events-in-overview.yml
+++ b/release-notes/unreleased/IGAPP-1076-show-description-of-events-in-overview.yml
@@ -1,0 +1,6 @@
+issue_key: IGAPP-1076
+show_in_stores: true
+platforms:
+  - native
+en: Show event description in event list
+de: Zeige Eventbeschreibung in der Eventliste


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.integreat-app.de/).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **IGAPP**.

The `textTruncator` function is an almost 1:1 copy of the one in `/src/web/urils/`. Would it make sense to move this to a shared function in `api-client`? (Possibly even apply it to the `EventModel` by default, since `event.excerpt` doesn't appear to ever be used un-truncated?) 