### PR TITLE
IGAPP-1112: Parent breadcrumb cut

### DIFF
--- a/release-notes/unreleased/IGAPP-1112-parent-breadcrumb-cut.yml
+++ b/release-notes/unreleased/IGAPP-1112-parent-breadcrumb-cut.yml
@@ -1,0 +1,5 @@
+issue_key: IGAPP-1112
+show_in_stores: true
+platforms:
+  - web
+en: Improve display of last breadcrumb

--- a/web/src/components/Breadcrumb.tsx
+++ b/web/src/components/Breadcrumb.tsx
@@ -3,11 +3,12 @@ import styled from 'styled-components'
 
 import { helpers } from '../constants/theme'
 
-const ListItem = styled.li`
+const SHRINK_FACTOR = 0.1
+const ListItem = styled.li<{ shrink: boolean }>`
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-  flex-shrink: 0.1;
+  flex-shrink: ${props => (props.shrink ? SHRINK_FACTOR : 0)};
 
   &:not(:last-of-type) {
     flex-shrink: 1;
@@ -31,13 +32,14 @@ const Separator = styled.span`
 
 type PropsType = {
   children: ReactNode
+  shrink?: boolean
 }
 
 /**
  * Displays breadcrumbs (Links) for lower category levels
  */
-const Breadcrumb = ({ children }: PropsType): ReactElement => (
-  <ListItem>
+const Breadcrumb = ({ children, shrink = false }: PropsType): ReactElement => (
+  <ListItem shrink={shrink}>
     <Separator aria-hidden />
     {children}
   </ListItem>

--- a/web/src/components/Breadcrumb.tsx
+++ b/web/src/components/Breadcrumb.tsx
@@ -32,7 +32,7 @@ const Separator = styled.span`
 
 type PropsType = {
   children: ReactNode
-  shrink?: boolean
+  shrink: boolean
 }
 
 /**

--- a/web/src/components/Breadcrumb.tsx
+++ b/web/src/components/Breadcrumb.tsx
@@ -38,7 +38,7 @@ type PropsType = {
 /**
  * Displays breadcrumbs (Links) for lower category levels
  */
-const Breadcrumb = ({ children, shrink = false }: PropsType): ReactElement => (
+const Breadcrumb = ({ children, shrink }: PropsType): ReactElement => (
   <ListItem shrink={shrink}>
     <Separator aria-hidden />
     {children}

--- a/web/src/components/Breadcrumbs.tsx
+++ b/web/src/components/Breadcrumbs.tsx
@@ -55,7 +55,7 @@ type PropsType = {
 const Breadcrumbs = ({ direction, ancestorBreadcrumbs, currentBreadcrumb }: PropsType): ReactElement => {
   // The current page should not be listed in the UI, but should be within the JsonLd.
   const jsonLdBreadcrumbs = [...ancestorBreadcrumbs, currentBreadcrumb]
-  // Min amount of chars when the last breadcrumb item should shrink
+  // Min text length after which the last breadcrumb item should shrink
   const MIN_SHRINK_CHARS = 20
 
   /* We are doing here funky stuff with directions. See here for more information about the idea:

--- a/web/src/components/Breadcrumbs.tsx
+++ b/web/src/components/Breadcrumbs.tsx
@@ -55,6 +55,8 @@ type PropsType = {
 const Breadcrumbs = ({ direction, ancestorBreadcrumbs, currentBreadcrumb }: PropsType): ReactElement => {
   // The current page should not be listed in the UI, but should be within the JsonLd.
   const jsonLdBreadcrumbs = [...ancestorBreadcrumbs, currentBreadcrumb]
+  // Min amount of chars when the last breadcrumb item should shrink
+  const MIN_SHRINK_CHARS = 20
 
   /* We are doing here funky stuff with directions. See here for more information about the idea:
    https://css-tricks.com/position-vertical-scrollbars-on-opposite-side-with-css/
@@ -70,7 +72,9 @@ const Breadcrumbs = ({ direction, ancestorBreadcrumbs, currentBreadcrumb }: Prop
               <HomeIcon src={iconHome} alt='' />
             </StyledLink>
           ) : (
-            <Breadcrumb key={breadcrumb.title}>{breadcrumb.node}</Breadcrumb>
+            <Breadcrumb key={breadcrumb.title} shrink={breadcrumb.title.length >= MIN_SHRINK_CHARS}>
+              {breadcrumb.node}
+            </Breadcrumb>
           )
         )}
       </OrderedList>


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.integreat-app.de/).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **IGAPP**.

Open in mobile mode
http://localhost:9000/stadtdachau/de/allgemeine-beratungsstellen-und-beh%C3%B6rden/behoerden/jobcenter-dachau
Now all last breadcrumb items will not be cut until they reach 20 chars
