### PR TITLE
IGAPP-1107: Sort events if start dates equal

### DIFF
--- a/api-client/src/endpoints/createEventsEndpoint.ts
+++ b/api-client/src/endpoints/createEventsEndpoint.ts
@@ -74,7 +74,15 @@ export default (baseUrl: string): Endpoint<ParamsType, Array<EventModel>> =>
               return 1
             }
 
-            return 0
+            if (event1.date.endDate.isBefore(event2.date.endDate)) {
+              return -1
+            }
+
+            if (event1.date.endDate.isAfter(event2.date.endDate)) {
+              return 1
+            }
+
+            return event1.title.localeCompare(event2.title)
           })
     )
     .build()

--- a/release-notes/unreleased/IGAPP-1107-event-order.yml
+++ b/release-notes/unreleased/IGAPP-1107-event-order.yml
@@ -1,0 +1,7 @@
+issue_key: IGAPP-1107
+show_in_stores: false
+platforms:
+  - web
+  - android
+  - ios
+en: Sort events by end date or title if the start dates are equal.


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.integreat-app.de/).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **IGAPP**.

Happens for me for example for all occurrences of `Frauengruppe` and `Frauen lernen Bildungs- und Erziehungseinrichtungen kennen` in `/muenchen/de/events` using the test cms (native: Frauengruppe before Frauen lernen..., web: the other way round). I think even if this is not reproducible on all platforms (e.g. @f1sh1918 failed to reproduce it) it makes sense to have a deterministic sorting for the case that start dates are equal.