### PR TITLE
IGAPP-1143: Internal linking of pois not working

### DIFF
--- a/api-client/src/routes/InternalPathnameParser.ts
+++ b/api-client/src/routes/InternalPathnameParser.ts
@@ -28,13 +28,15 @@ class InternalPathnameParser {
   _length: number
   _fallbackLanguageCode: string
   _fixedCity: string | null
+  _queryParams: string | undefined
 
-  constructor(pathname: string, languageCode: string, fixedCity: string | null) {
+  constructor(pathname: string, languageCode: string, fixedCity: string | null, queryParams?: string) {
     this._pathname = normalizePath(pathname)
     this._fixedCity = fixedCity
     this._parts = this.pathnameParts(pathname)
     this._length = this._parts.length
     this._fallbackLanguageCode = languageCode
+    this._queryParams = queryParams
   }
 
   pathnameParts = (pathname: string): string[] => pathname.split('/').filter(Boolean)
@@ -134,14 +136,13 @@ class InternalPathnameParser {
 
   pois = (): RouteInformationType => {
     const params = this.cityContentParams(POIS_ROUTE)
-
     if (!params) {
       return null
     }
 
-    // Single pois are identified via their city content path, e.g. '/augsburg/de/events/1234'
+    // Single pois are identified via their city content path and urlSlug, e.g.'/augsburg/de/location/?name=cafe-tür-an-tür'
     const cityContentPath = this._length > ENTITY_ID_INDEX ? this._pathname : undefined
-    return { ...params, route: POIS_ROUTE, cityContentPath }
+    return { ...params, route: POIS_ROUTE, cityContentPath, urlSlug: this._queryParams }
   }
 
   news = (): RouteInformationType => {

--- a/native/src/navigation/navigateToLink.ts
+++ b/native/src/navigation/navigateToLink.ts
@@ -1,6 +1,4 @@
-import Url from 'url-parse'
-
-import { OPEN_INTERNAL_LINK_SIGNAL_NAME, OPEN_MEDIA_SIGNAL_NAME } from 'api-client'
+import { nameQueryParam, OPEN_INTERNAL_LINK_SIGNAL_NAME, OPEN_MEDIA_SIGNAL_NAME, POIS_ROUTE } from 'api-client'
 import { IMAGE_VIEW_MODAL_ROUTE, PDF_VIEW_MODAL_ROUTE } from 'api-client/src/routes'
 import InternalPathnameParser from 'api-client/src/routes/InternalPathnameParser'
 import { RouteInformationType } from 'api-client/src/routes/RouteInformationTypes'
@@ -50,8 +48,18 @@ const navigateToLink = async <T extends RoutesType>(
         url,
       },
     })
-    const { pathname } = new Url(url)
-    const routeParser = new InternalPathnameParser(pathname, language, buildConfig().featureFlags.fixedCity)
+
+    const { pathname, searchParams } = new URL(url)
+    let routeParser = new InternalPathnameParser(pathname, language, buildConfig().featureFlags.fixedCity)
+
+    if (pathname.includes(POIS_ROUTE) && searchParams.has(nameQueryParam)) {
+      routeParser = new InternalPathnameParser(
+        pathname,
+        language,
+        buildConfig().featureFlags.fixedCity,
+        searchParams.get(nameQueryParam)!
+      )
+    }
     navigateTo(routeParser.route())
   } else {
     openExternalUrl(url)

--- a/release-notes/unreleased/IGAPP-1143-internal-linking-of-pois-not-working.yml
+++ b/release-notes/unreleased/IGAPP-1143-internal-linking-of-pois-not-working.yml
@@ -1,0 +1,7 @@
+issue_key: IGAPP-1143
+show_in_stores: true
+platforms:
+  - web
+  - ios
+  - android
+en: Fix internal linking of pois

--- a/web/src/CityContentSwitcher.tsx
+++ b/web/src/CityContentSwitcher.tsx
@@ -169,7 +169,7 @@ const CityContentSwitcher = ({ cities, languageCode }: CityContentSwitcherProps)
       {offersEnabled && render(SHELTER_ROUTE, ShelterPage, ':shelterId')}
       {offersEnabled && render(SPRUNGBRETT_OFFER_ROUTE, SprungbrettOfferPage)}
       {offersEnabled && render(OFFERS_ROUTE, OffersPage)}
-      {poisEnabled && render(POIS_ROUTE, PoisPage, ':poiId')}
+      {poisEnabled && render(POIS_ROUTE, PoisPage)}
       {localNewsEnabled && render(LOCAL_NEWS_ROUTE, LocalNewsPage, ':newsId')}
 
       {tuNewsEnabled && render(TU_NEWS_ROUTE, TuNewsPage)}

--- a/web/src/components/RemoteContent.tsx
+++ b/web/src/components/RemoteContent.tsx
@@ -1,5 +1,6 @@
 import Dompurify from 'dompurify'
 import React, { ReactElement, useCallback, useEffect } from 'react'
+import { NavigateFunction } from 'react-router-dom'
 import styled from 'styled-components'
 
 import buildConfig from '../constants/buildConfig'
@@ -88,7 +89,7 @@ const SandBox = styled.div<{ centered: boolean; smallText: boolean }>`
 
 type RemoteContentProps = {
   html: string
-  onInternalLinkClick: (url: string) => void
+  onInternalLinkClick: NavigateFunction
   centered?: boolean
   smallText?: boolean
 }
@@ -109,8 +110,8 @@ const RemoteContent = ({
       const target = event.currentTarget
 
       if (target instanceof HTMLAnchorElement) {
-        const href = target.href
-        onInternalLinkClick(decodeURIComponent(new URL(decodeURIComponent(href)).pathname))
+        const url = new URL(decodeURIComponent(target.href))
+        onInternalLinkClick({ pathname: url.pathname, search: url.search })
       }
     },
     [onInternalLinkClick]


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.integreat-app.de/).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **IGAPP**.

You can find testlinks here:
https://webnext.integreat.app/testumgebung/de/test-interne-maplinks

Note:
- redirect pois with urlSlugs internally does not work and we decided to keep queryParams as you can find in the link above
- only fixed the navigate methods for internal linking to pass query params
