### PR TITLE
IGAPP-1151: Fix android build failure by upgrading react-native

### DIFF
--- a/native/package.json
+++ b/native/package.json
@@ -79,7 +79,7 @@
     "query-string": "^7.1.1",
     "react": "17.0.2",
     "react-i18next": "^11.18.0",
-    "react-native": "0.67.2",
+    "react-native": "0.67.5",
     "react-native-blob-util": "^0.16.2",
     "react-native-elements": "^3.4.2",
     "react-native-gesture-handler": "^2.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16602,10 +16602,10 @@ react-native-webview@^11.22.7:
     escape-string-regexp "2.0.0"
     invariant "2.2.4"
 
-react-native@0.67.2:
-  version "0.67.2"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.67.2.tgz#312224bc2271c3cecd374d4bc425619cff4ea5dc"
-  integrity sha512-grEtpOLLvtSg8Bivg0ffVRCjTkresqMt7Jdog/geF6VAYhb4RnLaaUCWvyrfyB9buf135FKnqg5BIuve/XQNXA==
+react-native@0.67.5:
+  version "0.67.5"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.67.5.tgz#9f2aeabf0766fb4bd5385685f4f4f2406bcdf819"
+  integrity sha512-/xEksthqImZGDfcqzEmbOw0KRkp9/x+cC8T8uTHhSKLLa8pOFLGdF190UOjnLammGmAmFy0+ZcJf0Ujm53IGeA==
   dependencies:
     "@jest/create-cache-key-function" "^27.0.1"
     "@react-native-community/cli" "^6.0.0"


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.integreat-app.de/).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **IGAPP**.
