### PR TITLE
IGAPP-920: Poi thumbnail full space

### DIFF
--- a/native/src/components/PoiListItem.tsx
+++ b/native/src/components/PoiListItem.tsx
@@ -56,7 +56,7 @@ class PoiListItem extends PureComponent<PoiListItemProps> {
     const thumbnail = poi.properties.thumbnail ?? Placeholder
     return (
       <StyledTouchableOpacity onPress={navigateToPoi} activeOpacity={1} language={language}>
-        <Thumbnail source={thumbnail} />
+        <Thumbnail source={thumbnail} resizeMode='cover' />
         <Description>
           <Title>{poi.properties.title}</Title>
           {!!poi.properties.distance && (

--- a/release-notes/unreleased/IGAPP-920-poi-thumbnail-full-space.yml
+++ b/release-notes/unreleased/IGAPP-920-poi-thumbnail-full-space.yml
@@ -1,0 +1,8 @@
+issue_key: IGAPP-920
+show_in_stores: true
+platforms:
+  - web
+  - android
+  - ios
+en: Show thumbnail of location in correct aspect ratio
+de: Zeige Thumbnail der Lokation in korrektem Seitenverhältnis

--- a/web/src/components/PoiListItem.tsx
+++ b/web/src/components/PoiListItem.tsx
@@ -30,7 +30,7 @@ const Thumbnail = styled.img`
   height: clamp(70px, 10vh, 100px);
   flex-shrink: 0;
   border: 1px solid transparent;
-  object-fit: contain;
+  object-fit: fill;
   border-radius: 10px;
 `
 


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.integreat-app.de/).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **IGAPP**.

Show thumbnail images in 1:1 aspect ratio, even the image has a different aspect ratio