### PR TITLE
IGAPP-1207: Explicitly specify kotlin version

### DIFF
--- a/native/android/build.gradle
+++ b/native/android/build.gradle
@@ -2,6 +2,7 @@
 
 buildscript {
     ext {
+        kotlinVersion = "1.8.0"
         buildToolsVersion = "30.0.2"
         minSdkVersion = 21
         compileSdkVersion = 31


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.integreat-app.de/).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **IGAPP**.

**Fixes app crashing in ci. Could reproduce & fix this error locally with this change.**