### PR TITLE
IGAPP-1209: App crashes openingHours

### DIFF
--- a/api-client/src/models/PoiModel.ts
+++ b/api-client/src/models/PoiModel.ts
@@ -1,5 +1,5 @@
 import moment, { Moment } from 'moment'
-// Fix for this issue https://github.com/moment/moment/issues/5789
+// Fix for minifying js issue with hermes using moment().locale https://github.com/moment/moment/issues/5789
 import 'moment/locale/de'
 
 import { mapMarker, PoiFeature } from '../maps'

--- a/api-client/src/models/PoiModel.ts
+++ b/api-client/src/models/PoiModel.ts
@@ -1,4 +1,6 @@
 import moment, { Moment } from 'moment'
+// Fix for this issue https://github.com/moment/moment/issues/5789
+import 'moment/locale/de'
 
 import { mapMarker, PoiFeature } from '../maps'
 import ExtendedPageModel from './ExtendedPageModel'

--- a/release-notes/unreleased/IGAPP-1209-app-crashes-opening-hours.yaml
+++ b/release-notes/unreleased/IGAPP-1209-app-crashes-opening-hours.yaml
@@ -1,0 +1,7 @@
+issue_key: IGAPP-1209
+show_in_stores: true
+platforms:
+  - android
+  - ios
+en: App crashes when opening places are currently opened were fixed.
+de: App Abstürze beim Öffnen von Orten, die gerade geöffnet sind, wurden behoben.

--- a/release-notes/unreleased/IGAPP-1209-app-crashes-opening-hours.yaml
+++ b/release-notes/unreleased/IGAPP-1209-app-crashes-opening-hours.yaml
@@ -3,5 +3,5 @@ show_in_stores: true
 platforms:
   - android
   - ios
-en: App crashes when opening places are currently opened were fixed.
-de: App Abstürze beim Öffnen von Orten, die gerade geöffnet sind, wurden behoben.
+en: Fix app crashes for places that are currently opened.
+de: App Abstürze bei gerade geöffneten Orten wurden behoben.


### PR DESCRIPTION
- Added explicit moment locale import to fix minified import error

Reference: https://github.com/moment/moment/issues/5789

**Note:** can only be tested with release apk since error is only occurring when minifying js with hermes
(Enabling "JS Minify" in Dev Settings did not work for me to reproduce the error)

`cd android`
`./gradlew assembleRelease`
or [releaseApk](https://output.circle-artifacts.com/output/job/6732a316-7f57-4fb5-bb81-07589e139004/artifacts/0/native/android/integreat-e2e.apk)

Go to map -> click on a poi list item with OpeningHours f.e."Olympiastadion"
