### PR TITLE
IGAPP-1214: App crashes with no city context

### DIFF
--- a/native/src/contexts/AppContextProvider.tsx
+++ b/native/src/contexts/AppContextProvider.tsx
@@ -2,6 +2,7 @@ import React, { createContext, ReactElement, useCallback, useEffect, useMemo, us
 
 import { useLoadAsync } from 'api-client'
 
+import buildConfig from '../constants/buildConfig'
 import appSettings from '../utils/AppSettings'
 import dataContainer from '../utils/DefaultDataContainer'
 import * as PushNotificationsManager from '../utils/PushNotificationsManager'
@@ -34,7 +35,7 @@ const AppContextProvider = ({ children }: AppContextProviderProps): ReactElement
     if (!contentLanguage) {
       throw new Error('Language not initialized by I18nProvider!')
     }
-    setCityCode(selectedCity)
+    setCityCode(buildConfig().featureFlags.fixedCity ?? selectedCity)
     setLanguageCode(contentLanguage)
   }, [])
 

--- a/release-notes/unreleased/IGAPP-1214-app-crashes-with-no-city-code.yaml
+++ b/release-notes/unreleased/IGAPP-1214-app-crashes-with-no-city-code.yaml
@@ -1,0 +1,7 @@
+issue_key: IGAPP-1214
+show_in_stores: false
+platforms:
+  - android
+  - ios
+en: Fixed city will be provided in App context to avoid crashes.
+de: Festgelegte Stadt wird im App context bereitgestellt, um App Abstürze zu verhinden.


### PR DESCRIPTION
Since Aschaffenburg has no location selected because it's fixed to 'hallo' (cityCode) we have to provide it in AppContext (Refactoring issue)

**Testing**

- Build and Start Aschaffenburg App
- City "hallo Aschaffenburg" should be preselected
