### PR TITLE
IGAPP-1227: dynamically wait for localhost in e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -766,7 +766,7 @@ jobs:
         docker:
             - image: cimg/node:16.19.0-browsers
             - image: selenium/standalone-chrome
-        resource_class: small
+        resource_class: medium
         shell: /bin/bash -eo pipefail
         steps:
             - skip_job

--- a/.circleci/src/jobs/e2e_web.yml
+++ b/.circleci/src/jobs/e2e_web.yml
@@ -1,7 +1,7 @@
 docker:
   - image: cimg/node:16.19.0-browsers
   - image: selenium/standalone-chrome
-resource_class: small
+resource_class: medium
 shell: /bin/bash -eo pipefail
 steps:
   - skip_job

--- a/docs/e2e-tests.md
+++ b/docs/e2e-tests.md
@@ -43,6 +43,7 @@ The tests itself are then created in the test folder and have to end on `*.e2e.t
 
 ### Local Testing
 
+Selenium standalone requires Java 8.0+.
 To run the web E2E-tests you first have to start the web app, and then execute the e2e tests:
 
 ```

--- a/e2e-tests/tsconfig.json
+++ b/e2e-tests/tsconfig.json
@@ -4,7 +4,7 @@
     "skipLibCheck": true,
     "noEmit": true,
     "types": ["node", "@wdio/globals/types", "@wdio/jasmine-framework"],
-    "sourceMap": true
+    "sourceMap": false
   },
   "include": ["web", "native", "shared"]
 }

--- a/e2e-tests/web/waitForLocalhost.ts
+++ b/e2e-tests/web/waitForLocalhost.ts
@@ -1,16 +1,19 @@
 // mostly taken from https://github.com/sindresorhus/wait-for-localhost
 // copy pasted as we do not use esm at the moment
-import http from 'node:http';
+import http from 'node:http'
 
-export default function waitForLocalhost(timeout: number) {
-	return new Promise(resolve => {
-        const request = http.request({method: "head", port: 9000, family: 4, timeout}, response => {
-            if (response.statusCode === 200) {
-                resolve(200);
-                return;
-            }
-        });
+const STATUS_CODE_OK = 200
 
-        request.end();
-	});
-}
+const waitForLocalhost = (timeout: number): Promise<void> =>
+  new Promise((resolve, reject) => {
+    const request = http.request({ method: 'head', port: 9000, family: 4, timeout }, response => {
+      if (response.statusCode === STATUS_CODE_OK) {
+        resolve()
+      }
+      reject()
+    })
+
+    request.end()
+  })
+
+export default waitForLocalhost

--- a/e2e-tests/web/waitForLocalhost.ts
+++ b/e2e-tests/web/waitForLocalhost.ts
@@ -1,0 +1,16 @@
+// mostly taken from https://github.com/sindresorhus/wait-for-localhost
+// copy pasted as we do not use esm at the moment
+import http from 'node:http';
+
+export default function waitForLocalhost(timeout: number) {
+	return new Promise(resolve => {
+        const request = http.request({method: "head", port: 9000, family: 4, timeout}, response => {
+            if (response.statusCode === 200) {
+                resolve(200);
+                return;
+            }
+        });
+
+        request.end();
+	});
+}

--- a/e2e-tests/web/wdio.conf.ts
+++ b/e2e-tests/web/wdio.conf.ts
@@ -1,6 +1,6 @@
 import { Capabilities } from '@wdio/types/build/Capabilities'
-
 import { browsers, ciCapabilities } from './capabilities'
+import waitForLocalhost from './waitForLocalhost'
 
 const getCapabilities = (): Array<Capabilities> => {
   if (process.env.CI) {
@@ -34,15 +34,12 @@ export const config: WebdriverIO.Config = {
   },
 
   onPrepare: async (): Promise<void> => {
-    if (process.env.CI) {
-      const startupDelay = 20000
-      await new Promise(resolve => {
-        setTimeout(resolve, startupDelay)
-      })
-    }
+    const startupDelay = 100000
+    await waitForLocalhost(startupDelay)
   },
 
-  before: async (): Promise<void> => {
+  before: async (): Promise<void> => {    
     await browser.setTimeout({ implicit: 80000, pageLoad: 60000 })
   },
 }
+

--- a/e2e-tests/web/wdio.conf.ts
+++ b/e2e-tests/web/wdio.conf.ts
@@ -1,4 +1,5 @@
 import { Capabilities } from '@wdio/types/build/Capabilities'
+
 import { browsers, ciCapabilities } from './capabilities'
 import waitForLocalhost from './waitForLocalhost'
 
@@ -22,24 +23,29 @@ export const config: WebdriverIO.Config = {
   logLevel: 'info',
   bail: 0,
   baseUrl: 'http://localhost:9000',
-  waitforTimeout: 2000,
-  connectionRetryTimeout: 120000,
+  waitforTimeout: 2_000,
+  connectionRetryTimeout: 120_000,
   connectionRetryCount: 3,
   services: process.env.CI ? [] : ['selenium-standalone'],
   framework: 'jasmine',
   reporters: ['spec'],
 
   jasmineOpts: {
-    defaultTimeoutInterval: 300000,
+    defaultTimeoutInterval: 300_000,
   },
 
   onPrepare: async (): Promise<void> => {
-    const startupDelay = 100000
-    await waitForLocalhost(startupDelay)
+    if (process.env.CI) {
+      const startupDelay = 10_000
+      await new Promise(resolve => {
+        setTimeout(resolve, startupDelay)
+      })
+    }
+    const maxWaitTime = 100_000
+    await waitForLocalhost(maxWaitTime)
   },
 
-  before: async (): Promise<void> => {    
-    await browser.setTimeout({ implicit: 80000, pageLoad: 60000 })
+  before: async (): Promise<void> => {
+    await browser.setTimeout({ implicit: 80_000, pageLoad: 60_000 })
   },
 }
-

--- a/web/package.json
+++ b/web/package.json
@@ -13,7 +13,7 @@
     "start:malte": "yarn run webpack-dev-server-ts --env config_name=malte --env dev_server",
     "start:malte-test-cms": "yarn run webpack-dev-server-ts --env config_name=malte-test-cms --env dev_server",
     "start:aschaffenburg": "yarn run webpack-dev-server-ts --env config_name=aschaffenburg --env dev_server",
-    "start:integreat-e2e": "yarn run webpack-dev-server-ts --env config_name=integreat-e2e --env dev_server",
+    "start:integreat-e2e": "yarn run webpack-dev-server-ts --env config_name=integreat-e2e",
     "start:obdach": "yarn run webpack-dev-server-ts --env config_name=obdach --env dev_server",
     "build": "yarn build:integreat",
     "build:integreat": "yarn run webpack-ts --env config_name=integreat",


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.integreat-app.de/).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **IGAPP**.
