### PR TITLE
IGAPP-1223-invalidate-city-content-cache

### DIFF
--- a/native/src/routes/CategoriesContainer.tsx
+++ b/native/src/routes/CategoriesContainer.tsx
@@ -36,7 +36,7 @@ const CategoriesContainer = ({ navigation, route }: CategoriesContainerProps): R
   const resourceCacheUrl = useContext(StaticServerContext)
   const { navigateTo } = useNavigate()
 
-  const { data, ...response } = useLoadCityContent({ cityCode, languageCode })
+  const { data, refresh, ...response } = useLoadCityContent({ cityCode, languageCode })
 
   const path = route.params.path ?? cityContentPath({ cityCode, languageCode })
   const category = data?.categories.findCategoryByPath(path)
@@ -68,10 +68,11 @@ const CategoriesContainer = ({ navigation, route }: CategoriesContainerProps): R
 
   // Workaround clear cache on refresh if city content can't be loaded.
   // TODO IGAPP-1231: Proper cache invalidation for version updates
-  const clearResourcesAndCache = () => {
+  const clearResourcesAndCache = useCallback(() => {
     dataContainer.clearInMemoryCache()
     dataContainer.clearOfflineCache().catch(reportError)
-  }
+    refresh()
+  }, [refresh])
 
   return (
     <LoadingErrorHandler {...response} error={error} refresh={clearResourcesAndCache} scrollView>

--- a/native/src/routes/CategoriesContainer.tsx
+++ b/native/src/routes/CategoriesContainer.tsx
@@ -17,6 +17,8 @@ import useResourceCache from '../hooks/useResourceCache'
 import createNavigateToFeedbackModal from '../navigation/createNavigateToFeedbackModal'
 import urlFromRouteInformation from '../navigation/url'
 import testID from '../testing/testID'
+import dataContainer from '../utils/DefaultDataContainer'
+import { reportError } from '../utils/sentry'
 import LoadingErrorHandler from './LoadingErrorHandler'
 
 const Spacing = styled.View`
@@ -64,8 +66,15 @@ const CategoriesContainer = ({ navigation, route }: CategoriesContainerProps): R
   const error =
     data?.categories && !category && previousLanguageCode === languageCode ? ErrorCode.PageNotFound : response.error
 
+  // Workaround clear cache on refresh if city content can't be loaded.
+  // TODO IGAPP-1231: Proper cache invalidation for version updates
+  const clearResourcesAndCache = () => {
+    dataContainer.clearInMemoryCache()
+    dataContainer.clearOfflineCache().catch(reportError)
+  }
+
   return (
-    <LoadingErrorHandler {...response} error={error} scrollView>
+    <LoadingErrorHandler {...response} error={error} refresh={clearResourcesAndCache} scrollView>
       {data && category && (
         <SpaceBetween {...(category.isRoot() ? testID('Dashboard-Page') : {})}>
           {category.isRoot() ? (

--- a/native/src/utils/DatabaseConnector.ts
+++ b/native/src/utils/DatabaseConnector.ts
@@ -220,6 +220,9 @@ class DatabaseConnector {
 
     if (!cityMetaData) {
       log(`Did not find city '${cityCode}' im metaData '${JSON.stringify(metaData)}'`, 'warning')
+      // Workaround for city content invalidation.
+      // TODO IGAPP-1231: Proper cache invalidation for version updates
+      this._deleteMetaOfCities([cityCode])
       throw Error('cannot store last update for unused city')
     }
 

--- a/native/src/utils/DatabaseConnector.ts
+++ b/native/src/utils/DatabaseConnector.ts
@@ -220,9 +220,6 @@ class DatabaseConnector {
 
     if (!cityMetaData) {
       log(`Did not find city '${cityCode}' im metaData '${JSON.stringify(metaData)}'`, 'warning')
-      // Workaround for city content invalidation.
-      // TODO IGAPP-1231: Proper cache invalidation for version updates
-      this._deleteMetaOfCities([cityCode])
       throw Error('cannot store last update for unused city')
     }
 

--- a/release-notes/unreleased/IGAPP-1223-invalidate-city-content-cache.yml
+++ b/release-notes/unreleased/IGAPP-1223-invalidate-city-content-cache.yml
@@ -1,0 +1,7 @@
+issue_key: IGAPP-1223
+show_in_stores: false
+platforms:
+  - ios
+  - android
+en: Fix problems with content cache.
+de: Behebung von Problemen mit dem Caching von Inhalten.


### PR DESCRIPTION
This issue comes up due to invalidate caches for pois, due to changing structure in `DataConnector`
Therefore i added a invalidateCache fkt on refresh if this error occurs on category page.
The handling with invalid cache should be improved and maybe be invalidated in specific intervals like updating major versions.
[IGAPP-1231](https://issues.tuerantuer.org/browse/IGAPP-1231)

1. Checkout this revision: d8470389 (2023.1.5)
2. deploy on device
3. Open location f.e. Dortmund with PoiData (even Map Feature is disabled)
4. Checkout this branch
5. There should come unknown error on start
6. Click try again. Content should load (even with console.errors only occur in debug mode)

