### PR TITLE
IGAPP-XXX: increase swipe timeout

### DIFF
--- a/e2e-tests/native/test/helpers/Gestures.ts
+++ b/e2e-tests/native/test/helpers/Gestures.ts
@@ -1,4 +1,4 @@
-const WAIT_FOR_SWIPE_FINISHED = 1000
+const WAIT_FOR_SWIPE_FINISHED = 2000
 
 type SelectorReturn = ReturnType<typeof $>
 


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.integreat-app.de/).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **IGAPP**.

Somehow swiping now takes longer (?) on ios, so increasing the timeouts will fix failing builds. (Tested already in browserstack)