### PR TITLE
Add `zh` as fallback language code for `zh-CN`

### DIFF
--- a/translations/src/config.ts
+++ b/translations/src/config.ts
@@ -139,6 +139,7 @@ class Config {
     fa_pr: ['pes'],
     'de-si': ['de'],
     sr: ['sr-Cyrl'],
+    zh: ['zh-CN'],
     'zh-hans': ['zh-CN'],
     // Slugs from the CMS are (and have to be) lowercase
     'sr-cyrl': ['sr-Cyrl'],


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.integreat-app.de/).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **IGAPP**.
