### PR TITLE
IGAPP-1270: Deprecated ios resources ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -365,7 +365,7 @@ jobs:
                     - integreat-test-cms
                     - aschaffenburg
                 type: enum
-        resource_class: medium
+        resource_class: macos.x86.medium.gen2
         shell: /bin/bash --login -o pipefail
         steps:
             - skip_job:

--- a/.circleci/src/jobs/build_ios.yml
+++ b/.circleci/src/jobs/build_ios.yml
@@ -5,11 +5,11 @@ parameters:
     default: integreat
 macos:
   xcode: 14.2.0
-resource_class: medium
+resource_class: macos.x86.medium.gen2
 environment:
   FL_OUTPUT_DIR: output
   FASTLANE_SKIP_UPDATE_CHECK: true
-  TOTAL_CPUS: 4 # For mac with resource_class medium, used in metro.config.ci.js.
+  TOTAL_CPUS: 4 # For mac with resource_class macos.x86.medium.gen2, used in metro.config.ci.js.
 shell: /bin/bash --login -o pipefail
 steps:
   - skip_job:


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.integreat-app.de/).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **IGAPP**.
