### PR TITLE
IGAPP-1272: Fix recurring end dates

### DIFF
--- a/api-client/src/endpoints/createEventsEndpoint.ts
+++ b/api-client/src/endpoints/createEventsEndpoint.ts
@@ -86,7 +86,7 @@ const mapJsonToEvent = (event: JsonEventType): EventModel => {
 const getEndDate = (event: JsonEventType, startDate: Date): Date => {
   const start = moment.tz(`${event.event.start_date} ${event.event.start_time}`, event.event.timezone)
   const end = moment.tz(`${event.event.end_date} ${event.event.end_time}`, event.event.timezone)
-  const durationInDays = start.diff(end, 'days')
+  const durationInDays = end.diff(start, 'days')
   return moment(startDate).add(durationInDays, 'days').toDate()
 }
 

--- a/release-notes/unreleased/IGAPP-1272-fix-recurring-end-dates.yml
+++ b/release-notes/unreleased/IGAPP-1272-fix-recurring-end-dates.yml
@@ -1,0 +1,8 @@
+issue_key: IGAPP-1272
+show_in_stores: true
+platforms:
+  - web
+  - android
+  - ios
+en: The end date of recurring events lasting several dates is shown correctly
+de: Das Enddatum von mehrtägigen, wiederkehrenden Events wird korrekt angezeigt


### PR DESCRIPTION
This pull request belongs to the issue https://issues.tuerantuer.org/browse/IGAPP-1272

To test: go to http://localhost:9000/testumgebung/de/events/test-event-for-date$2023-05-15 and see that the end date is two days after the start date, not two days before.
