### PR TITLE
IGAPP-1230: Map unscrollable

### DIFF
--- a/api-client/src/maps/index.ts
+++ b/api-client/src/maps/index.ts
@@ -9,6 +9,7 @@ export type MapViewViewport = {
   latitude: number
   longitude: number
   zoom: number
+  maxZoom?: number
 }
 
 // type is used to calculate the initial boundingBox using height and width
@@ -90,6 +91,7 @@ export const defaultMercatorViewportConfig: MapViewMercatorViewport = {
 
 export const normalDetailZoom = 15
 export const closerDetailZoom = 18
+export const maxMapZoom = 21
 export const clusterRadius = 50
 export const animationDuration = 2000
 

--- a/release-notes/unreleased/IGAPP-1230-map-unscrollable.yml
+++ b/release-notes/unreleased/IGAPP-1230-map-unscrollable.yml
@@ -1,0 +1,5 @@
+issue_key: IGAPP-1230
+show_in_stores: true
+platforms:
+  - web
+en: Fix issue that in certain case the map becomes unscrollable by zooming very close

--- a/web/src/components/MapView.tsx
+++ b/web/src/components/MapView.tsx
@@ -13,6 +13,7 @@ import {
   PoiFeatureCollection,
   MapViewMercatorViewport,
   clusterRadius,
+  maxMapZoom,
 } from 'api-client'
 import { UiDirectionType } from 'translations'
 
@@ -87,7 +88,8 @@ const MapView = forwardRef((props: MapViewProps, ref: React.Ref<MapRef>): ReactE
     languageCode,
     geolocationControlPosition,
   } = props
-  const [viewport, setViewport] = useState<MapViewViewport>(bboxViewport)
+  // Workaround for https://github.com/mapbox/mapbox-gl-js/issues/8890
+  const [viewport, setViewport] = useState<MapViewViewport>({ ...bboxViewport, maxZoom: maxMapZoom })
   const [cursor, setCursor] = useState<MapCursorType>('auto')
   const theme = useTheme()
   const navigate = useNavigate()
@@ -129,7 +131,7 @@ const MapView = forwardRef((props: MapViewProps, ref: React.Ref<MapRef>): ReactE
           height: '100%',
           width: '100%',
         }}
-        onMove={evt => setViewport(evt.viewState)}
+        onMove={evt => setViewport(prevState => ({ ...prevState, ...evt.viewState }))}
         onDragStart={() => changeCursor('grab')}
         onDragEnd={() => changeCursor('auto')}
         onMouseEnter={() => changeCursor('pointer')}


### PR DESCRIPTION
When many pois are placed at the same location and the user scrolls very close, `react-maps-gl` facing an rendering issue which is still not solved.

I think restricting `maxZoom: 21` should be fine since no one needs to zoom closer
