### PR TITLE
IGAPP-1294: Internal links broken ios

### DIFF
--- a/native/src/utils/__tests__/openExternalUrl.spec.ts
+++ b/native/src/utils/__tests__/openExternalUrl.spec.ts
@@ -57,6 +57,22 @@ describe('openExternalUrl', () => {
     })
   })
 
+  it('should encode urls before opening them', async () => {
+    const rawUrl = 'https://kein.schö.ner/Link/zum/öffnen'
+    const encodedUrl = encodeURI(rawUrl)
+    await openExternalUrl(rawUrl, showSnackbar)
+    expect(InAppBrowser.close).toHaveBeenCalled()
+    expect(InAppBrowser.open).toHaveBeenLastCalledWith(encodedUrl, expect.anything())
+    expect(Linking.openURL).not.toHaveBeenCalled()
+    expect(sendTrackingSignal).toHaveBeenCalledTimes(1)
+    expect(sendTrackingSignal).toHaveBeenCalledWith({
+      signal: {
+        name: OPEN_EXTERNAL_LINK_SIGNAL_NAME,
+        url: encodedUrl,
+      },
+    })
+  })
+
   it('should open http urls with linking if inapp browser is not available', async () => {
     const url = 'https://som.niceli.nk/mor/etext'
     mocked(InAppBrowser.isAvailable).mockImplementation(async () => false)
@@ -76,21 +92,6 @@ describe('openExternalUrl', () => {
       signal: {
         name: OPEN_OS_LINK_SIGNAL_NAME,
         url,
-      },
-    })
-  })
-
-  it('should encode urls before opening them', async () => {
-    const rawUrl = 'https://kein.schö.ner/Link/zum/öffnen'
-    const encodedUrl = encodeURI(rawUrl)
-    await openExternalUrl(rawUrl, showSnackbar)
-    expect(InAppBrowser.open).toHaveBeenLastCalledWith(encodedUrl, expect.anything())
-    expect(Linking.openURL).not.toHaveBeenCalled()
-    expect(showSnackbar).not.toHaveBeenCalled()
-    expect(sendTrackingSignal).toHaveBeenCalledWith({
-      signal: {
-        name: OPEN_EXTERNAL_LINK_SIGNAL_NAME,
-        url: encodedUrl,
       },
     })
   })

--- a/native/src/utils/__tests__/openExternalUrl.spec.ts
+++ b/native/src/utils/__tests__/openExternalUrl.spec.ts
@@ -80,6 +80,21 @@ describe('openExternalUrl', () => {
     })
   })
 
+  it('should encode urls before opening them', async () => {
+    const rawUrl = 'https://kein.schö.ner/Link/zum/öffnen'
+    const encodedUrl = encodeURI(rawUrl)
+    await openExternalUrl(rawUrl, showSnackbar)
+    expect(InAppBrowser.open).toHaveBeenLastCalledWith(encodedUrl, expect.anything())
+    expect(Linking.openURL).not.toHaveBeenCalled()
+    expect(showSnackbar).not.toHaveBeenCalled()
+    expect(sendTrackingSignal).toHaveBeenCalledWith({
+      signal: {
+        name: OPEN_EXTERNAL_LINK_SIGNAL_NAME,
+        url: encodedUrl,
+      },
+    })
+  })
+
   it('should show snackbar if opening url is not supported', async () => {
     const url = 'mor:erando.mstu.ff'
     mocked(Linking.canOpenURL).mockImplementation(async () => false)

--- a/native/src/utils/openExternalUrl.ts
+++ b/native/src/utils/openExternalUrl.ts
@@ -9,8 +9,8 @@ import buildConfig from '../constants/buildConfig'
 import sendTrackingSignal from './sendTrackingSignal'
 import { reportError } from './sentry'
 
-const openExternalUrl = async (url: string, showSnackbar: (snackbar: SnackbarType) => void): Promise<void> => {
-  const encodedUrl = encodeURI(url)
+const openExternalUrl = async (rawUrl: string, showSnackbar: (snackbar: SnackbarType) => void): Promise<void> => {
+  const encodedUrl = encodeURI(rawUrl)
   const { protocol } = new URL(encodedUrl)
 
   try {

--- a/native/src/utils/openExternalUrl.ts
+++ b/native/src/utils/openExternalUrl.ts
@@ -10,7 +10,8 @@ import sendTrackingSignal from './sendTrackingSignal'
 import { reportError } from './sentry'
 
 const openExternalUrl = async (url: string, showSnackbar: (snackbar: SnackbarType) => void): Promise<void> => {
-  const { protocol } = new URL(url)
+  const encodedUrl = encodeURI(url)
+  const { protocol } = new URL(encodedUrl)
 
   try {
     // Custom tabs are not available in all browsers and support only http and https
@@ -18,24 +19,24 @@ const openExternalUrl = async (url: string, showSnackbar: (snackbar: SnackbarTyp
       sendTrackingSignal({
         signal: {
           name: OPEN_EXTERNAL_LINK_SIGNAL_NAME,
-          url,
+          url: encodedUrl,
         },
       })
       InAppBrowser.close()
-      await InAppBrowser.open(url, {
+      await InAppBrowser.open(encodedUrl, {
         toolbarColor: buildConfig().lightTheme.colors.themeColor,
       })
     } else {
-      const canOpen = await Linking.canOpenURL(url)
+      const canOpen = await Linking.canOpenURL(encodedUrl)
 
       if (canOpen) {
         sendTrackingSignal({
           signal: {
             name: OPEN_OS_LINK_SIGNAL_NAME,
-            url,
+            url: encodedUrl,
           },
         })
-        await Linking.openURL(url)
+        await Linking.openURL(encodedUrl)
       } else {
         showSnackbar({ text: 'noSuitableAppInstalled' })
       }

--- a/release-notes/unreleased/IGAPP-1294-internal-links-broken-ios.yml
+++ b/release-notes/unreleased/IGAPP-1294-internal-links-broken-ios.yml
@@ -1,0 +1,6 @@
+issue_key: IGAPP-1294
+show_in_stores: true
+platforms:
+  - ios
+en: Issue with opening internal links on iOS devices was fixed.
+de: Ein Problem mit dem Öffnen interner Links auf iOS-Geräten wurde behoben.


### PR DESCRIPTION
fix opening internal links (which are handled by opening in the browser) by encoding the url
