### PR TITLE
IGAPP-1301: Missing tiles after installing new version

### DIFF
--- a/native/src/components/Categories.tsx
+++ b/native/src/components/Categories.tsx
@@ -1,6 +1,6 @@
 import { mapValues } from 'lodash'
 import React, { ReactElement } from 'react'
-import { View } from 'react-native'
+import { Platform, View } from 'react-native'
 
 import { CategoriesMapModel, CategoryModel, CityModel } from 'api-client'
 import { CATEGORIES_ROUTE } from 'api-client/src/routes'
@@ -38,7 +38,7 @@ export const getCachedThumbnail = (category: CategoryModel, resourceCache: PageR
   const resource = resourceCache[category.thumbnail]
 
   if (resource) {
-    return URL_PREFIX + resource.filePath
+    return Platform.OS === 'ios' ? resource.filePath : URL_PREFIX + resource.filePath
   }
 
   return category.thumbnail

--- a/native/src/components/Categories.tsx
+++ b/native/src/components/Categories.tsx
@@ -1,6 +1,6 @@
 import { mapValues } from 'lodash'
 import React, { ReactElement } from 'react'
-import { Platform, View } from 'react-native'
+import { View } from 'react-native'
 
 import { CategoriesMapModel, CategoryModel, CityModel } from 'api-client'
 import { CATEGORIES_ROUTE } from 'api-client/src/routes'
@@ -38,7 +38,7 @@ export const getCachedThumbnail = (category: CategoryModel, resourceCache: PageR
   const resource = resourceCache[category.thumbnail]
 
   if (resource) {
-    return Platform.OS === 'ios' ? resource.filePath : URL_PREFIX + resource.filePath
+    return URL_PREFIX + resource.filePath
   }
 
   return category.thumbnail

--- a/native/src/components/SimpleImage.tsx
+++ b/native/src/components/SimpleImage.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react'
-import { Image, View, ImageSourcePropType, StyleProp, ImageStyle, ImageResizeMode } from 'react-native'
+import { Image, View, ImageSourcePropType, StyleProp, ImageStyle, ImageResizeMode, Platform } from 'react-native'
 
 export type ImageSourceType = string | number | null
 type SimpleImageProps = {
@@ -7,7 +7,9 @@ type SimpleImageProps = {
   style?: StyleProp<ImageStyle>
   resizeMode?: ImageResizeMode
 }
-
+// For ios you should not use the absolute path, since it can change with a future build version, therefore we use home directory
+// https://github.com/facebook/react-native/commit/23909cd6f62056de0cd0f7c06e3997dd967c139a
+const getLocalFilePathForIosFiles = (uri: string) => `~${uri.substring(uri.indexOf('/Documents'))}`
 const getImageSource = (uri: string | number): ImageSourcePropType =>
   typeof uri === 'number'
     ? uri
@@ -15,11 +17,11 @@ const getImageSource = (uri: string | number): ImageSourcePropType =>
         uri,
         cache: 'reload',
       }
-
 const SimpleImage = ({ source, style, resizeMode = 'contain' }: SimpleImageProps): ReactElement => {
   if (source === null) {
     return <View style={style} />
   }
+  console.log(Platform.OS, source)
 
   return <Image source={getImageSource(source)} resizeMode={resizeMode} style={style} />
 }

--- a/native/src/components/SimpleImage.tsx
+++ b/native/src/components/SimpleImage.tsx
@@ -7,21 +7,27 @@ type SimpleImageProps = {
   style?: StyleProp<ImageStyle>
   resizeMode?: ImageResizeMode
 }
+
 // For ios you should not use the absolute path, since it can change with a future build version, therefore we use home directory
 // https://github.com/facebook/react-native/commit/23909cd6f62056de0cd0f7c06e3997dd967c139a
-const getLocalFilePathForIosFiles = (uri: string) => `~${uri.substring(uri.indexOf('/Documents'))}`
+const getLocalPlatformFilepath = (uri: string): string => {
+  if (Platform.OS === 'ios' && uri.includes('file://')) {
+    return `~${uri.substring(uri.indexOf('/Documents'))}`
+  }
+  return uri
+}
 const getImageSource = (uri: string | number): ImageSourcePropType =>
   typeof uri === 'number'
     ? uri
     : {
-        uri,
+        uri: getLocalPlatformFilepath(uri),
         cache: 'reload',
       }
+
 const SimpleImage = ({ source, style, resizeMode = 'contain' }: SimpleImageProps): ReactElement => {
   if (source === null) {
     return <View style={style} />
   }
-  console.log(Platform.OS, source)
 
   return <Image source={getImageSource(source)} resizeMode={resizeMode} style={style} />
 }

--- a/release-notes/unreleased/IGAPP-1301-missing-tiles-after-installing-new-version.yml
+++ b/release-notes/unreleased/IGAPP-1301-missing-tiles-after-installing-new-version.yml
@@ -1,0 +1,5 @@
+issue_key: IGAPP-1301
+show_in_stores: true
+platforms:
+  - ios
+en: Fix images can not be loaded from cache


### PR DESCRIPTION
This fix resolves the issue that the image can't be loaded from cache for ios

Testing:

- Checkout revision: a0b47588
- deploy on ios
- choose a city
- checkout this branch
- deploy on ios
- select same city as on the other branch
- tiles should load as expected

Tested on ios simulator and real device
