### PR TITLE
IGAPP-1308: Remove ios image caching

### DIFF
--- a/native/src/components/SimpleImage.tsx
+++ b/native/src/components/SimpleImage.tsx
@@ -21,7 +21,6 @@ const getImageSource = (uri: string | number): ImageSourcePropType =>
     ? uri
     : {
         uri: getLocalPlatformFilepath(uri),
-        cache: 'reload',
       }
 
 const SimpleImage = ({ source, style, resizeMode = 'contain' }: SimpleImageProps): ReactElement => {

--- a/release-notes/unreleased/IGAPP-1308-remove-ios-image-caching.yml
+++ b/release-notes/unreleased/IGAPP-1308-remove-ios-image-caching.yml
@@ -1,6 +1,0 @@
-issue_key: IGAPP-1308
-show_in_stores: false
-platforms:
-  - ios
-en: Remove ios image caching
-de: Entferne Bildercaching für ios.

--- a/release-notes/unreleased/IGAPP-1308-remove-ios-image-caching.yml
+++ b/release-notes/unreleased/IGAPP-1308-remove-ios-image-caching.yml
@@ -1,0 +1,6 @@
+issue_key: IGAPP-1308
+show_in_stores: false
+platforms:
+  - ios
+en: Remove ios image caching
+de: Entferne Bildercaching für ios.


### PR DESCRIPTION
I removed the cache control `reload` since its not needed in our case and was used to fix a bug with local images on ios which were not working and was already fixed. So we can fallback to default caching strategy.
You can find more information here
https://reactnative.dev/docs/images#cache-control-ios-only