### PR TITLE
IGAPP-1265: Remove react render html pod

### DIFF
--- a/native/ios/Podfile.lock
+++ b/native/ios/Podfile.lock
@@ -385,8 +385,6 @@ PODS:
     - React-Core
   - react-native-pdf (6.6.2):
     - React-Core
-  - react-native-render-html (6.3.4):
-    - React-Core
   - react-native-safe-area-context (4.5.0):
     - RCT-Folly
     - RCTRequired
@@ -583,7 +581,6 @@ DEPENDENCIES:
   - "react-native-mapbox-gl (from `../node_modules/@react-native-mapbox-gl/maps`)"
   - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
   - react-native-pdf (from `../node_modules/react-native-pdf`)
-  - react-native-render-html (from `../node_modules/react-native-render-html`)
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - "react-native-static-server (from `../node_modules/@dr.pogodin/react-native-static-server`)"
   - react-native-webview (from `../node_modules/react-native-webview`)
@@ -703,8 +700,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-community/netinfo"
   react-native-pdf:
     :path: "../node_modules/react-native-pdf"
-  react-native-render-html:
-    :path: "../node_modules/react-native-render-html"
   react-native-safe-area-context:
     :path: "../node_modules/react-native-safe-area-context"
   react-native-static-server:
@@ -817,7 +812,6 @@ SPEC CHECKSUMS:
   react-native-mapbox-gl: 9fc139bea0119fd862c93df0adba1849b053e435
   react-native-netinfo: 2517ad504b3d303e90d7a431b0fcaef76d207983
   react-native-pdf: 33c622cbdf776a649929e8b9d1ce2d313347c4fa
-  react-native-render-html: 984dfe2294163d04bf5fe25d7c9f122e60e05ebe
   react-native-safe-area-context: 39c2d8be3328df5d437ac1700f4f3a4f75716acc
   react-native-static-server: 9bb6c921baf4f2ad7e84832b82fa0eb5fe57c9f0
   react-native-webview: 9f111dfbcfc826084d6c507f569e5e03342ee1c1


### PR DESCRIPTION
Small addition to sync the pods for ios. Was missing in Steffens pr
