### PR TITLE
IGAPP-1191: Add a TextLink

### DIFF
--- a/native/src/components/OrganizationContentInfo.tsx
+++ b/native/src/components/OrganizationContentInfo.tsx
@@ -6,16 +6,11 @@ import styled from 'styled-components/native'
 import { OrganizationModel } from 'api-client'
 
 import HighlightBox from './HighlightBox'
-import Link from './Link'
 import SimpleImage from './SimpleImage'
+import TextLink from './TextLink'
 
 const Thumbnail = styled(SimpleImage)`
   height: 80px;
-`
-
-const StyledText = styled.Text`
-  flex-direction: row;
-  flex-wrap: wrap;
 `
 
 const Box = styled(HighlightBox)`
@@ -29,9 +24,9 @@ const OrganizationContent = styled.Text`
   font-family: ${props => props.theme.fonts.native.decorativeFontBold};
   padding: 16px 0 8px;
 `
-
-const StyledLink = styled(Link)`
-  padding: 0;
+const StyledText = styled.Text`
+  flex-direction: row;
+  flex-wrap: wrap;
 `
 
 type OrganizationContentInfoProps = {
@@ -48,7 +43,7 @@ const OrganizationContentInfo = ({ organization }: OrganizationContentInfoProps)
         <StyledText>
           <Trans i18nKey='categories:organizationMoreInformation' domain={new URL(organization.url).hostname}>
             This gets{{ organization: organization.name }}replaced
-            <StyledLink url={organization.url} text={new URL(organization.url).hostname} />
+            <TextLink url={organization.url} text={new URL(organization.url).hostname} />
             by i18n
           </Trans>
         </StyledText>

--- a/native/src/components/TextLink.tsx
+++ b/native/src/components/TextLink.tsx
@@ -13,6 +13,10 @@ type TextLinkProps = {
   url: string
 }
 
+/**
+ * Touchable has a bottom spacing that we can't remove, hence this component for a link surrounded by text
+ */
+
 const TextLink = ({ text, url }: TextLinkProps): ReactElement => {
   const showSnackbar = useSnackbar()
   return (

--- a/native/src/components/TextLink.tsx
+++ b/native/src/components/TextLink.tsx
@@ -1,0 +1,25 @@
+import React, { ReactElement } from 'react'
+import styled from 'styled-components/native'
+
+import useSnackbar from '../hooks/useSnackbar'
+import openExternalUrl from '../utils/openExternalUrl'
+
+const LinkText = styled.Text`
+  text-decoration: underline;
+`
+
+type TextLinkProps = {
+  text: string
+  url: string
+}
+
+const TextLink = ({ text, url }: TextLinkProps): ReactElement => {
+  const showSnackbar = useSnackbar()
+  return (
+    <LinkText onPress={() => openExternalUrl(url, showSnackbar)} accessibilityRole='link'>
+      {text}
+    </LinkText>
+  )
+}
+
+export default TextLink


### PR DESCRIPTION
@steffenkleinle I couldn't get the styling to work with the existing Touchable link but this did the trick. What do you think? 
<img width="528" alt="image" src="https://github.com/digitalfabrik/integreat-app/assets/18513943/7639ab68-2b87-4980-8d69-4a0cb07e3a07">
