### PR TITLE
IGAPP-1351: Improve layout of thanks for feedback

### DIFF
--- a/release-notes/unreleased/IGAPP-1351-improve-feedback-thanks-layout.yml
+++ b/release-notes/unreleased/IGAPP-1351-improve-feedback-thanks-layout.yml
@@ -1,0 +1,5 @@
+issue_key: IGAPP-1351
+show_in_stores: false
+platforms:
+  - web
+en: Improve the display of the message thanking for feedback in small screens

--- a/web/src/components/Feedback.tsx
+++ b/web/src/components/Feedback.tsx
@@ -12,6 +12,7 @@ import TextInput from './TextInput'
 
 export const Container = styled.div`
   display: flex;
+  flex: 1;
   max-height: 80vh;
   box-sizing: border-box;
   flex-direction: column;

--- a/web/src/components/FeedbackModal.tsx
+++ b/web/src/components/FeedbackModal.tsx
@@ -41,7 +41,7 @@ const ModalContent = styled.div`
   @media ${dimensions.smallViewport} {
     height: 100%;
     align-items: center;
-    justify-content: center;
+    width: 100%;
   }
 `
 const Header = styled.div<{ flexDirection: string }>`


### PR DESCRIPTION
This pull request belongs to https://issues.tuerantuer.org/browse/IGAPP-1351 .

It turns the screen thanking our users for feedback (in small browsers) from 
<img width="503" alt="image" src="https://github.com/digitalfabrik/integreat-app/assets/18513943/a49e52f6-2269-4dae-aa84-742773245a15">


to 
<img width="436" alt="image" src="https://github.com/digitalfabrik/integreat-app/assets/18513943/d0a2b2dc-4fd2-4dc6-847f-f4c73f4582f4">

