### PR TITLE
2314: Remove unused and sometimes missing lastUpdate property

### DIFF
--- a/native/src/utils/DataContainer.ts
+++ b/native/src/utils/DataContainer.ts
@@ -4,7 +4,6 @@ import { CategoriesMapModel, CityModel, EventModel, PoiModel } from 'api-client'
 
 export type PageResourceCacheEntryStateType = {
   filePath: string
-  lastUpdate: DateTime
   hash: string
 }
 export type PageResourceCacheStateType = Record<string, PageResourceCacheEntryStateType>

--- a/native/src/utils/DatabaseConnector.ts
+++ b/native/src/utils/DatabaseConnector.ts
@@ -165,7 +165,6 @@ type CityLastUsageType = {
 type MetaCitiesType = Record<CityCodeType, MetaCitiesEntryType>
 type PageResourceCacheEntryJsonType = {
   file_path: string
-  last_update: string
   hash: string
 }
 type PageResourceCacheJsonType = Record<string, PageResourceCacheEntryJsonType>
@@ -661,7 +660,6 @@ class DatabaseConnector {
             fileResourceCache,
             (entry: PageResourceCacheEntryJsonType): PageResourceCacheEntryStateType => ({
               filePath: entry.file_path,
-              lastUpdate: DateTime.fromISO(entry.last_update),
               hash: entry.hash,
             })
           )
@@ -680,7 +678,6 @@ class DatabaseConnector {
             fileResourceCache,
             (entry: PageResourceCacheEntryStateType): PageResourceCacheEntryJsonType => ({
               file_path: entry.filePath,
-              last_update: entry.lastUpdate.toISO(),
               hash: entry.hash,
             })
           )

--- a/native/src/utils/FetcherModule.ts
+++ b/native/src/utils/FetcherModule.ts
@@ -3,14 +3,7 @@ import { isEmpty } from 'lodash'
 import NativeFetcherModule from './NativeFetcherModule'
 
 export type TargetFilePathsType = Record<string, string>
-export type FetchResultType = Record<
-  string,
-  {
-    lastUpdate: string
-    url: string
-    errorMessage: string | null | undefined
-  }
->
+export type FetchResultType = Record<string, { url: string; errorMessage: string | null | undefined }>
 
 class FetcherModule {
   // TODO IGAPP-217: Correctly handle already fetching

--- a/native/src/utils/__tests__/DatabaseConnector.spec.ts
+++ b/native/src/utils/__tests__/DatabaseConnector.spec.ts
@@ -31,14 +31,12 @@ describe('DatabaseConnector', () => {
       '/path/to/page': {
         'https://test.de/path/to/resource/test.png': {
           filePath: '/local/path/to/resource/b4b5dca65e423.png',
-          lastUpdate: DateTime.fromISO('2011-02-04T00:00:00.000'),
           hash: 'testHash',
         },
       },
       '/path/to/page/child': {
         'https://test.de/path/to/resource/test2.jpg': {
           filePath: '/local/path/to/resource/970c65c41eac0.jpg',
-          lastUpdate: DateTime.fromISO('2011-05-04T00:00:00.000'),
           hash: 'testHash',
         },
       },

--- a/native/src/utils/__tests__/DefaultDataContainer.spec.ts
+++ b/native/src/utils/__tests__/DefaultDataContainer.spec.ts
@@ -14,7 +14,6 @@ const testResources = {
   '/path/to/page': {
     'https://test.de/path/to/resource/test.png': {
       filePath: '/local/path/to/resource2/b4b5dca65e423.png',
-      lastUpdate: DateTime.fromISO('2011-02-04T00:00:00.000Z'),
       hash: 'testHash',
     },
   },
@@ -23,7 +22,6 @@ const previousResources = {
   '/path/to/page': {
     'https://test.de/path/to/resource/test.png': {
       filePath: '/local/path/to/resource/b4b5dca65e423.png',
-      lastUpdate: DateTime.fromISO('2011-02-04T00:00:00.000Z'),
       hash: 'testHash',
     },
   },
@@ -32,7 +30,6 @@ const anotherTestResources = {
   '/path/to/page': {
     'https://test.de/path/to/anotherResource/test.png': {
       filePath: '/local/path/to/resource3/b4b5dca65e424.png',
-      lastUpdate: DateTime.fromISO('2011-02-04T00:00:00.000Z'),
       hash: 'testHash',
     },
   },

--- a/native/src/utils/loadResourceCache.ts
+++ b/native/src/utils/loadResourceCache.ts
@@ -1,6 +1,5 @@
 import NetInfo from '@react-native-community/netinfo'
 import { flatten, mapValues, pickBy, reduce, values } from 'lodash'
-import { DateTime } from 'luxon'
 
 import { CategoriesMapModel, EventModel, ExtendedPageModel, PoiModel } from 'api-client/src'
 
@@ -81,7 +80,6 @@ const loadResourceCache = async ({
         if (downloadResult) {
           acc[downloadResult.url] = {
             filePath,
-            lastUpdate: DateTime.fromISO(downloadResult.lastUpdate),
             hash: fetchMapTarget.urlHash,
           }
         }


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
Remove the unused property lastUpdate of fetch results which was sometimes undefined and therefore crashing the app.

### Proposed changes

<!-- Describe this PR in more detail. -->

- Unused property lastUpdate sometimes returned by NativeFetcherModule is now ignored
- Unused property lastUpdate of resource cache was removed and is not saved to database connector anymore
- Removing the property and not paring it as DateTime avoids the app crashing

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- There is no more lastUpdate timestamp for resource cache entries

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2314 

---

<!--
DOR:
- [Release notes](https://github.com/Integreat/integreat-react-native-app/blob/develop/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
