### PR TITLE
Update template for release note

### DIFF
--- a/release-notes/ReleaseNoteTemplate.yml
+++ b/release-notes/ReleaseNoteTemplate.yml
@@ -1,4 +1,4 @@
-issue_key: <jira issue key> # e.g. IGAPP-123 (NATIVE-587, WEBAPP-42)
+issue_key: <github issue number> # e.g. #1234
 show_in_stores: <boolean> # whether this note should be shown in the stores, either true or false
 platforms: # relevant platforms, possible values: web, android and ios
   - <platform1>


### PR DESCRIPTION
### Short description

The template for the release notes now mentions a Github issue number instead of a JIRA issue key.

---

<!--
DOR:
- [Release notes](https://github.com/Integreat/integreat-react-native-app/blob/develop/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
