### PR TITLE
2377: Fix other category

### DIFF
--- a/native/src/components/PoiFiltersModal.tsx
+++ b/native/src/components/PoiFiltersModal.tsx
@@ -113,8 +113,8 @@ const PoiFiltersModal = ({
               <StyledToggleButton
                 key={it.id}
                 text={it.name}
-                active={it === selectedPoiCategory}
-                onPress={() => setSelectedPoiCategory(it === selectedPoiCategory ? null : it)}
+                active={it.id === selectedPoiCategory?.id}
+                onPress={() => setSelectedPoiCategory(it.id === selectedPoiCategory?.id ? null : it)}
                 Icon={<SvgUri uri={it.icon} />}
               />
             ))}

--- a/native/src/routes/Pois.tsx
+++ b/native/src/routes/Pois.tsx
@@ -83,7 +83,7 @@ const Pois = ({ pois: allPois, language, cityModel, route, navigation }: PoisPro
   const pois = useMemo(
     () =>
       allPois
-        .filter(poi => !poiCategoryFilter || poi.category === poiCategoryFilter)
+        .filter(poi => !poiCategoryFilter || poi.category.isEqual(poiCategoryFilter))
         .filter(poi => !poiCurrentlyOpenFilter || poi.isCurrentlyOpen),
     [allPois, poiCategoryFilter, poiCurrentlyOpenFilter],
   )

--- a/release-notes/unreleased/2377-poi-category-others.yml
+++ b/release-notes/unreleased/2377-poi-category-others.yml
@@ -1,0 +1,7 @@
+issue_key: 2377
+show_in_stores: true
+platforms:
+  - android
+  - ios
+en: The filter Other can now be selected.
+de: Der Filter Other kann nun ausgewählt werden.


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
This PR fixes the selection of the `Other` category in the poi filters.

### Proposed changes

<!-- Describe this PR in more detail. -->

- Use correct check instead of `===`

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2377

---

<!--
DOR:
- [Release notes](https://github.com/Integreat/integreat-react-native-app/blob/develop/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
