### PR TITLE
Disable console.error in tests #2407

### DIFF
--- a/web/src/utils/sentry.ts
+++ b/web/src/utils/sentry.ts
@@ -6,6 +6,10 @@ import { FetchError, NotFoundError } from 'api-client'
 
 import buildConfig from '../constants/buildConfig'
 
+console.error = () => {
+  // Do nothing.
+};
+
 const sentryEnabled = (): boolean => buildConfig().featureFlags.sentry
 const developerFriendly = (): boolean => buildConfig().featureFlags.developerFriendly
 


### PR DESCRIPTION
### Short description

Attempting to hide console.error from logs in sentry.ts

### Proposed changes

Overrode default console.error behavior in sentry.ts

-
-

-

### Resolved issues

#2407

Fixes: #

---

<!--
DOR:
- [Release notes](https://github.com/Integreat/integreat-react-native-app/blob/develop/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
