### PR TITLE
Disable console.error in tests #2407

### DIFF
--- a/api-client/jest.setup.ts
+++ b/api-client/jest.setup.ts
@@ -1,5 +1,7 @@
 global.fetch = require('jest-fetch-mock')
 
+console.error = () => undefined
+
 class FormDataMock {
   formData = {}
   append(name: string, value: object) {

--- a/native/jest.setup.ts
+++ b/native/jest.setup.ts
@@ -7,6 +7,8 @@ import { I18nManager } from './src/testing/I18nManagerMock'
 
 global.fetch = require('jest-fetch-mock')
 
+console.error = () => undefined
+
 jest.mock('@react-native-async-storage/async-storage', () => mockAsyncStorage)
 
 // react-navigation jest setup

--- a/translations/jest.setup.ts
+++ b/translations/jest.setup.ts
@@ -1,0 +1,1 @@
+console.error = () => undefined

--- a/web/jest.setup.ts
+++ b/web/jest.setup.ts
@@ -8,7 +8,7 @@ import 'raf/polyfill'
 global.fetch = require('jest-fetch-mock')
 // Setup config mock
 
-console.error = () => {}
+console.error = () => undefined
 
 const walkDir = (dir: string, callback: (dir: string) => void) => {
   fs.readdirSync(dir).forEach(f => {

--- a/web/jest.setup.ts
+++ b/web/jest.setup.ts
@@ -8,6 +8,8 @@ import 'raf/polyfill'
 global.fetch = require('jest-fetch-mock')
 // Setup config mock
 
+console.error = () => {}
+
 const walkDir = (dir: string, callback: (dir: string) => void) => {
   fs.readdirSync(dir).forEach(f => {
     const filePath = path.join(dir, f)

--- a/web/src/utils/sentry.ts
+++ b/web/src/utils/sentry.ts
@@ -6,10 +6,6 @@ import { FetchError, NotFoundError } from 'api-client'
 
 import buildConfig from '../constants/buildConfig'
 
-console.error = () => {
-  // Do nothing.
-};
-
 const sentryEnabled = (): boolean => buildConfig().featureFlags.sentry
 const developerFriendly = (): boolean => buildConfig().featureFlags.developerFriendly
 

--- a/web/src/utils/sentry.ts
+++ b/web/src/utils/sentry.ts
@@ -6,6 +6,10 @@ import { FetchError, NotFoundError } from 'api-client'
 
 import buildConfig from '../constants/buildConfig'
 
+console.error = () => {
+  // Do nothing.
+};
+
 const sentryEnabled = (): boolean => buildConfig().featureFlags.sentry
 const developerFriendly = (): boolean => buildConfig().featureFlags.developerFriendly
 


### PR DESCRIPTION
### Short description

Disabled console.error in jest tests

### Proposed changes

Changed default console.error behavior

Fixes #2407 