### PR TITLE
2409: Improve poi category filter layout

### DIFF
--- a/release-notes/unreleased/2409-improve-poi-category-filter-layout.yml
+++ b/release-notes/unreleased/2409-improve-poi-category-filter-layout.yml
@@ -1,0 +1,5 @@
+issue_key: 2409
+show_in_stores: false
+platforms:
+  - web
+en: The layout of the location category filters was improved.

--- a/web/src/components/ModalContent.tsx
+++ b/web/src/components/ModalContent.tsx
@@ -19,6 +19,7 @@ const Header = styled.div<{ small: boolean }>`
   justify-content: space-between;
   font-size: ${props => props.theme.fonts.subTitleFontSize};
   font-weight: bold;
+  align-items: center;
 
   ${props =>
     props.small &&
@@ -38,6 +39,8 @@ const CloseButton = styled.button`
 const StyledIcon = styled(Icon)`
   width: 24px;
   height: 24px;
+  align-self: center;
+  display: flex;
 `
 
 type ModalProps = {

--- a/web/src/components/PoiFilters.tsx
+++ b/web/src/components/PoiFilters.tsx
@@ -9,7 +9,9 @@ import ModalContent from './ModalContent'
 import Checkbox from './base/Checkbox'
 import Icon from './base/Icon'
 import TextButton from './base/TextButton'
-import ToggleButton from './base/ToggleButton'
+import ToggleButton, { toggleButtonWidth } from './base/ToggleButton'
+
+const tileColumnGap = 16
 
 const Container = styled.div`
   display: flex;
@@ -41,16 +43,16 @@ const SortingHint = styled.div`
   align-self: flex-end;
   font-size: 0.75rem;
   color: ${props => props.theme.colors.textColor};
-  font-family: ${props => props.theme.fonts.native.decorativeFontRegular};
+  font-family: ${props => props.theme.fonts.web.decorativeFont};
   padding: 0 4px;
 `
 
-const TileRow = styled.div`
-  display: flex;
-  justify-content: space-around;
-  flex-wrap: wrap;
-  column-gap: 16px;
+const TileRow = styled.div<{ itemCount: number }>`
+  display: grid;
+  column-gap: ${tileColumnGap}px;
   row-gap: 24px;
+  justify-content: center;
+  grid-template-columns: repeat(${props => props.itemCount}, ${toggleButtonWidth}px);
 `
 
 const StyledButton = styled(TextButton)`
@@ -70,6 +72,7 @@ type PoiFiltersProps = {
   setSelectedPoiCategory: (poiCategory: PoiCategoryModel | null) => void
   currentlyOpenFilter: boolean
   setCurrentlyOpenFilter: (currentlyOpen: boolean) => void
+  panelWidth: number
 }
 
 const PoiFilters = ({
@@ -79,6 +82,7 @@ const PoiFilters = ({
   setSelectedPoiCategory,
   currentlyOpenFilter,
   setCurrentlyOpenFilter,
+  panelWidth,
 }: PoiFiltersProps): ReactElement => {
   const poiCategories = pois
     .map(it => it.category)
@@ -104,7 +108,7 @@ const PoiFilters = ({
             <SubTitle>{t('poiCategories')}</SubTitle>
             <SortingHint>{t('alphabetLetters')}</SortingHint>
           </Row>
-          <TileRow>
+          <TileRow itemCount={Math.floor(panelWidth / (toggleButtonWidth + tileColumnGap))}>
             {poiCategories.map(it => (
               <ToggleButton
                 key={it.id}

--- a/web/src/components/PoisDesktop.tsx
+++ b/web/src/components/PoisDesktop.tsx
@@ -29,8 +29,8 @@ const PanelContainer = styled.article`
   height: 100%;
   display: flex;
   flex-direction: column;
-  width: 332px;
-  min-width: 332px;
+  width: ${dimensions.poiDesktopPanelWidth}px;
+  min-width: ${dimensions.poiDesktopPanelWidth}px;
 `
 
 const ListViewWrapper = styled.div<{ panelHeights: number; bottomBarHeight: number }>`

--- a/web/src/components/base/ToggleButton.tsx
+++ b/web/src/components/base/ToggleButton.tsx
@@ -3,13 +3,14 @@ import styled from 'styled-components'
 
 import StyledSmallViewTip from '../StyledSmallViewTip'
 
+export const toggleButtonWidth = 100
 const StyledButton = styled.button<{ $active: boolean | null }>`
   border: none;
   box-shadow:
     0 1px 2px rgba(0, 0, 0, 0.25),
     0 1px 4px 1px rgba(0, 0, 0, 0.15);
   border-radius: 18px;
-  width: 100px;
+  width: ${toggleButtonWidth}px;
   height: 80px;
   background-color: ${props => (props.$active ? props.theme.colors.themeColor : props.theme.colors.backgroundColor)};
   color: ${props => props.theme.colors.textSecondaryColor};

--- a/web/src/constants/dimensions.ts
+++ b/web/src/constants/dimensions.ts
@@ -12,6 +12,7 @@ export type DimensionsType = {
   headerHeightSmall: number
   footerHeight: number
   navigationMenuHeight: number
+  poiDesktopPanelWidth: number
 }
 
 const dimensions: DimensionsType = {
@@ -28,6 +29,7 @@ const dimensions: DimensionsType = {
   headerHeightSmall: 70,
   footerHeight: 50,
   navigationMenuHeight: 90,
+  poiDesktopPanelWidth: 332,
 }
 
 export default dimensions

--- a/web/src/routes/PoisPage.tsx
+++ b/web/src/routes/PoisPage.tsx
@@ -66,7 +66,7 @@ const PoisPage = ({ cityCode, languageCode, city, pathname }: CityRouteProps): R
   } = useLoadFromEndpoint(createPOIsEndpoint, cmsApiBaseUrl, { city: cityCode, language: languageCode })
   // keep the old mapViewport when changing the viewport
   const [mapViewport, setMapViewport] = useState<MapViewViewport>()
-  const { viewportSmall } = useWindowDimensions()
+  const { viewportSmall, width } = useWindowDimensions()
   const direction = config.getScriptDirection(languageCode)
 
   const pois = useMemo(
@@ -177,9 +177,9 @@ const PoisPage = ({ cityCode, languageCode, city, pathname }: CityRouteProps): R
       setSelectedPoiCategory={updatePoiCategoryFilter}
       currentlyOpenFilter={poiCurrentlyOpenFilter}
       setCurrentlyOpenFilter={updatePoiCurrentlyOpenFilter}
+      panelWidth={viewportSmall ? width : dimensions.poiDesktopPanelWidth}
     />
   )
-
   if (showFilterSelection && viewportSmall) {
     return FiltersModal
   }


### PR DESCRIPTION
### Short description

Depending on the amount of categories the filter layout of the toggle buttons look weird/displaced

### Proposed changes

The amount of icons per row is now depending on the width of the panel and implemented with a grid layout
Items of the next should should align left.

### Side effects

Hopefully none

### Resolved issues

#2409 

Desktop Panel
<img width="264" alt="image" src="https://github.com/digitalfabrik/integreat-app/assets/37902063/87279387-4be8-40e4-8d2c-9c009b7a0335">

mobile
<img width="294" alt="image" src="https://github.com/digitalfabrik/integreat-app/assets/37902063/9ac49244-6f2a-4651-ab9b-76d35fb17ec1">

iPadMini (768px width before it breaks to desktop)
<img width="574" alt="image" src="https://github.com/digitalfabrik/integreat-app/assets/37902063/6b0c3568-d1dc-411b-9adb-4732bf9c1009">


