### PR TITLE
2438: Fix push notifications for android 13+

### DIFF
--- a/native/jest.setup.ts
+++ b/native/jest.setup.ts
@@ -10,6 +10,7 @@ global.fetch = require('jest-fetch-mock')
 console.error = () => undefined
 
 jest.mock('@react-native-async-storage/async-storage', () => mockAsyncStorage)
+jest.mock('react-native-permissions', () => require('react-native-permissions/mock'))
 
 // react-navigation jest setup
 // https://reactnavigation.org/docs/testing#mocking-native-modules

--- a/native/src/Navigator.tsx
+++ b/native/src/Navigator.tsx
@@ -62,6 +62,7 @@ import SprungbrettOfferContainer from './routes/SprungbrettOfferContainer'
 import appSettings, { ASYNC_STORAGE_VERSION } from './utils/AppSettings'
 import dataContainer from './utils/DefaultDataContainer'
 import {
+  androidPushNotificationPermissionFix,
   quitAppStatePushNotificationListener,
   useForegroundPushNotificationListener,
 } from './utils/PushNotificationsManager'
@@ -92,13 +93,17 @@ const Stack = createStackNavigator<RoutesParamsType>()
 
 const Navigator = (): ReactElement | null => {
   const showSnackbar = useSnackbar()
-  const { cityCode, changeCityCode } = useContext(AppContext)
+  const { cityCode, changeCityCode, languageCode } = useContext(AppContext)
   const navigation = useNavigation<NavigationProps<RoutesType>>()
   const { data: settings, error: settingsError, refresh: refreshSettings } = useLoadAsync(appSettings.loadSettings)
   const [initialRoute, setInitialRoute] = useState<InitialRouteType>(null)
 
   // Preload cities
   const { data: cities, error: citiesError, refresh: refreshCities } = useLoadCities()
+
+  useEffect(() => {
+    androidPushNotificationPermissionFix(cityCode, languageCode).catch(reportError)
+  }, [cityCode, languageCode])
 
   useForegroundPushNotificationListener({ showSnackbar, navigate: navigation.navigate })
 

--- a/native/src/__tests__/Navigator.spec.tsx
+++ b/native/src/__tests__/Navigator.spec.tsx
@@ -122,6 +122,7 @@ jest.mock('../utils/PushNotificationsManager', () => ({
   pushNotificationsSupported: jest.fn(() => true),
   quitAppStatePushNotificationListener: jest.fn(),
   useForegroundPushNotificationListener: jest.fn(),
+  androidPushNotificationPermissionFix: jest.fn(async () => undefined),
 }))
 jest.mock('../utils/FetcherModule')
 

--- a/native/src/components/__tests__/NearbyCities.spec.tsx
+++ b/native/src/components/__tests__/NearbyCities.spec.tsx
@@ -15,7 +15,6 @@ jest.mock('../../utils/LocationPermissionManager', () => ({
   checkLocationPermission: jest.fn(),
   requestLocationPermission: jest.fn(),
 }))
-jest.mock('react-native-permissions', () => require('react-native-permissions/mock'))
 jest.mock('@react-native-community/geolocation')
 jest.mock('react-i18next')
 

--- a/native/src/contexts/AppContextProvider.tsx
+++ b/native/src/contexts/AppContextProvider.tsx
@@ -5,7 +5,7 @@ import { useLoadAsync } from 'api-client'
 import buildConfig from '../constants/buildConfig'
 import appSettings from '../utils/AppSettings'
 import dataContainer from '../utils/DefaultDataContainer'
-import * as PushNotificationsManager from '../utils/PushNotificationsManager'
+import { subscribeNews, unsubscribeNews } from '../utils/PushNotificationsManager'
 import { reportError } from '../utils/sentry'
 
 type AppContextType = {
@@ -47,34 +47,18 @@ const AppContextProvider = ({ children }: AppContextProviderProps): ReactElement
     }
   }, [cityCode])
 
-  const subscribe = useCallback((cityCode: string, languageCode: string) => {
-    PushNotificationsManager.requestPushNotificationPermission()
-      .then(permissionGranted =>
-        permissionGranted
-          ? PushNotificationsManager.subscribeNews(cityCode, languageCode)
-          : appSettings.setSettings({ allowPushNotifications: false }),
-      )
-      .catch(reportError)
-  }, [])
-
-  const unsubscribe = useCallback(
-    (cityCode: string, languageCode: string) =>
-      PushNotificationsManager.unsubscribeNews(cityCode, languageCode).catch(reportError),
-    [],
-  )
-
   const changeCityCode = useCallback(
     (newCityCode: string | null): void => {
       setCityCode(newCityCode)
       appSettings.setSelectedCity(newCityCode).catch(reportError)
       if (languageCode && cityCode) {
-        unsubscribe(cityCode, languageCode)
+        unsubscribeNews(cityCode, languageCode).catch(reportError)
       }
       if (languageCode && newCityCode) {
-        subscribe(newCityCode, languageCode)
+        subscribeNews(newCityCode, languageCode).catch(reportError)
       }
     },
-    [cityCode, languageCode, subscribe, unsubscribe],
+    [cityCode, languageCode],
   )
 
   const changeLanguageCode = useCallback(
@@ -82,13 +66,13 @@ const AppContextProvider = ({ children }: AppContextProviderProps): ReactElement
       setLanguageCode(newLanguageCode)
       appSettings.setContentLanguage(newLanguageCode).catch(reportError)
       if (cityCode && languageCode) {
-        unsubscribe(cityCode, languageCode)
+        unsubscribeNews(cityCode, languageCode).catch(reportError)
       }
       if (cityCode) {
-        subscribe(cityCode, newLanguageCode)
+        subscribeNews(cityCode, newLanguageCode).catch(reportError)
       }
     },
-    [cityCode, languageCode, subscribe, unsubscribe],
+    [cityCode, languageCode],
   )
 
   const appContext = useMemo(

--- a/native/src/utils/__tests__/createSettingsSections.spec.ts
+++ b/native/src/utils/__tests__/createSettingsSections.spec.ts
@@ -24,7 +24,6 @@ jest.mock('../../utils/PushNotificationsManager', () => ({
   subscribeNews: jest.fn(),
   unsubscribeNews: jest.fn(),
 }))
-jest.mock('react-native-permissions', () => require('react-native-permissions/mock'))
 jest.mock('@react-native-community/geolocation')
 
 const mockRequestPushNotificationPermission = mocked(requestPushNotificationPermission)

--- a/native/src/utils/createSettingsSections.ts
+++ b/native/src/utils/createSettingsSections.ts
@@ -10,8 +10,12 @@ import NativeConstants from '../constants/NativeConstants'
 import { NavigationProps } from '../constants/NavigationTypes'
 import buildConfig from '../constants/buildConfig'
 import { SettingsType } from './AppSettings'
-import * as NotificationsManager from './PushNotificationsManager'
-import { pushNotificationsEnabled } from './PushNotificationsManager'
+import {
+  pushNotificationsEnabled,
+  requestPushNotificationPermission,
+  subscribeNews,
+  unsubscribeNews,
+} from './PushNotificationsManager'
 import openExternalUrl from './openExternalUrl'
 import { initSentry } from './sentry'
 
@@ -74,15 +78,15 @@ const createSettingsSections = ({
                   }),
                   async (newSettings): Promise<boolean> => {
                     if (!cityCode) {
-                      // No city selected so nothing to do here
+                      // No city selected so nothing to do here (should not ever happen since settings are only available from city content routes)
                       return true
                     }
 
                     if (newSettings.allowPushNotifications) {
-                      const status = await NotificationsManager.requestPushNotificationPermission()
+                      const status = await requestPushNotificationPermission()
 
                       if (status) {
-                        await NotificationsManager.subscribeNews(cityCode, languageCode, true)
+                        await subscribeNews(cityCode, languageCode, true)
                       } else {
                         // If the user has rejected the permission once, it can only be changed in the system settings
                         openSettings()
@@ -90,7 +94,7 @@ const createSettingsSections = ({
                         return false
                       }
                     } else {
-                      await NotificationsManager.unsubscribeNews(cityCode, languageCode)
+                      await unsubscribeNews(cityCode, languageCode)
                     }
                     return true
                   },

--- a/release-notes/unreleased/2438-fix-push-news-android-13.yml
+++ b/release-notes/unreleased/2438-fix-push-news-android-13.yml
@@ -1,0 +1,6 @@
+issue_key: 2438
+show_in_stores: true
+platforms:
+  - android
+en: Support receiving push notifications on Android 13.
+de: Das Empfangen von Push Nachrichten auf Android 13 wird nun unterstützt.


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
Since Android 13 explicit push notification permission has to be requested, which will be done with this PR.

### Proposed changes

<!-- Describe this PR in more detail. -->

- Check on app start whether permissions are already available and request them and subscribe to channel otherwise (on android 13+)
- Decouple subscribing to channel from permissions on city/language change
- Use react-native-permissions to ask for permissions

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Permissions are not requested anymore if changing city/language.

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2438.

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
