### PR TITLE
2381: Don't open the kebab menu when tabbing through the app

### DIFF
--- a/release-notes/unreleased/2381-tabbing-kebab-menu.yml
+++ b/release-notes/unreleased/2381-tabbing-kebab-menu.yml
@@ -1,0 +1,5 @@
+issue_key: 2381
+show_in_stores: false
+platforms:
+  - web
+en: Tabbing through the page doesn't open the kebab menu anymore

--- a/web/src/components/KebabMenu.tsx
+++ b/web/src/components/KebabMenu.tsx
@@ -100,7 +100,10 @@ const KebabMenu = ({ items, direction, show, setShow, Footer }: KebabMenuProps):
       <Portal
         className='kebab-menu'
         show={show}
-        style={window.scrollY > 0 ? { top: `${window.scrollY}px` } : undefined}>
+        style={{
+          visibility: show ? 'visible' : 'hidden',
+          top: window.scrollY > 0 ? `${window.scrollY}px` : undefined,
+        }}>
         {/* disabled because this is an overlay for backdrop close */}
         {/* eslint-disable-next-line styled-components-a11y/no-static-element-interactions,styled-components-a11y/click-events-have-key-events */}
         <Overlay onClick={onClick} show={show} />


### PR DESCRIPTION
### Short description

When tabbing all the way through the app, at the very end it would open the kebab menu because it was already there just visibly hidden and the tab somehow seems to trigger an `onClick` there. This also tells the HTML that the menu is hidden when the user can't see it, and now doesn't open just by tabbing through anymore.

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2381 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
