### PR TITLE
2496: Dates of recurring events wrong if changing to daylight saving time

### DIFF
--- a/api-client/src/models/__tests__/DateModel.spec.ts
+++ b/api-client/src/models/__tests__/DateModel.spec.ts
@@ -135,8 +135,8 @@ describe('DateModel', () => {
   describe('recurrences', () => {
     it('should update start and end date according to recurrence rule and ignore delivered dates', () => {
       const date = new DateModel({
-        startDate: DateTime.fromISO('2017-11-27T19:30:00+02:00'),
-        endDate: DateTime.fromISO('2017-11-28T21:30:00+02:00'),
+        startDate: DateTime.fromISO('2017-09-27T19:30:00+02:00'),
+        endDate: DateTime.fromISO('2017-09-28T21:30:00+02:00'),
         allDay: false,
         recurrenceRule: rrulestr('DTSTART:20230414T050000\nRRULE:FREQ=WEEKLY;BYDAY=MO'),
       })
@@ -158,13 +158,13 @@ describe('DateModel', () => {
 
     it('should return exactly count recurrences', () => {
       const date = new DateModel({
-        startDate: DateTime.fromISO('2017-11-27T19:30:00+02:00'),
-        endDate: DateTime.fromISO('2017-11-28T21:30:00+02:00'),
+        startDate: DateTime.fromISO('2017-09-27T19:30:00+02:00'),
+        endDate: DateTime.fromISO('2017-09-28T21:30:00+02:00'),
         allDay: false,
         recurrenceRule: rrulestr('DTSTART:20230414T050000\nRRULE:FREQ=WEEKLY;BYDAY=MO'),
       })
 
-      expect(date.recurrences(3)).toEqual([
+      expect(date.recurrences(4)).toEqual([
         new DateModel({
           allDay: false,
           recurrenceRule: null,
@@ -183,13 +183,19 @@ describe('DateModel', () => {
           startDate: DateTime.fromISO('2023-10-23T07:00:00.000+02:00'),
           endDate: DateTime.fromISO('2023-10-24T09:00:00.000+02:00'),
         }),
+        new DateModel({
+          allDay: false,
+          recurrenceRule: null,
+          startDate: DateTime.fromISO('2023-10-30T07:00:00.000+01:00'),
+          endDate: DateTime.fromISO('2023-10-31T09:00:00.000+01:00'),
+        }),
       ])
     })
 
     it('should return less recurrences if rrule ends', () => {
       const date = new DateModel({
-        startDate: DateTime.fromISO('2017-11-27T19:30:00+02:00'),
-        endDate: DateTime.fromISO('2017-11-28T21:30:00+02:00'),
+        startDate: DateTime.fromISO('2017-09-27T19:30:00+02:00'),
+        endDate: DateTime.fromISO('2017-09-28T21:30:00+02:00'),
         allDay: false,
         recurrenceRule: rrulestr('DTSTART:20230414T050000\nRRULE:FREQ=WEEKLY;BYDAY=MO;UNTIL=20231015T050000'),
       })

--- a/release-notes/unreleased/2496-wrong-dst.yml
+++ b/release-notes/unreleased/2496-wrong-dst.yml
@@ -1,0 +1,8 @@
+issue_key: 2438
+show_in_stores: true
+platforms:
+  - android
+  - ios
+  - web
+en: Fixed wrong dates caused by daylight savings time.
+de: Falsch angezeigte Daten durch Zeitverschiebung behoben.

--- a/release-notes/unreleased/2496-wrong-dst.yml
+++ b/release-notes/unreleased/2496-wrong-dst.yml
@@ -5,4 +5,4 @@ platforms:
   - ios
   - web
 en: Fixed wrong dates caused by daylight savings time.
-de: Falsch angezeigte Daten durch Zeitverschiebung behoben.
+de: Falsch angezeigte Daten durch Zeitumstellung behoben.


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
Our rrule doesn't support working with timezones, therefore the time was wrong if the start dates was in DST and the some recurrences not or the other way round. This PR also adds the offset such that times are displayed correctly.

### Proposed changes

<!-- Describe this PR in more detail. -->

Keep the offset of the original start date and add the offset difference to all dates returned by rrule.

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

None.

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2496.

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
