### PR TITLE
2514: Remove pre-commit from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,6 @@ If you are using a different IDE like Visual Studio Code the steps might [differ
 - **Open either the [web](web) or [native](native) directory separately in IntelliJ (File > Open).**
 - Follow the steps mentioned in the [web README](web/README.md) or the [native README](native/README.md).
 - [optional]: Enable `Languages & Frameworks > JavaScript > Prettier > On Save` to enable prettier autoformatting.
-- [optional]: Install our pre-commit hook for prettier autoformatting and automated updates of the CircleCI config:
-
-  > cd .git/hooks
-
-  > ln -s ../../.github/hooks/pre-commit pre-commit
 
 _We are recommending to use either a Linux distribution or MacOS for development.
 If you want to develop on Windows anyway, follow the steps [here](./docs/windows-setup.md)


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->

Pre-commit has been fixed and there is no longer need to mention it on Readme

Fixes: #2514

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
