### PR TITLE
2541: Fix event export

### DIFF
--- a/api-client/src/utils/index.ts
+++ b/api-client/src/utils/index.ts
@@ -2,4 +2,4 @@ import { DateTime } from 'luxon'
 
 export const getSlugFromPath = (path: string): string => path.split('/').pop() ?? ''
 
-export const formatDateICal = (date: DateTime): string => `${date.toFormat('yyyyMMddTHHmm')}00`
+export const formatDateICal = (date: DateTime): string => date.toFormat("yyyyMMdd'T'HHmm'00'")

--- a/native/ios/Integreat/Info.plist
+++ b/native/ios/Integreat/Info.plist
@@ -60,6 +60,8 @@
 	</dict>
 	<key>NSCalendarsUsageDescription</key>
 	<string>Integreat wants to access the calendar to add an event.</string>
+	<key>NSCalendarsFullAccessUsageDescription</key>
+	<string>Integreat wants to access the calendar to add an event.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>NotoSansArabic-Regular.ttf</string>

--- a/native/ios/Podfile
+++ b/native/ios/Podfile
@@ -1,5 +1,6 @@
 require_relative '../node_modules/react-native/scripts/react_native_pods'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
+require_relative '../node_modules/react-native-permissions/scripts/setup'
 
 platform :ios, min_ios_version_supported
 prepare_react_native_project!
@@ -24,6 +25,12 @@ target 'Integreat' do
 
   # Flags change depending on the env values.
   flags = get_default_flags()
+
+  setup_permissions([
+    'Calendars',
+    'LocationWhenInUse',
+    'Notifications',
+  ])
 
   use_react_native!(
     :path => config[:reactNativePath],
@@ -56,8 +63,4 @@ target 'Integreat' do
     # Required for Mapbox
     $RNMBGL.post_install(installer)
   end
-
-  permissions_path = '../node_modules/react-native-permissions/ios'
-  pod 'Permission-LocationWhenInUse', :path => "#{permissions_path}/LocationWhenInUse"
-  pod 'Permission-Notifications', :path => "#{permissions_path}/Notifications"
 end

--- a/native/ios/Podfile.lock
+++ b/native/ios/Podfile.lock
@@ -142,10 +142,6 @@ PODS:
   - nanopb/decode (2.30908.0)
   - nanopb/encode (2.30908.0)
   - OpenSSL-Universal (1.1.1100)
-  - Permission-LocationWhenInUse (3.8.4):
-    - RNPermissions
-  - Permission-Notifications (3.8.4):
-    - RNPermissions
   - PromisesObjC (2.3.1)
   - RCT-Folly (2021.07.22.00):
     - boost
@@ -518,7 +514,7 @@ PODS:
     - React-Core
   - RNLocalize (3.0.2):
     - React-Core
-  - RNPermissions (3.8.4):
+  - RNPermissions (4.0.0-beta.1):
     - React-Core
   - RNReanimated (3.4.2):
     - DoubleConversion
@@ -596,8 +592,6 @@ DEPENDENCIES:
   - libevent (~> 2.1.12)
   - "maplibre-react-native (from `../node_modules/@maplibre/maplibre-react-native`)"
   - OpenSSL-Universal (= 1.1.1100)
-  - Permission-LocationWhenInUse (from `../node_modules/react-native-permissions/ios/LocationWhenInUse`)
-  - Permission-Notifications (from `../node_modules/react-native-permissions/ios/Notifications`)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCTRequired (from `../node_modules/react-native/Libraries/RCTRequired`)
   - RCTSystemSetting (from `../node_modules/react-native-system-setting`)
@@ -695,10 +689,6 @@ EXTERNAL SOURCES:
     :podspec: "../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec"
   maplibre-react-native:
     :path: "../node_modules/@maplibre/maplibre-react-native"
-  Permission-LocationWhenInUse:
-    :path: "../node_modules/react-native-permissions/ios/LocationWhenInUse"
-  Permission-Notifications:
-    :path: "../node_modules/react-native-permissions/ios/Notifications"
   RCT-Folly:
     :podspec: "../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec"
   RCTRequired:
@@ -828,8 +818,6 @@ SPEC CHECKSUMS:
   maplibre-react-native: f08cc1b867c4b3080b34955f8e2ce938361df4c2
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
-  Permission-LocationWhenInUse: 24d97eeb25d8ff9f2232e070f792eeb1360ccaf0
-  Permission-Notifications: e06c4b115105e9aed6ed8d03c9894c23c1051731
   PromisesObjC: c50d2056b5253dadbd6c2bea79b0674bd5a52fa4
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
   RCTRequired: 4db5e3e18b906377a502da5b358ff159ba4783ed
@@ -874,7 +862,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: c0d04458598fcb26052494ae23dda8f8f5162b13
   RNInAppBrowser: e36d6935517101ccba0e875bac8ad7b0cb655364
   RNLocalize: dbea38dcb344bf80ff18a1757b1becf11f70cae4
-  RNPermissions: f1b49dd05fa9b83993cd05a9ee115247944d8f1a
+  RNPermissions: 9c76579839681bde6f2acc479239dbca21c71dcc
   RNReanimated: 49cdb63e767bb7e743ff4c12f7d85722c0d008f2
   RNScreens: b21dc57dfa2b710c30ec600786a3fc223b1b92e7
   RNSentry: 0a1daa8ee81e2776f977ae8c66e67c8d85587828
@@ -885,6 +873,6 @@ SPEC CHECKSUMS:
   Yoga: 39310a10944fc864a7550700de349183450f8aaa
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: c273128d3223ff1b4b77fc982f00e5cdfdc945e2
+PODFILE CHECKSUM: 868219d0c2641b5c41192a48ec4fe30be4ac26bb
 
 COCOAPODS: 1.11.2

--- a/native/package.json
+++ b/native/package.json
@@ -80,7 +80,7 @@
     "react-native-inappbrowser-reborn": "^3.7.0",
     "react-native-localize": "^3.0.2",
     "react-native-pdf": "^6.7.1",
-    "react-native-permissions": "^3.8.4",
+    "react-native-permissions": "^4.0.0-beta.1",
     "react-native-reanimated": "^3.4.2",
     "react-native-safe-area-context": "^4.7.1",
     "react-native-screens": "^3.24.0",

--- a/native/src/components/ExportEventButton.tsx
+++ b/native/src/components/ExportEventButton.tsx
@@ -8,6 +8,7 @@ import styled from 'styled-components/native'
 import { EventModel } from 'api-client'
 
 import useSnackbar from '../hooks/useSnackbar'
+import { reportError } from '../utils/sentry'
 import CalendarChoice from './CalendarChoiceModal'
 import TextButton from './base/TextButton'
 
@@ -56,8 +57,9 @@ const ExportEventButton = ({ event }: ExportEventButtonType): ReactElement => {
       } else {
         showSnackbar({ text: 'generalError' })
       }
-    } catch {
+    } catch (e) {
       showSnackbar({ text: 'generalError' })
+      reportError(e)
     }
   }
 
@@ -86,8 +88,9 @@ const ExportEventButton = ({ event }: ExportEventButtonType): ReactElement => {
     } else if (editableCalendars.length === 1) {
       try {
         await exportEventToCalendar(editableCalendars[0]?.id)
-      } catch {
+      } catch (e) {
         showSnackbar({ text: 'generalError' })
+        reportError(e)
       }
     } else {
       setCalendars(editableCalendars)
@@ -99,8 +102,9 @@ const ExportEventButton = ({ event }: ExportEventButtonType): ReactElement => {
     setShowCalendarChoiceModal(false)
     try {
       await exportEventToCalendar(id)
-    } catch {
+    } catch (e) {
       showSnackbar({ text: 'generalError' })
+      reportError(e)
     }
   }
 

--- a/release-notes/unreleased/2541-fix-event-export.yml
+++ b/release-notes/unreleased/2541-fix-event-export.yml
@@ -1,0 +1,7 @@
+issue_key: 2541
+show_in_stores: true
+platforms:
+  - android
+  - web
+en: Adding events to the calendar works again
+de: Man kann Events wieder zum eigenen Kalender hinzufügen

--- a/yarn.lock
+++ b/yarn.lock
@@ -13090,13 +13090,6 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-pkg-dir@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-5.0.0.tgz#a02d6aebe6ba133a928f74aec20bafdfe6b8e760"
-  integrity sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==
-  dependencies:
-    find-up "^5.0.0"
-
 plist@^3.0.5:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/plist/-/plist-3.0.5.tgz#2cbeb52d10e3cdccccf0c11a63a85d830970a987"
@@ -13670,13 +13663,10 @@ react-native-pdf@^6.7.1:
     crypto-js "^3.2.0"
     deprecated-react-native-prop-types "^2.3.0"
 
-react-native-permissions@^3.8.4:
-  version "3.8.4"
-  resolved "https://registry.yarnpkg.com/react-native-permissions/-/react-native-permissions-3.8.4.tgz#20f203f1dd659c28fb770fc26bbbf0126faa797e"
-  integrity sha512-tJq+5eNqu8Y1PpmuSVMjQtW8E7YJbQ0LSbZ1o9KjgF7etgYmBSZeCR138x715vyZUAtwuecV+ybEM9z8dDs76Q==
-  dependencies:
-    picocolors "^1.0.0"
-    pkg-dir "^5.0.0"
+react-native-permissions@^4.0.0-beta.1:
+  version "4.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/react-native-permissions/-/react-native-permissions-4.0.0-beta.1.tgz#ff72e16a66d5f60394cf0d61b7d0d7acca0ca3c3"
+  integrity sha512-O2t1qXEcZDTfCLnu1Un8fsbX48VePOsJmsqmQqSg1qwxIMs6B9bzTo2M0eObMvCLTkLOT5qqhMtJ1kgYYNLB0g==
 
 react-native-reanimated@^3.4.2:
   version "3.4.2"


### PR DESCRIPTION
### Short description

This fixes the event export and adds monitoring for it.

### Proposed changes

- For the web export, the format didn't escape the letter 'T' in the middle of the DateTime, so we got an additional localized 24-hour time in there instead of a T, e.g. getting `2023110613:17131700` instead of `20231106T131700`.
- For the Android export, we were also using a wrong format. There was an additional problem here: for allDay events, the start and end have to be at midnight. The dates that we get from the API are at midnight for the start and at 23:59:00 for the end. I added a minute and set the times to be at midnight.
- Another Android issue: in Android 13 and 14, an exported calendar event is added to the Google Calendar and then added to the calendar app at the next sync. So, usually within a minute but not within a second. This lead to an error when trying to open the event from the link in the Snackbar so I deleted that link. Not linking to the event seems to also be the default Android behavior.
- One more Android issue: Android split the permissions for the calendar into a read and a write one.
- And one iOS issue: Apple changed its calendar permissions for iOS 17 which is why I switched to the latest rn-permissions to request those. rn-calendar-events is not updated anymore.

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Updated rn-permissions to a beta version.
-

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2541 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
