### PR TITLE
2554: Add workaround for XCode 15

### DIFF
--- a/native/ios/fastlane/Fastfile
+++ b/native/ios/fastlane/Fastfile
@@ -65,6 +65,13 @@ lane :build do |options|
   match(type: "development", app_identifier: build_config['bundleIdentifier'], readonly: true)
   match(type: "appstore", app_identifier: build_config['bundleIdentifier'], readonly: true)
 
+  if [ "$XCODE_VERSION_MAJOR" = "1500" ]; then
+    echo "Remove signature files (Xcode 15 workaround)"
+
+    rm "$BUILD_DIR/Release-iphoneos/Mapbox.xcframework-ios.signature"
+  fi
+
+
   increment_build_number(
       build_number: version_code
   )


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
Removing a signature that is copied twice by XCode 15.

Because the thought has crossed my mind to not: We need XCode 15 for the latest rn-permissions, which we in turn need to keep the calendar exports working for iOS 17.

Fixes: #2554 