### PR TITLE
Fix-XCode15-bug

### DIFF
--- a/native/ios/Integreat.xcodeproj/project.pbxproj
+++ b/native/ios/Integreat.xcodeproj/project.pbxproj
@@ -262,6 +262,7 @@
 				FCE17F1E70FA43899589ED22 /* [CP] Copy Pods Resources */,
 				31AF7631F7FB8B3BE99E14B2 /* [CP-User] [RNFB] Core Configuration */,
 				A2E593BDBAA2516521D00062 /* [CP] Embed Pods Frameworks */,
+				2E4AEEB92AFD3D4800365635 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -375,6 +376,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "../node_modules/react-native/scripts/react-native-xcode.sh index.ts\n";
+		};
+		2E4AEEB92AFD3D4800365635 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 8;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+			shellPath = /bin/sh;
+			shellScript = "# Workaround for Mapbox ios certificates issue - https://stackoverflow.com/questions/77397157\n  if [ \"$XCODE_VERSION_MAJOR\" = \"1500\" ]; then\n    echo \"Remove signature files (Xcode 15 workaround)\"\n\n    rm \"$BUILD_DIR/Release-iphoneos/Mapbox.xcframework-ios.signature\"\n  fi\n";
 		};
 		31AF7631F7FB8B3BE99E14B2 /* [CP-User] [RNFB] Core Configuration */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/native/ios/fastlane/Fastfile
+++ b/native/ios/fastlane/Fastfile
@@ -65,13 +65,6 @@ lane :build do |options|
   match(type: "development", app_identifier: build_config['bundleIdentifier'], readonly: true)
   match(type: "appstore", app_identifier: build_config['bundleIdentifier'], readonly: true)
 
-  if [ "$XCODE_VERSION_MAJOR" = "1500" ]; then
-    echo "Remove signature files (Xcode 15 workaround)"
-
-    rm "$BUILD_DIR/Release-iphoneos/Mapbox.xcframework-ios.signature"
-  fi
-
-
   increment_build_number(
       build_number: version_code
   )


### PR DESCRIPTION
### Short description

Mapbox has some issues with certificate duplicates on ios with Xcode 15 builds.

### Proposed changes

<!-- Describe this PR in more detail. -->

-  add a script that removes the old certificate in the build phase for XCode15

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2556 

Here is a pipeline log for the branch (build ios):
https://app.circleci.com/pipelines/github/digitalfabrik/integreat-app/9992/workflows/effc5556-e2f7-4a66-9f08-9e2c79fc515d/jobs/55885

Further information:
https://github.com/CocoaPods/CocoaPods/issues/12022
