### PR TITLE
2477 wrong app name in feedback

### DIFF
--- a/native/src/components/Feedback.tsx
+++ b/native/src/components/Feedback.tsx
@@ -1,3 +1,4 @@
+import name from 'build-config-name'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ActivityIndicator, ScrollView, Text, TextInput } from 'react-native'
@@ -137,7 +138,7 @@ const Feedback = ({
             <Text>({t('optionalInfo')})</Text>
           </HeadlineContainer>
           <DescriptionContainer>
-            <Text>{t('commentDescription')}</Text>
+            <Text>{t('commentDescription', { name })}</Text>
           </DescriptionContainer>
           <CommentInput onChangeText={onCommentChanged} value={comment} multiline numberOfLines={3} />
           <HeadlineContainer>

--- a/native/src/components/Feedback.tsx
+++ b/native/src/components/Feedback.tsx
@@ -1,4 +1,3 @@
-import name from 'build-config-name'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ActivityIndicator, ScrollView, Text, TextInput } from 'react-native'
@@ -6,6 +5,7 @@ import { useTheme } from 'styled-components'
 import styled from 'styled-components/native'
 
 import { NoteIcon } from '../assets'
+import { appNameUsed } from '../constants/buildConfig'
 import useNavigate from '../hooks/useNavigate'
 import Caption from './Caption'
 import FeedbackButtons from './FeedbackButtons'
@@ -138,7 +138,7 @@ const Feedback = ({
             <Text>({t('optionalInfo')})</Text>
           </HeadlineContainer>
           <DescriptionContainer>
-            <Text>{t('commentDescription', { name })}</Text>
+            <Text>{t('commentDescription', { appNameUsed })}</Text>
           </DescriptionContainer>
           <CommentInput onChangeText={onCommentChanged} value={comment} multiline numberOfLines={3} />
           <HeadlineContainer>

--- a/native/src/constants/buildConfig.ts
+++ b/native/src/constants/buildConfig.ts
@@ -25,6 +25,9 @@ import malteIntroOffersIcon from 'build-configs/malte/assets/intro-slides/Offers
 import malteIntroSearchIcon from 'build-configs/malte/assets/intro-slides/Search.svg'
 import malteLocationMarker from 'build-configs/malte/assets/location-marker.svg'
 
+// get the appName dynamically
+export const appNameUsed = name
+
 type AssetsType = {
   AppIcon: React.JSXElementConstructor<SvgProps>
   LoadingImage: React.JSXElementConstructor<SvgProps>

--- a/translations/translations.json
+++ b/translations/translations.json
@@ -2474,7 +2474,7 @@
       "headline": "Wie findest du diese Seite?",
       "description": "Wähle eine Reaktion aus und/oder schreibe einen Kommentar.",
       "commentHeadline": "Kommentar",
-      "commentDescription": "Teile uns dein Feedback mit! Wir schätzen sowohl positives als auch negatives Feedback, da es uns hilft, Integreat zu verbessern.",
+      "commentDescription": "Teile uns dein Feedback mit! Wir schätzen sowohl positives als auch negatives Feedback, da es uns hilft, {{appNameUsed}} zu verbessern.",
       "isThisSiteUseful": "Ist diese Seite hilfreich?",
       "useful": "Hilfreich",
       "notUseful": "Nicht hilfreich",


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->

Wrong app name on page Feedback "...da es uns hilft Integreat zu verbessern" in Malte app and Hallo Aschaffenburg app

<!-- Describe this PR in more detail. -->

The App name changes dynamically in  the Feedback page. 
Depending on the app it reads "...da es uns hilft Integreat zu verbessern"  or "...da es uns hilft malte zu verbessern" .
Added a placeholder in translations.json  and created a constant which is used in Feedback.tsx to change the app name dynamically.

### Side effects
None

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

#2477 

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
