### PR TITLE
2575: Focus trap bottom action sheet

### DIFF
--- a/release-notes/unreleased/2575-focus-trap-bottom-action-sheet.yml
+++ b/release-notes/unreleased/2575-focus-trap-bottom-action-sheet.yml
@@ -1,0 +1,5 @@
+issue_key: 2575
+show_in_stores: false
+platforms:
+  - web
+en: Fix feedback can not be opened from the bottom action sheet

--- a/web/src/components/Modal.tsx
+++ b/web/src/components/Modal.tsx
@@ -62,7 +62,7 @@ const Modal = ({ title, closeModal, children, direction, wrapInPortal = false }:
 
     return () => layoutElement?.setAttribute('aria-hidden', 'false')
   }, [])
-  // display check option is needed for portals - https://github.com/focus-trap/tabbable/blob/master/CHANGELOG.md#532
+  // display check option is needed for portals - https://github.com/focus-trap/tabbable/blob/master/CHANGELOG.md#600
   const Modal = (
     <FocusTrap focusTrapOptions={{ clickOutsideDeactivates: true, tabbableOptions: { displayCheck: 'legacy-full' } }}>
       <ModalContainer role='dialog' aria-hidden={false} aria-modal>

--- a/web/src/components/Modal.tsx
+++ b/web/src/components/Modal.tsx
@@ -62,9 +62,9 @@ const Modal = ({ title, closeModal, children, direction, wrapInPortal = false }:
 
     return () => layoutElement?.setAttribute('aria-hidden', 'false')
   }, [])
-
+  // display check option is needed for portals - https://github.com/focus-trap/tabbable/blob/master/CHANGELOG.md#532
   const Modal = (
-    <FocusTrap focusTrapOptions={{ clickOutsideDeactivates: true }}>
+    <FocusTrap focusTrapOptions={{ clickOutsideDeactivates: true, tabbableOptions: { displayCheck: 'legacy-full' } }}>
       <ModalContainer role='dialog' aria-hidden={false} aria-modal>
         <Overlay onClick={closeModal} role='button' tabIndex={0} onKeyPress={closeModal} aria-label={t('close')} />
         <ModalContentContainer>


### PR DESCRIPTION
### Short description

Focus trap lib since `10.x` can not detect nodes from a portal (bottom action sheet) and will throw an error (opening feedback modal)

### Proposed changes

<!-- Describe this PR in more detail. -->

- added a legacy displayCheck for finding the node in the portal

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2575 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
