### PR TITLE
2505: Filter button too close

### DIFF
--- a/native/src/components/PoiFiltersModal.tsx
+++ b/native/src/components/PoiFiltersModal.tsx
@@ -17,7 +17,6 @@ const Container = styled.View`
   flex: 1;
   flex-direction: column;
   align-items: flex-start;
-  padding: 0 16px;
 `
 
 const SubTitle = styled(Text)`

--- a/release-notes/unreleased/2505-filter-button-too-close.yml
+++ b/release-notes/unreleased/2505-filter-button-too-close.yml
@@ -1,0 +1,7 @@
+issue_key: 2505
+show_in_stores: false
+platforms:
+  - ios
+  - android
+en: Remove unneeded padding for filter buttons
+de: Unnötiger Abstand von Poi-Filter-Buttons entfernt


### PR DESCRIPTION
### Short description

On small device the filter buttons are too close together.

### Proposed changes

<!-- Describe this PR in more detail. -->

- remove padding of view, since there is alright sufficient padding

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2505

Sorry didn't want to grab this easy issue. I expected it to be more complicated like only rendering less issue per row on small devices by creating a grid or sth. But seems like there was just a unneeded padding
