### PR TITLE
2359: Show not found error for pois

### DIFF
--- a/native/src/routes/Pois.tsx
+++ b/native/src/routes/Pois.tsx
@@ -1,5 +1,5 @@
 import { BottomSheetScrollViewMethods } from '@gorhom/bottom-sheet'
-import React, { ReactElement, useCallback, useMemo, useRef, useState } from 'react'
+import React, { ReactElement, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ScrollView, useWindowDimensions } from 'react-native'
 import { SvgUri } from 'react-native-svg'
@@ -8,16 +8,15 @@ import styled from 'styled-components/native'
 import {
   CityModel,
   embedInCollection,
+  ErrorCode,
+  GeoJsonPoi,
+  isMultipoi,
+  MapFeature,
+  PoiCategoryModel,
   PoiModel,
   PoisRouteType,
   prepareFeatureLocations,
-  GeoJsonPoi,
-  MapFeature,
-  isMultipoi,
   sortMapFeatures,
-  NotFoundError,
-  fromError,
-  PoiCategoryModel,
 } from 'api-client'
 
 import { ClockIcon, EditLocationIcon } from '../assets'
@@ -110,7 +109,6 @@ const Pois = ({ pois: allPois, language, cityModel, route, navigation }: PoisPro
         : features.find(feature => feature.properties.pois.some(poi => poi.slug === slug)),
     [features, multipoi, slug],
   )
-  const currentPoi = useMemo(() => (slug ? pois.find(poi => slug === poi.slug) : undefined), [pois, slug])
 
   const scrollTo = (position: number) => {
     setTimeout(() => {
@@ -129,7 +127,7 @@ const Pois = ({ pois: allPois, language, cityModel, route, navigation }: PoisPro
   }
 
   const deselectFeature = () => {
-    if (multipoi && currentPoi) {
+    if (multipoi && poi) {
       navigation.setParams({ slug: undefined })
     } else {
       deselectAll()
@@ -168,29 +166,15 @@ const Pois = ({ pois: allPois, language, cityModel, route, navigation }: PoisPro
     <PoiListItem key={poi.path} poi={poi} language={language} navigateToPoi={() => selectGeoJsonPoiInList(poi)} t={t} />
   )
 
-  const setScrollPosition = useCallback(
-    (position: number) => {
-      if (!currentPoi) {
-        setListScrollPosition(position)
-      }
-    },
-    [currentPoi],
-  )
+  const setScrollPosition = (position: number) => {
+    if (!poi) {
+      setListScrollPosition(position)
+    }
+  }
 
-  const singlePoiContent = currentPoi && (
-    <PoiDetails language={language} poi={currentPoi} poiFeature={currentPoi.getFeature(coordinates)} />
-  )
-  const failurePoiContent = !currentPoi && slug && (
-    <Failure
-      code={fromError(
-        new NotFoundError({
-          type: 'poi',
-          id: '',
-          city: cityModel.code,
-          language,
-        }),
-      )}
-    />
+  const singlePoiContent = poi && <PoiDetails language={language} poi={poi} poiFeature={poi.getFeature(coordinates)} />
+  const failurePoiContent = !poi && slug && (
+    <Failure code={ErrorCode.PageNotFound} buttonAction={deselectAll} buttonLabel={t('detailsHeader')} />
   )
 
   const list = currentFeatureOnMap
@@ -264,7 +248,7 @@ const Pois = ({ pois: allPois, language, cityModel, route, navigation }: PoisPro
       <BottomActionsSheet
         ref={scrollRef}
         setScrollPosition={setScrollPosition}
-        title={!currentPoi && !multipoi ? t('listTitle') : undefined}
+        title={!slug && !multipoi ? t('listTitle') : undefined}
         onChange={setSheetSnapPointIndex}
         initialIndex={sheetSnapPointIndex}
         snapPoints={getBottomSheetSnapPoints(deviceHeight)}

--- a/web/src/components/BottomActionSheet.tsx
+++ b/web/src/components/BottomActionSheet.tsx
@@ -8,6 +8,7 @@ import { UiDirectionType } from 'translations'
 
 import '../styles/BottomActionSheet.css'
 import { getSnapPoints } from '../utils/getSnapPoints'
+import { RichLayout } from './Layout'
 import Spacer from './Spacer'
 
 const Title = styled.h1`
@@ -25,6 +26,10 @@ const StyledSpacer = styled(Spacer)`
 
 const StyledBottomSheet = styled(BottomSheet)<{ direction: string }>`
   direction: ${props => props.direction};
+`
+
+const StyledLayout = styled(RichLayout)`
+  min-height: unset;
 `
 
 type BottomActionSheetProps = {
@@ -82,9 +87,11 @@ const BottomActionSheet = React.forwardRef(
         // snapPoints have been supplied in the previous line
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         defaultSnap={({ snapPoints }) => snapPoints[1]!}>
-        {children}
-        <StyledSpacer borderColor={theme.colors.borderColor} />
-        <ToolbarContainer>{toolbar}</ToolbarContainer>
+        <StyledLayout>
+          {children}
+          <StyledSpacer borderColor={theme.colors.borderColor} />
+          <ToolbarContainer>{toolbar}</ToolbarContainer>
+        </StyledLayout>
       </StyledBottomSheet>
     )
   },

--- a/web/src/components/Failure.tsx
+++ b/web/src/components/Failure.tsx
@@ -6,15 +6,15 @@ import styled from 'styled-components'
 import { SadSmileyIcon } from '../assets'
 import Icon from './base/Icon'
 
-const Centered = styled.div`
-  & > * {
-    display: block;
-    margin-top: 50px;
-    text-align: center;
-  }
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  text-align: center;
 `
 
 const StyledIcon = styled(Icon)`
+  align-self: center;
   width: 64px;
   height: 64px;
 `
@@ -28,13 +28,11 @@ type FailureProps = {
 const Failure = ({ errorMessage, goToPath, goToMessage = 'goTo.start' }: FailureProps): ReactElement => {
   const { t } = useTranslation('error')
   return (
-    <Centered>
-      <div>
-        <StyledIcon src={SadSmileyIcon} />
-      </div>
+    <Container>
+      <StyledIcon src={SadSmileyIcon} />
       <div role='alert'>{t(errorMessage)}</div>
       {!!goToPath && <Link to={goToPath}>{goToMessage ? t(goToMessage) : goToPath}</Link>}
-    </Centered>
+    </Container>
   )
 }
 

--- a/web/src/components/PoiSharedChildren.tsx
+++ b/web/src/components/PoiSharedChildren.tsx
@@ -1,0 +1,59 @@
+import React, { ReactElement } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { GeoJsonPoi, LocationType, PoiModel, sortMapFeatures } from 'api-client'
+import { UiDirectionType } from 'translations'
+
+import Failure from './Failure'
+import List from './List'
+import PoiDetails from './PoiDetails'
+import PoiListItem from './PoiListItem'
+
+type PoiSharedChildrenProps = {
+  poiListFeatures: GeoJsonPoi[]
+  currentPoi: PoiModel | null
+  slug?: string
+  selectPoi: (geoJsonPoi: GeoJsonPoi | null) => void
+  userLocation: LocationType | undefined
+  direction: UiDirectionType
+  toolbar?: ReactElement
+}
+
+const PoiSharedChildren = ({
+  poiListFeatures,
+  currentPoi,
+  slug,
+  selectPoi,
+  userLocation,
+  direction,
+  toolbar,
+}: PoiSharedChildrenProps): ReactElement => {
+  const { t } = useTranslation('pois')
+
+  if (currentPoi) {
+    return (
+      <PoiDetails
+        poi={currentPoi}
+        feature={currentPoi.getFeature(userLocation)}
+        direction={direction}
+        toolbar={toolbar}
+      />
+    )
+  }
+
+  if (slug) {
+    return <Failure errorMessage='notFound.poi' goToMessage='pois:detailsHeader' goToPath='.' />
+  }
+
+  const renderPoiListItem = (poi: GeoJsonPoi) => <PoiListItem key={poi.path} poi={poi} selectPoi={selectPoi} />
+  return (
+    <List
+      noItemsMessage={t('noPois')}
+      items={sortMapFeatures(poiListFeatures)}
+      renderItem={renderPoiListItem}
+      borderless
+    />
+  )
+}
+
+export default PoiSharedChildren

--- a/web/src/components/PoisMobile.tsx
+++ b/web/src/components/PoisMobile.tsx
@@ -3,15 +3,7 @@ import React, { ReactElement, useCallback, useEffect, useRef, useState } from 'r
 import { useTranslation } from 'react-i18next'
 import styled, { css } from 'styled-components'
 
-import {
-  embedInCollection,
-  GeoJsonPoi,
-  LocationType,
-  MapViewViewport,
-  MapFeature,
-  PoiModel,
-  sortMapFeatures,
-} from 'api-client'
+import { embedInCollection, GeoJsonPoi, LocationType, MapViewViewport, MapFeature, PoiModel } from 'api-client'
 import { UiDirectionType } from 'translations'
 
 import { ArrowBackspaceIcon } from '../assets'
@@ -20,10 +12,8 @@ import useWindowDimensions from '../hooks/useWindowDimensions'
 import { getSnapPoints } from '../utils/getSnapPoints'
 import BottomActionSheet, { ScrollableBottomSheetRef } from './BottomActionSheet'
 import GoBack from './GoBack'
-import List from './List'
 import MapView, { MapViewRef } from './MapView'
-import PoiDetails from './PoiDetails'
-import PoiListItem from './PoiListItem'
+import PoiSharedChildren from './PoiSharedChildren'
 import Icon from './base/Icon'
 
 const geolocatorTopOffset = 10
@@ -108,6 +98,7 @@ const PoisMobile = ({
   const { selectGeoJsonPoiInList, selectFeatureOnMap, currentFeatureOnMap, currentPoi, poiListFeatures } =
     useMapFeatures(features, pois, slug)
   const { height } = useWindowDimensions()
+  const canGoBack = !!currentFeatureOnMap || !!slug
 
   const isBottomActionSheetFullScreen = bottomActionSheetHeight >= height
   const changeSnapPoint = (snapPoint: number) => {
@@ -121,10 +112,6 @@ const PoisMobile = ({
     }
     selectGeoJsonPoiInList(poiFeature)
   }
-
-  const renderPoiListItem = (poi: GeoJsonPoi) => (
-    <PoiListItem key={poi.path} poi={poi} selectPoi={handleSelectFeatureInList} />
-  )
 
   const handleSelectFeatureOnMap = useCallback(
     (feature: MapFeature | null) => {
@@ -140,21 +127,8 @@ const PoisMobile = ({
   )
 
   useEffect(() => {
-    if (!currentFeatureOnMap) {
-      sheetRef.current?.scrollElement?.scrollTo({ top: scrollOffset })
-    } else {
-      sheetRef.current?.scrollElement?.scrollTo({ top: 0 })
-    }
+    sheetRef.current?.scrollElement?.scrollTo({ top: currentFeatureOnMap ? 0 : scrollOffset })
   }, [currentFeatureOnMap, scrollOffset])
-
-  const poiList = (
-    <List
-      noItemsMessage={t('noPois')}
-      items={sortMapFeatures(poiListFeatures)}
-      renderItem={renderPoiListItem}
-      borderless
-    />
-  )
 
   useEffect(() => {
     if (mapViewRef && geocontrolPosition.current) {
@@ -180,7 +154,7 @@ const PoisMobile = ({
         languageCode={languageCode}
         Overlay={
           <>
-            {currentFeatureOnMap && (
+            {canGoBack && (
               <BackNavigation
                 onClick={() => handleSelectFeatureOnMap(null)}
                 role='button'
@@ -195,23 +169,26 @@ const PoisMobile = ({
         }
       />
       <BottomActionSheet
-        title={!currentFeatureOnMap ? t('listTitle') : undefined}
+        title={!canGoBack ? t('listTitle') : undefined}
         toolbar={toolbar}
         ref={sheetRef}
         setBottomActionSheetHeight={setBottomActionSheetHeight}
         direction={direction}
         sibling={<GeocontrolContainer id='geolocate' direction={direction} ref={geocontrolPosition} height={height} />}>
-        {currentFeatureOnMap && (
+        {canGoBack && (
           <GoBackContainer hidden={!isBottomActionSheetFullScreen}>
             <GoBack goBack={() => selectGeoJsonPoiInList(null)} viewportSmall text={t('detailsHeader')} />
           </GoBackContainer>
         )}
         <ListContainer>
-          {currentPoi ? (
-            <PoiDetails poi={currentPoi} feature={currentPoi.getFeature(userLocation)} direction={direction} />
-          ) : (
-            poiList
-          )}
+          <PoiSharedChildren
+            poiListFeatures={poiListFeatures}
+            currentPoi={currentPoi}
+            selectPoi={handleSelectFeatureInList}
+            userLocation={userLocation}
+            direction={direction}
+            slug={slug}
+          />
         </ListContainer>
       </BottomActionSheet>
     </>


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
Show a not found error if n poi can be found for the given slug.

### Proposed changes

<!-- Describe this PR in more detail. -->
- Fix the order to actually show an error if no poi is found (native)
- Introduce a new `PoiSharedChildren` component for reusability between mobile and desktop (web)
- Handle not found error in PoiSharedChildren (web)
- Show back button and hide `In deiner Nähe` for not found error (web)

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
None.

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2359.

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
