### PR TITLE
2580: Center search icon

### DIFF
--- a/web/src/components/SearchInput.tsx
+++ b/web/src/components/SearchInput.tsx
@@ -41,6 +41,8 @@ const Wrapper = styled.div`
 const StyledIcon = styled(Icon)`
   width: 20px;
   height: 20px;
+  position: relative;
+  top: 4px;
 `
 
 type SearchInputProps = {

--- a/web/src/components/SearchInput.tsx
+++ b/web/src/components/SearchInput.tsx
@@ -36,7 +36,7 @@ const Wrapper = styled.div`
   box-sizing: border-box;
   padding: 10px 10%;
   background-color: ${props => props.theme.colors.backgroundColor};
-  display: inline-flex;
+  display: flex;
   align-items: center;
 `
 

--- a/web/src/components/SearchInput.tsx
+++ b/web/src/components/SearchInput.tsx
@@ -36,13 +36,13 @@ const Wrapper = styled.div`
   box-sizing: border-box;
   padding: 10px 10%;
   background-color: ${props => props.theme.colors.backgroundColor};
+  display: inline-flex;
+  align-items: center;
 `
 
 const StyledIcon = styled(Icon)`
   width: 20px;
   height: 20px;
-  position: relative;
-  top: 4px;
 `
 
 type SearchInputProps = {


### PR DESCRIPTION
Short description
The Search Icon is not centered with the input "Suche"

Proposed changes
Center and align the Search Icon with the input, set it a little lower

Side effects
Resolved issues
The Search Icon is aligned with the Input "Suche"

Fixes: https://github.com/digitalfabrik/integreat-app/issues/2580

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
