### PR TITLE
258: Embed video native

### DIFF
--- a/api-client/src/routes/RouteInformationTypes.ts
+++ b/api-client/src/routes/RouteInformationTypes.ts
@@ -1,6 +1,7 @@
 import {
   CategoriesRouteType,
   CityNotCooperatingRouteType,
+  ConsentRouteType,
   DisclaimerRouteType,
   EventsRouteType,
   JpalTrackingRouteType,
@@ -27,6 +28,10 @@ export type LandingRouteInformationType = {
 
 export type LicensesInformationType = {
   route: LicensesRouteType
+}
+
+export type ConsentInformationType = {
+  route: ConsentRouteType
 }
 
 export type CityNotCooperatingInformationType = {
@@ -86,5 +91,6 @@ export type NonNullableRouteInformationType =
   | PoisRouteInformationType
   | LicensesInformationType
   | SearchRouteInformationType
+  | ConsentInformationType
 
 export type RouteInformationType = NonNullableRouteInformationType | null

--- a/api-client/src/routes/index.ts
+++ b/api-client/src/routes/index.ts
@@ -69,6 +69,9 @@ export const IMAGE_VIEW_MODAL_ROUTE: ImageViewModalRouteType = 'image'
 export type FeedbackModalRouteType = 'feedback'
 export const FEEDBACK_MODAL_ROUTE: FeedbackModalRouteType = 'feedback'
 
+export type ConsentRouteType = 'consent'
+export const CONSENT_ROUTE: ConsentRouteType = 'consent'
+
 // Web routes
 export type MainDisclaimerRouteType = 'main-disclaimer'
 export const MAIN_DISCLAIMER_ROUTE: MainDisclaimerRouteType = 'main-disclaimer'

--- a/api-client/src/routes/pathname.ts
+++ b/api-client/src/routes/pathname.ts
@@ -1,6 +1,7 @@
 import {
   CATEGORIES_ROUTE,
   CITY_NOT_COOPERATING_ROUTE,
+  CONSENT_ROUTE,
   DISCLAIMER_ROUTE,
   EVENTS_ROUTE,
   JPAL_TRACKING_ROUTE,
@@ -33,7 +34,11 @@ export const cityContentPath = ({ cityCode, languageCode, route, path }: CityCon
   constructPathname([cityCode, languageCode, route, path])
 
 export const pathnameFromRouteInformation = (routeInformation: NonNullableRouteInformationType): string => {
-  if (routeInformation.route === JPAL_TRACKING_ROUTE || routeInformation.route === LICENSES_ROUTE) {
+  if (
+    routeInformation.route === JPAL_TRACKING_ROUTE ||
+    routeInformation.route === LICENSES_ROUTE ||
+    routeInformation.route === CONSENT_ROUTE
+  ) {
     // https://integreat.app/jpal
     return constructPathname([routeInformation.route])
   }

--- a/api-client/src/tracking/index.ts
+++ b/api-client/src/tracking/index.ts
@@ -2,6 +2,7 @@ import {
   CategoriesRouteType,
   ChangeLanguageModalRouteType,
   CityNotCooperatingRouteType,
+  ConsentRouteType,
   DisclaimerRouteType,
   EventsRouteType,
   FeedbackModalRouteType,
@@ -38,6 +39,7 @@ export type OpenPageSignalType = {
     | JpalTrackingRouteType
     | ChangeLanguageModalRouteType
     | LicensesRouteType
+    | ConsentRouteType
   url: string
 }
 type ClosePageSignalNameType = 'close_page'

--- a/api-client/src/utils/index.ts
+++ b/api-client/src/utils/index.ts
@@ -3,3 +3,6 @@ import { DateTime } from 'luxon'
 export const getSlugFromPath = (path: string): string => path.split('/').pop() ?? ''
 
 export const formatDateICal = (date: DateTime): string => date.toFormat("yyyyMMdd'T'HHmm'00'")
+
+export const capitalizeFirstLetter = (words: string[]): string[] =>
+  words.map(word => word.charAt(0).toUpperCase() + word.slice(1))

--- a/build-configs/BuildConfigType.ts
+++ b/build-configs/BuildConfigType.ts
@@ -51,7 +51,7 @@ export type CommonBuildConfigType = {
   hostName: string
   // Hostnames from which resources are automatically downloaded for offline usage.
   allowedHostNames: Array<string>
-  allowedIframeSources: string[]
+  whiteListedIframeSources: string[]
   // Regex defining which urls to intercept as they are internal ones.
   internalLinksHijackPattern: string
   featureFlags: FeatureFlagsType

--- a/build-configs/aschaffenburg/index.ts
+++ b/build-configs/aschaffenburg/index.ts
@@ -15,7 +15,6 @@ const APPLICATION_ID = 'app.aschaffenburg'
 const BUNDLE_IDENTIFIER = 'app.aschaffenburg'
 
 const commonAschaffenburgBuildConfig: CommonBuildConfigType = {
-  allowedIframeSources: ['vimeo'],
   appName: 'hallo aschaffenburg',
   appIcon: 'app_icon_aschaffenburg',
   lightTheme,
@@ -23,6 +22,7 @@ const commonAschaffenburgBuildConfig: CommonBuildConfigType = {
   cmsUrl: 'https://cms.integreat-app.de',
   hostName: 'halloaschaffenburg.de',
   allowedHostNames: ['cms.integreat-app.de', 'admin.integreat-app.de'],
+  whiteListedIframeSources: ['vimeo'],
   translationsOverride: aschaffenburgOverrideTranslations,
   internalLinksHijackPattern:
     'https?:\\/\\/(cms(-test)?\\.integreat-app\\.de|web\\.integreat-app\\.de|integreat\\.app|aschaffenburg\\.app)(?!\\/(media|[^/]*\\/(wp-content|wp-admin|wp-json))\\/.*).*',

--- a/build-configs/integreat/index.ts
+++ b/build-configs/integreat/index.ts
@@ -14,7 +14,6 @@ const APPLICATION_ID = 'tuerantuer.app.integreat'
 const BUNDLE_IDENTIFIER = 'de.integreat-app'
 
 const commonIntegreatBuildConfig: CommonBuildConfigType = {
-  allowedIframeSources: ['vimeo'],
   appName: 'Integreat',
   appIcon: 'app_icon_integreat',
   lightTheme,
@@ -23,6 +22,7 @@ const commonIntegreatBuildConfig: CommonBuildConfigType = {
   switchCmsUrl: 'https://cms-test.integreat-app.de',
   hostName: 'integreat.app',
   allowedHostNames: ['cms.integreat-app.de', 'cms-test.integreat-app.de', 'admin.integreat-app.de'],
+  whiteListedIframeSources: ['vimeo'],
   internalLinksHijackPattern:
     'https?:\\/\\/(cms(-test)?\\.integreat-app\\.de|web\\.integreat-app\\.de|integreat\\.app)(?!\\/(media|[^/]*\\/(wp-content|wp-admin|wp-json))\\/.*).*',
   featureFlags: {

--- a/build-configs/malte/index.ts
+++ b/build-configs/malte/index.ts
@@ -15,7 +15,6 @@ const APPLICATION_ID = 'de.malteapp'
 const BUNDLE_IDENTIFIER = 'de.malteapp'
 
 const commonMalteBuildConfig: CommonBuildConfigType = {
-  allowedIframeSources: ['vimeo'],
   appName: 'Malte',
   appIcon: 'app_icon_malte',
   lightTheme,
@@ -23,6 +22,7 @@ const commonMalteBuildConfig: CommonBuildConfigType = {
   cmsUrl: 'https://cms.malteapp.de',
   switchCmsUrl: 'https://malte-test.tuerantuer.org',
   allowedHostNames: ['cms.malteapp.de', 'malte-test.tuerantuer.org'],
+  whiteListedIframeSources: ['vimeo'],
   translationsOverride: malteOverrideTranslations,
   internalLinksHijackPattern:
     'https?:\\/\\/((cms\\.)?malteapp\\.de|malte-test\\.tuerantuer\\.org)(?!\\/(media|[^/]*\\/(wp-content|wp-admin|wp-json))\\/.*).*',

--- a/build-configs/obdach/index.ts
+++ b/build-configs/obdach/index.ts
@@ -4,7 +4,6 @@ import mainImprint from './mainImprint'
 import { lightTheme } from './theme'
 
 const commonObdachBuildConfig: CommonBuildConfigType = {
-  allowedIframeSources: ['vimeo'],
   appName: 'Netzwerk Obdach & Wohnen',
   appIcon: 'app_icon_obdach',
   lightTheme,
@@ -12,6 +11,7 @@ const commonObdachBuildConfig: CommonBuildConfigType = {
   cmsUrl: 'https://cms.netzwerkobdachwohnen.de',
   hostName: 'netzwerkobdachwohnen.de',
   allowedHostNames: ['cms.netzwerkobdachwohnen.de', 'admin.netzwerkobdachwohnen.de'],
+  whiteListedIframeSources: ['vimeo'],
   internalLinksHijackPattern:
     'https?:\\/\\/((cms\\.)?netzwerkobdachwohnen\\.de)(?!\\/(media|[^/]*\\/(wp-content|wp-admin|wp-json))\\/.*).*',
   featureFlags: {

--- a/native/src/Navigator.tsx
+++ b/native/src/Navigator.tsx
@@ -8,6 +8,7 @@ import {
   CategoriesRouteType,
   CHANGE_LANGUAGE_MODAL_ROUTE,
   CITY_NOT_COOPERATING_ROUTE,
+  CONSENT_ROUTE,
   DISCLAIMER_ROUTE,
   EVENTS_ROUTE,
   EXTERNAL_OFFER_ROUTE,
@@ -31,6 +32,7 @@ import {
   useLoadAsync,
 } from 'api-client'
 
+import Consent from './components/Consent'
 import Header from './components/Header'
 import RedirectContainer from './components/RedirectContainer'
 import TransparentHeader from './components/TransparentHeader'
@@ -221,6 +223,7 @@ const Navigator = (): ReactElement | null => {
         <Stack.Screen name={SETTINGS_ROUTE} component={Settings} />
         <Stack.Screen name={LICENSES_ROUTE} component={Licenses} />
         <Stack.Screen name={EXTERNAL_OFFER_ROUTE} component={ExternalOfferContainer} />
+        <Stack.Screen name={CONSENT_ROUTE} component={Consent} />
       </Stack.Group>
     </Stack.Navigator>
   )

--- a/native/src/components/Consent.tsx
+++ b/native/src/components/Consent.tsx
@@ -1,0 +1,64 @@
+import { useFocusEffect } from '@react-navigation/native'
+import React, { ReactElement, useCallback, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { View, StyleSheet } from 'react-native'
+import styled from 'styled-components/native'
+
+import { capitalizeFirstLetter } from 'api-client'
+
+import buildConfig from '../constants/buildConfig'
+import appSettings, { ExternalSourcePermission } from '../utils/AppSettings'
+import { reportError } from '../utils/sentry'
+import Caption from './Caption'
+import ConsentSection from './ConsentSection'
+import Layout from './Layout'
+
+export const ItemSeparator = styled.View`
+  background-color: ${props => props.theme.colors.textDecorationColor};
+  height: ${StyleSheet.hairlineWidth}px;
+`
+
+const Consent = (): ReactElement | null => {
+  const [externalSources, setExternalSources] = useState<ExternalSourcePermission[]>([])
+  const { t } = useTranslation('consent')
+
+  useFocusEffect(
+    useCallback(() => {
+      appSettings.loadExternalSourcePermissions().then(setExternalSources).catch(reportError)
+    }, []),
+  )
+
+  const onPress = (type: string, allowed: boolean) => {
+    const updatedSources = externalSources
+    const arrayIndex = externalSources.findIndex(source => source.type === type)
+    if (arrayIndex > -1) {
+      updatedSources.splice(arrayIndex, 1, { type, allowed })
+    } else {
+      updatedSources.push({ type, allowed })
+    }
+    setExternalSources(updatedSources)
+    appSettings.setExternalSourcePermissions(updatedSources).catch(reportError)
+  }
+  const getInitialValue = (src: string): boolean =>
+    externalSources.find(source => source.type === src)?.allowed ?? false
+
+  return (
+    <Layout>
+      <Caption title={t('headline')} />
+      <ItemSeparator />
+      <View>
+        {capitalizeFirstLetter(buildConfig().whiteListedIframeSources).map(src => (
+          <ConsentSection
+            key={src}
+            title={src}
+            description={t('consentDescription', { source: src })}
+            initialSwitchValue={getInitialValue(src)}
+            onPress={onPress}
+          />
+        ))}
+      </View>
+    </Layout>
+  )
+}
+
+export default Consent

--- a/native/src/components/Consent.tsx
+++ b/native/src/components/Consent.tsx
@@ -8,6 +8,7 @@ import { capitalizeFirstLetter } from 'api-client'
 
 import buildConfig from '../constants/buildConfig'
 import appSettings, { ExternalSourcePermission } from '../utils/AppSettings'
+import { updateExternalSources } from '../utils/helpers'
 import { reportError } from '../utils/sentry'
 import Caption from './Caption'
 import ConsentSection from './ConsentSection'
@@ -19,28 +20,22 @@ export const ItemSeparator = styled.View`
 `
 
 const Consent = (): ReactElement | null => {
-  const [externalSources, setExternalSources] = useState<ExternalSourcePermission[]>([])
+  const [externalSourcePermissions, setExternalSourcePermissions] = useState<ExternalSourcePermission[]>([])
   const { t } = useTranslation('consent')
 
   useFocusEffect(
     useCallback(() => {
-      appSettings.loadExternalSourcePermissions().then(setExternalSources).catch(reportError)
+      appSettings.loadExternalSourcePermissions().then(setExternalSourcePermissions).catch(reportError)
     }, []),
   )
 
   const onPress = (type: string, allowed: boolean) => {
-    const updatedSources = externalSources
-    const arrayIndex = externalSources.findIndex(source => source.type === type)
-    if (arrayIndex > -1) {
-      updatedSources.splice(arrayIndex, 1, { type, allowed })
-    } else {
-      updatedSources.push({ type, allowed })
-    }
-    setExternalSources(updatedSources)
+    const updatedSources = updateExternalSources(externalSourcePermissions, { type, allowed })
+    setExternalSourcePermissions(updatedSources)
     appSettings.setExternalSourcePermissions(updatedSources).catch(reportError)
   }
   const getInitialValue = (src: string): boolean =>
-    externalSources.find(source => source.type === src)?.allowed ?? false
+    externalSourcePermissions.find(source => source.type === src)?.allowed ?? false
 
   return (
     <Layout>

--- a/native/src/components/ConsentSection.tsx
+++ b/native/src/components/ConsentSection.tsx
@@ -1,0 +1,61 @@
+import React, { ReactElement, useEffect, useState } from 'react'
+import { View, Switch } from 'react-native'
+import styled, { useTheme } from 'styled-components/native'
+
+import { ItemSeparator } from './Consent'
+import Text from './base/Text'
+
+const Container = styled(View)`
+  flex-direction: row;
+  padding: 16px;
+`
+
+const TextContainer = styled(View)`
+  flex: 1;
+`
+
+const Description = styled(Text)`
+  color: ${props => props.theme.colors.textSecondaryColor};
+`
+type ConsentSectionProps = {
+  title: string
+  description: string
+  initialSwitchValue: boolean
+  onPress: (type: string, value: boolean) => void
+}
+
+const ConsentSection = ({ title, description, initialSwitchValue, onPress }: ConsentSectionProps): ReactElement => {
+  const [allow, setAllow] = useState<boolean>(initialSwitchValue)
+
+  useEffect(() => {
+    setAllow(initialSwitchValue)
+  }, [initialSwitchValue])
+
+  const theme = useTheme()
+  return (
+    <>
+      <Container>
+        <TextContainer>
+          <Text>{title}</Text>
+          <Description>{description}</Description>
+        </TextContainer>
+        <Switch
+          thumbColor={theme.colors.themeColor}
+          trackColor={{
+            true: theme.colors.themeColor,
+            false: theme.colors.textSecondaryColor,
+          }}
+          accessibilityRole='switch'
+          value={allow}
+          onValueChange={val => {
+            setAllow(val)
+            onPress(title, val)
+          }}
+        />
+      </Container>
+      <ItemSeparator />
+    </>
+  )
+}
+
+export default ConsentSection

--- a/native/src/components/ConsentSection.tsx
+++ b/native/src/components/ConsentSection.tsx
@@ -17,6 +17,7 @@ const TextContainer = styled(View)`
 const Description = styled(Text)`
   color: ${props => props.theme.colors.textSecondaryColor};
 `
+
 type ConsentSectionProps = {
   title: string
   description: string

--- a/native/src/components/RemoteContent.tsx
+++ b/native/src/components/RemoteContent.tsx
@@ -1,14 +1,23 @@
+import { useFocusEffect } from '@react-navigation/native'
 import React, { ReactElement, useCallback, useEffect, useState } from 'react'
-import { Text } from 'react-native'
+import { useTranslation } from 'react-i18next'
+import { Text, Platform } from 'react-native'
 import WebView, { WebViewMessageEvent } from 'react-native-webview'
 import { WebViewNavigation } from 'react-native-webview/lib/WebViewTypes'
 import { useTheme } from 'styled-components/native'
 
-import { ErrorCode } from 'api-client'
+import { CONSENT_ROUTE, ErrorCode } from 'api-client'
 
 import buildConfig from '../constants/buildConfig'
 import { userAgent } from '../constants/endpoint'
-import { HEIGHT_MESSAGE_TYPE, WARNING_MESSAGE_TYPE } from '../constants/webview'
+import {
+  HEIGHT_MESSAGE_TYPE,
+  IFRAME_MESSAGE_TYPE,
+  SETTINGS_MESSAGE_TYPE,
+  WARNING_MESSAGE_TYPE,
+} from '../constants/webview'
+import useNavigate from '../hooks/useNavigate'
+import appSettings, { ExternalSourcePermission } from '../utils/AppSettings'
 import renderHtml from '../utils/renderHtml'
 import { log, reportError } from '../utils/sentry'
 import Failure from './Failure'
@@ -38,10 +47,16 @@ const RemoteContent = (props: RemoteContentProps): ReactElement | null => {
   const { onLoad, content, cacheDictionary, resourceCacheUrl, language, onLinkPress } = props
   const [error, setError] = useState<string | null>(null)
   const [pressedUrl, setPressedUrl] = useState<string | null>(null)
+  const [allowedExternalSourcePermissions, setAllowedExternalSourcePermissions] = useState<ExternalSourcePermission[]>(
+    [],
+  )
+  const [reloadSettings, setReloadSettings] = useState<boolean>(false)
+  const { navigateTo } = useNavigate()
   // https://github.com/react-native-webview/react-native-webview/issues/1069#issuecomment-651699461
   const defaultWebviewHeight = 1
   const [webViewHeight, setWebViewHeight] = useState<number>(defaultWebviewHeight)
   const theme = useTheme()
+  const { t } = useTranslation()
 
   useEffect(() => {
     // If it takes too long returning false in onShouldStartLoadWithRequest the webview loads the pressed url anyway on android.
@@ -58,39 +73,78 @@ const RemoteContent = (props: RemoteContentProps): ReactElement | null => {
     }
   }, [onLoad, webViewHeight, content])
 
-  // messages are triggered in renderHtml.ts
-  const onMessage = useCallback((event: WebViewMessageEvent) => {
-    const message = JSON.parse(event.nativeEvent.data)
-    if (message.type === HEIGHT_MESSAGE_TYPE && typeof message.height === 'number') {
-      setWebViewHeight(message.height)
-      return
-    }
+  useFocusEffect(
+    useCallback(() => {
+      appSettings.loadExternalSourcePermissions().then(setAllowedExternalSourcePermissions).catch(reportError)
+    }, []),
+  )
 
-    if (message.type === WARNING_MESSAGE_TYPE) {
-      log(message.message, 'warning')
-    } else {
-      const error = new Error(
-        message.message ? JSON.stringify(message.message) : 'Unknown message received from webview',
-      )
-      reportError(error)
-      setError(error.message)
+  // Webview content does not reload on AllowedExternalSourcePermissions change
+  useEffect(() => {
+    if (reloadSettings) {
+      appSettings.loadExternalSourcePermissions().then(setAllowedExternalSourcePermissions).catch(reportError)
+      setReloadSettings(false)
     }
-  }, [])
+  }, [reloadSettings])
+
+  // messages are triggered in renderHtml.ts
+  const onMessage = useCallback(
+    (event: WebViewMessageEvent) => {
+      const message = JSON.parse(event.nativeEvent.data)
+      if (message.type === HEIGHT_MESSAGE_TYPE && typeof message.height === 'number') {
+        setWebViewHeight(message.height)
+        return
+      }
+
+      if (message.type === SETTINGS_MESSAGE_TYPE && typeof message.openSettings === 'boolean') {
+        navigateTo({ route: CONSENT_ROUTE })
+        return
+      }
+
+      if (message.type === IFRAME_MESSAGE_TYPE && typeof message.allowedSource === 'object') {
+        const { type, allowed } = message.allowedSource
+        const updatedSources = allowedExternalSourcePermissions
+        const arrayIndex = updatedSources.findIndex(source => source.type === type)
+        if (arrayIndex > -1) {
+          updatedSources.splice(arrayIndex, 1, { type, allowed })
+        } else {
+          updatedSources.push({ type, allowed })
+        }
+
+        appSettings.setExternalSourcePermissions(updatedSources).catch(reportError)
+        setReloadSettings(true)
+        return
+      }
+
+      if (message.type === WARNING_MESSAGE_TYPE) {
+        log(message.message, 'warning')
+      } else {
+        const error = new Error(
+          message.message ? JSON.stringify(message.message) : 'Unknown message received from webview',
+        )
+        reportError(error)
+        setError(error.message)
+      }
+    },
+    [allowedExternalSourcePermissions, navigateTo],
+  )
 
   const onShouldStartLoadWithRequest = useCallback(
     (event: WebViewNavigation): boolean => {
-      if (buildConfig().allowedIframeSources.some(source => event.url.indexOf(source) > 0)) {
+      if (buildConfig().whiteListedIframeSources.some(source => event.url.indexOf(source) > 0)) {
         return true
       }
       if (event.url === new URL(resourceCacheUrl).href) {
         // Needed on iOS for the initial load
         return true
       }
+      // block non click events on ios that come up with iframes to avoid opening the iframe source directly in browser
+      if (event.navigationType !== 'click' && Platform.OS === 'ios') {
+        return false
+      }
       // If it takes too long returning false the webview loads the pressed url anyway on android.
       // Therefore only set it to state and execute onLinkPress in useEffect.
-      if (event.navigationType === 'click') {
-        setPressedUrl(event.url)
-      }
+      setPressedUrl(event.url)
       return false
     },
     [resourceCacheUrl],
@@ -107,7 +161,15 @@ const RemoteContent = (props: RemoteContentProps): ReactElement | null => {
     <WebView
       source={{
         baseUrl: resourceCacheUrl,
-        html: renderHtml(content, cacheDictionary, buildConfig().allowedIframeSources, theme, language),
+        html: renderHtml(
+          content,
+          cacheDictionary,
+          buildConfig().whiteListedIframeSources,
+          theme,
+          language,
+          allowedExternalSourcePermissions,
+          t,
+        ),
       }}
       originWhitelist={['*']} // Needed by iOS to load the initial html
       javaScriptEnabled

--- a/native/src/constants/NavigationTypes.ts
+++ b/native/src/constants/NavigationTypes.ts
@@ -44,6 +44,8 @@ import {
   CityNotCooperatingRouteType,
   LICENSES_ROUTE,
   LicensesRouteType,
+  CONSENT_ROUTE,
+  ConsentRouteType,
 } from 'api-client'
 
 import { FeedbackInformationType } from '../components/FeedbackContainer'
@@ -69,6 +71,7 @@ export type RoutesType =
   | ImageViewModalRouteType
   | FeedbackModalRouteType
   | LicensesRouteType
+  | ConsentRouteType
 
 type RouteTitle = {
   title?: string
@@ -86,6 +89,7 @@ export type RoutesParamsType = {
   [CATEGORIES_ROUTE]: RouteTitle & {
     path?: string
   }
+
   [POIS_ROUTE]: RouteTitle & {
     slug?: string
     multipoi?: string | null
@@ -99,6 +103,7 @@ export type RoutesParamsType = {
   }
   [DISCLAIMER_ROUTE]: undefined
   [OFFERS_ROUTE]: undefined
+  [CONSENT_ROUTE]: undefined
   [JPAL_TRACKING_ROUTE]: undefined
   [EXTERNAL_OFFER_ROUTE]: {
     url: string

--- a/native/src/constants/__mocks__/buildConfig.ts
+++ b/native/src/constants/__mocks__/buildConfig.ts
@@ -20,6 +20,7 @@ const buildConfig = jest.fn<CommonBuildConfigType, []>(
     switchCmsUrl: 'https://cms-test.integreat-app.de',
     hostName: 'integreat.app',
     allowedHostNames: ['cms.integreat-app.de', 'cms-test.integreat-app.de', 'admin.integreat-app.de'],
+    whiteListedIframeSources: ['vimeo'],
     internalLinksHijackPattern:
       'https?:\\/\\/(cms(-test)?\\.integreat-app\\.de|web\\.integreat-app\\.de|integreat\\.app)(?!\\/[^/]*\\/(wp-content|wp-admin|wp-json)\\/.*).*',
     featureFlags: {

--- a/native/src/constants/webview.ts
+++ b/native/src/constants/webview.ts
@@ -4,6 +4,8 @@ import { WebViewSource } from 'react-native-webview/lib/WebViewTypes'
 export const ERROR_MESSAGE_TYPE = 'error'
 export const WARNING_MESSAGE_TYPE = 'warning'
 export const HEIGHT_MESSAGE_TYPE = 'height'
+export const IFRAME_MESSAGE_TYPE = 'iframe'
+export const SETTINGS_MESSAGE_TYPE = 'settings'
 
 export const URL_PREFIX = 'file://'
 export const getFontFaceSource = (fontName: string): string | undefined =>

--- a/native/src/hooks/useNavigate.ts
+++ b/native/src/hooks/useNavigate.ts
@@ -4,6 +4,7 @@ import { useCallback, useContext } from 'react'
 import {
   CATEGORIES_ROUTE,
   CITY_NOT_COOPERATING_ROUTE,
+  CONSENT_ROUTE,
   DISCLAIMER_ROUTE,
   EVENTS_ROUTE,
   JPAL_TRACKING_ROUTE,
@@ -15,6 +16,7 @@ import {
   POIS_ROUTE,
   RouteInformationType,
   SEARCH_ROUTE,
+  SETTINGS_ROUTE,
   SPRUNGBRETT_OFFER_ROUTE,
 } from 'api-client'
 
@@ -48,6 +50,11 @@ const navigate = <T extends RoutesType>(
 
   if (routeInformation.route === LICENSES_ROUTE) {
     navigation.push(LICENSES_ROUTE)
+    return
+  }
+
+  if (routeInformation.route === CONSENT_ROUTE) {
+    navigation.push(CONSENT_ROUTE)
     return
   }
 

--- a/native/src/hooks/useNavigate.ts
+++ b/native/src/hooks/useNavigate.ts
@@ -16,7 +16,6 @@ import {
   POIS_ROUTE,
   RouteInformationType,
   SEARCH_ROUTE,
-  SETTINGS_ROUTE,
   SPRUNGBRETT_OFFER_ROUTE,
 } from 'api-client'
 

--- a/native/src/hooks/useNavigateToDeepLink.ts
+++ b/native/src/hooks/useNavigateToDeepLink.ts
@@ -5,6 +5,7 @@ import {
   CATEGORIES_ROUTE,
   CITY_NOT_COOPERATING_ROUTE,
   cityContentPath,
+  CONSENT_ROUTE,
   InternalPathnameParser,
   INTRO_ROUTE,
   JPAL_TRACKING_ROUTE,
@@ -79,7 +80,8 @@ const navigateToDeepLink = async <T extends RoutesType>({
     routeInformation.route !== LANDING_ROUTE &&
     routeInformation.route !== JPAL_TRACKING_ROUTE &&
     routeInformation.route !== CITY_NOT_COOPERATING_ROUTE &&
-    routeInformation.route !== LICENSES_ROUTE
+    routeInformation.route !== LICENSES_ROUTE &&
+    routeInformation.route !== CONSENT_ROUTE
       ? routeInformation.cityCode
       : null
 

--- a/native/src/utils/AppSettings.ts
+++ b/native/src/utils/AppSettings.ts
@@ -5,6 +5,11 @@ import { SignalType } from 'api-client'
 
 export const ASYNC_STORAGE_VERSION = '1'
 
+export type ExternalSourcePermission = {
+  type: string
+  allowed: boolean
+}
+
 export type SettingsType = {
   storageVersion: string | null
   contentLanguage: string | null
@@ -16,6 +21,7 @@ export type SettingsType = {
   jpalTrackingEnabled: boolean | null
   jpalTrackingCode: string | null
   jpalSignals: Array<SignalType>
+  externalSourcePermissions: ExternalSourcePermission[]
 }
 export const defaultSettings: SettingsType = {
   storageVersion: null,
@@ -28,6 +34,7 @@ export const defaultSettings: SettingsType = {
   jpalTrackingEnabled: null,
   jpalTrackingCode: null,
   jpalSignals: [],
+  externalSourcePermissions: [],
 }
 
 class AppSettings {
@@ -72,6 +79,17 @@ class AppSettings {
   loadVersion = async (): Promise<string | null> => {
     const settings = await this.loadSettings()
     return settings.storageVersion
+  }
+
+  setExternalSourcePermissions = async (permissions: ExternalSourcePermission[]): Promise<void> => {
+    await this.setSettings({
+      externalSourcePermissions: permissions,
+    })
+  }
+
+  loadExternalSourcePermissions = async (): Promise<ExternalSourcePermission[]> => {
+    const settings = await this.loadSettings()
+    return settings.externalSourcePermissions
   }
 
   setContentLanguage = async (language: string): Promise<void> => {

--- a/native/src/utils/createSettingsSections.ts
+++ b/native/src/utils/createSettingsSections.ts
@@ -3,7 +3,7 @@ import { TFunction } from 'i18next'
 import { AccessibilityRole, SectionListData } from 'react-native'
 import { openSettings } from 'react-native-permissions'
 
-import { JPAL_TRACKING_ROUTE, LICENSES_ROUTE, SettingsRouteType } from 'api-client'
+import { CONSENT_ROUTE, JPAL_TRACKING_ROUTE, LICENSES_ROUTE, SettingsRouteType } from 'api-client'
 
 import { SnackbarType } from '../components/SnackbarContainer'
 import NativeConstants from '../constants/NativeConstants'
@@ -124,6 +124,13 @@ const createSettingsSections = ({
               return true
             },
           )
+        },
+      },
+      {
+        title: t('externalResourcesTitle'),
+        description: t('externalResourcesDescription'),
+        onPress: () => {
+          navigation.navigate(CONSENT_ROUTE)
         },
       },
       {

--- a/native/src/utils/helpers.ts
+++ b/native/src/utils/helpers.ts
@@ -3,7 +3,7 @@ import BlobUtil from 'react-native-blob-util'
 import Url from 'url-parse'
 
 import buildConfig from '../constants/buildConfig'
-import appSettings from './AppSettings'
+import appSettings, { ExternalSourcePermission } from './AppSettings'
 import { log } from './sentry'
 
 // Android throws an error if attempting to delete non existing directories/files
@@ -83,3 +83,18 @@ export const getExtension = (urlString: string): string => {
 
 export const getErrorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : 'No error message available'
+
+export const updateExternalSources = (
+  sources: ExternalSourcePermission[],
+  newSource: ExternalSourcePermission,
+): ExternalSourcePermission[] => {
+  const updatedSources = sources
+  const { allowed, type } = newSource
+  const arrayIndex = updatedSources.findIndex(source => source.type === type)
+  if (arrayIndex > -1) {
+    updatedSources.splice(arrayIndex, 1, { type, allowed })
+  } else {
+    updatedSources.push({ type, allowed })
+  }
+  return updatedSources
+}

--- a/native/src/utils/renderHtml.ts
+++ b/native/src/utils/renderHtml.ts
@@ -31,7 +31,7 @@ const renderJS = (
     window.ReactNativeWebView.postMessage(JSON.stringify({ type, message: message }))
   }
 
-  (function catchErrors () {
+  (function catchErrors() {
     window.onerror = function(msg, url, lineNo, columnNo, error) {
       const string = msg.toLowerCase()
       const substring = 'script error'
@@ -52,7 +52,7 @@ const renderJS = (
     }
   })();
 
-  (function replaceResourcesWithCached () {
+  (function replaceResourcesWithCached() {
     const hrefs = document.querySelectorAll('[href]')
     const srcs = document.querySelectorAll('[src]')
     const cacheDictionary = ${JSON.stringify(cacheDictionary)}
@@ -84,7 +84,7 @@ const renderJS = (
     }
   })();
 
-  (function addWebviewHeightListeners () {
+  (function addWebviewHeightListeners() {
     const container = document.getElementById('measure-container')
 
     function adjustHeight () {
@@ -105,52 +105,54 @@ const renderJS = (
     details.forEach(detail => detail.addEventListener('toggle', adjustHeight))
   })();
 
-  (function handleIframes () {
-    function capitalizeFirstLetter (word) {
+  (function handleIframes() {
+    function capitalizeFirstLetter(word) {
       return word.charAt(0).toUpperCase() + word.slice(1)
     }
-    
+
     function showMessage(text, element, className) {
-      const textNode = document.createTextNode(text);
-      if(className){
-         element.classList.add(className)
+      const textNode = document.createTextNode(text)
+      if (className) {
+        element.classList.add(className)
       }
       element.appendChild(textNode)
     }
-    
+
     function showSettingsButton(element) {
-      function onClickHandler() {
+      function onClickHandler () {
         window.ReactNativeWebView.postMessage(JSON.stringify({ type: '${SETTINGS_MESSAGE_TYPE}', openSettings: true }))
       }
+
       const buttonLabel = ${JSON.stringify(t('layout:settings'))}
-      const button = document.createElement('button');
-      button.name = "opt-in-settings-button";
-      button.innerHTML = buttonLabel;
-      button.id = "opt-in-settings-button";
-      button.onclick = onClickHandler;
-      element.appendChild(button);
+      const button = document.createElement('button')
+      button.name = 'opt-in-settings-button'
+      button.innerHTML = buttonLabel
+      button.id = 'opt-in-settings-button'
+      button.onclick = onClickHandler
+      element.appendChild(button)
     }
-    
+
     function showMessageWithSettings(text, iframeContainer) {
-      showMessage(text, iframeContainer, "iframe-info-text")
+      showMessage(text, iframeContainer, 'iframe-info-text')
       showSettingsButton(iframeContainer)
-      
+
     }
-    
+
     function showOptIn(text, iframeContainer, source) {
-      function onClickHandler() {
-        window.ReactNativeWebView.postMessage(JSON.stringify({ type: '${IFRAME_MESSAGE_TYPE}', allowedSource: {type: source, allowed: true} }))
+      function onClickHandler () {
+        window.ReactNativeWebView.postMessage(JSON.stringify({ type: '${IFRAME_MESSAGE_TYPE}', allowedSource: { type: source, allowed: true } }))
       }
-      const checkbox = document.createElement('input');
-      checkbox.type = "checkbox";
-      checkbox.name = "opt-in-checkbox";
-      checkbox.id = "opt-in-checkbox";
-      checkbox.onclick = onClickHandler;
+
+      const checkbox = document.createElement('input')
+      checkbox.type = 'checkbox'
+      checkbox.name = 'opt-in-checkbox'
+      checkbox.id = 'opt-in-checkbox'
+      checkbox.onclick = onClickHandler
       const label = document.createElement('label')
-      label.htmlFor = "opt-in-checkbox";
-      label.appendChild(document.createTextNode(text));
-      iframeContainer.appendChild(label);
-      iframeContainer.appendChild(checkbox);
+      label.htmlFor = 'opt-in-checkbox'
+      label.appendChild(document.createTextNode(text))
+      iframeContainer.appendChild(label)
+      iframeContainer.appendChild(checkbox)
     }
 
     function showBlockMessageWithSettings(text, iframeContainer) {
@@ -158,52 +160,55 @@ const renderJS = (
       showSettingsButton(iframeContainer)
     }
 
-    function handleWhiteListedIframeSources (iframe, allowedExternalSourcePermissions, iframeSource, iframeContainer) {
+    function handleWhiteListedIframeSources(iframe, allowedExternalSourcePermissions, iframeSource, iframeContainer) {
+      if (externalSourcePermissions.some(source => source.type === iframeSource && source.allowed)) {
         // Add do not track parameter (only working for vimeo)
-     if (externalSourcePermissions.some(source => source.type === iframeSource && source.allowed)) {
-        const url = new URL(iframe.src)
-        url.searchParams.append('dnt', '1')
-        iframe.setAttribute('src', url.href)
-       const message = ${JSON.stringify(
-         t('remoteContent:knownResourceContentMessageOne'),
-       )} + iframeSource +". " + ${JSON.stringify(t('remoteContent:knownResourceContentMessageTwo'))}
-       showMessageWithSettings(message, iframeContainer)
+        if (iframeSource === 'Vimeo') {
+          const url = new URL(iframe.src)
+          url.searchParams.append('dnt', '1')
+          iframe.setAttribute('src', url.href)
+        }
+        const message = ${JSON.stringify(
+          t('remoteContent:knownResourceContentMessageOne'),
+        )} + iframeSource + '. ' + ${JSON.stringify(t('remoteContent:knownResourceContentMessageTwo'))}
+          showMessageWithSettings(message, iframeContainer)
+      } else if (externalSourcePermissions.some(source => source.type === iframeSource && !source.allowed)) {
+          const translation = ${JSON.stringify(t('remoteContent:knownResourceBlocked'))}
+          const message = iframeSource + ' ' + translation
+          showBlockMessageWithSettings(message, iframeContainer)
+          iframe.remove()
       }
-      else if (externalSourcePermissions.some(source => source.type === iframeSource && !source.allowed)) {
-       const translation = ${JSON.stringify(t('remoteContent:knownResourceBlocked'))}
-       const message= iframeSource + " "+ translation
-       showBlockMessageWithSettings(message, iframeContainer)
-       iframe.remove()
-     }
-     // No permissions set for listed sources
+      // No permissions set for listed sources
       else {
-       const translation = ${JSON.stringify(t('remoteContent:knownResourceOptIn'))}
-       const message = translation + iframeSource
-       showOptIn(message, iframeContainer, iframeSource)
-       iframe.remove()
+        const translation = ${JSON.stringify(t('remoteContent:knownResourceOptIn'))}
+        const message = translation + iframeSource
+        showOptIn(message, iframeContainer, iframeSource)
+        iframe.remove()
       }
     }
-    
+
     const iframes = document.querySelectorAll('iframe')
     const whiteListedIframeSources = ${JSON.stringify(whiteListedIframeSources)}
     const externalSourcePermissions = ${JSON.stringify(externalSourcePermissions)}
-   
+
     iframes.forEach((iframe) => {
       const iframeContainer = document.createElement('div')
       iframeContainer.classList.add('iframe-container')
       iframe.parentNode.appendChild(iframeContainer)
       const whiteListedIframeSource = whiteListedIframeSources.find(src => iframe.src.indexOf(src) > 0)
       if (whiteListedIframeSource) {
-        handleWhiteListedIframeSources(iframe, externalSourcePermissions, capitalizeFirstLetter(whiteListedIframeSource), iframeContainer )
-
+        handleWhiteListedIframeSources(iframe,
+          externalSourcePermissions,
+          capitalizeFirstLetter(whiteListedIframeSource),
+          iframeContainer)
       } else {
         const translation = ${JSON.stringify(t('remoteContent:unknownResourceBlocked'))}
-        const message = translation +"\\n"+iframe.src
-        showMessage(message, iframeContainer);
+        const message = translation + '\\n' + iframe.src
+        showMessage(message, iframeContainer)
         iframe.remove()
       }
     })
-  })();
+  })()
 `
 
 // To use parameters or external constants in renderHTML, you need to use string interpolation, e.g.
@@ -354,8 +359,8 @@ const renderHtml = (
         height: calc(60vw);
         background-color: ${theme.colors.backgroundAccentColor};
       }
-      
-      .iframe-container{
+
+      .iframe-container {
         padding: 12px;
         background-color: ${theme.colors.themeColor};
         display: flex;
@@ -363,12 +368,12 @@ const renderHtml = (
         overflow-wrap: anywhere;
         font-size: ${theme.fonts.hintFontSize};
       }
-      
+
       .iframe-info-text {
         font-size: ${theme.fonts.decorativeFontSizeSmall};
         background-color: ${theme.colors.backgroundAccentColor};
       }
-      
+
       .iframe-info-text > #opt-in-settings-button {
         font-size: ${theme.fonts.decorativeFontSizeSmall};
       }
@@ -390,9 +395,9 @@ const renderHtml = (
         /* Webview in android doesn't set correct size for checkboxes */
         heigth: 40px;
         width: 40px;
-        
+
       @media not screen and (-webkit-min-device-pixel-ratio: 1) {
-        height:  16px;
+        height: 16px;
         width: 16px;
       }
 

--- a/translations/translations.json
+++ b/translations/translations.json
@@ -8400,14 +8400,23 @@
   "remoteContent": {
     "de": {
       "knownResourceOptIn": "Ich bin damit einverstanden, dass mir Inhalte dieser externen Quelle angezeigt werden: ",
-      "knownResourceBlocked": "wurde geblockt. Unter Einstellungen können sie diese Ressource wieder zulassen.",
-      "unknownResourceBlocked": "Ein externer Inhalt wurde geblockt:"
+      "knownResourceBlocked": "wurde geblockt. Unter Einstellungen können sie Inhalte dieser Quelle zulassen.",
+      "unknownResourceBlocked": "Ein Inhalt von einer externen Quelle wurde geblockt:"
+    },
+    "en": {
+      "knownResourceOptIn": "I agree that content from this external source may be displayed to me: ",
+      "knownResourceBlocked": "has been blocked. You can allow content from this source in settings.",
+      "unknownResourceBlocked": "Content from an external source has been blocked:"
     }
   },
   "consent": {
     "de": {
-      "headline": "Externe Inhalte",
+      "headline": "Externe Quellen",
       "consentDescription": "Inhalte von {{source}} zulassen"
+    },
+    "en": {
+      "headline": "External Sources",
+      "consentDescription": "Allow content from {{source}}"
     }
   },
   "search": {
@@ -8636,8 +8645,8 @@
       "enabled": "aktiviert",
       "disabled": "deaktiviert",
       "decline": "Ablehnen",
-      "externalResourcesTitle": "Externe Ressourcen",
-      "externalResourcesDescription": "Legen sie fest welche externen Ressourcen zugelassen werden"
+      "externalResourcesTitle": "Externe Quellen",
+      "externalResourcesDescription": "Legen sie fest welche externen Quellen zugelassen werden"
     },
     "am": {
       "sentryTitle": "የመተግበሪያ መረጋጋት",
@@ -8776,7 +8785,9 @@
       "trackingLeaveDescription": "You have disabled tracking. Tracking helps us to improve the {{appName}} app and provide better information for immigrants. Are you sure you want to leave the screen without enabling tracking?",
       "enabled": "activated",
       "disabled": "deactivated",
-      "decline": "Refuse"
+      "decline": "Refuse",
+      "externalResourcesTitle": "External Sources",
+      "externalResourcesDescription": "Specify which external sources are permitted"
     },
     "es": {
       "sentryTitle": "Estabilidad de la app",

--- a/translations/translations.json
+++ b/translations/translations.json
@@ -8400,11 +8400,15 @@
   "remoteContent": {
     "de": {
       "knownResourceOptIn": "Ich bin damit einverstanden, dass mir Inhalte dieser externen Quelle angezeigt werden: ",
+      "knownResourceContentMessageOne": "Dieses Element enthält Daten von ",
+      "knownResourceContentMessageTwo": "Du kannst die Einbettung solcher Inhalte hier blockieren: ",
       "knownResourceBlocked": "wurde geblockt. Unter Einstellungen können sie Inhalte dieser Quelle zulassen.",
       "unknownResourceBlocked": "Ein Inhalt von einer externen Quelle wurde geblockt:"
     },
     "en": {
       "knownResourceOptIn": "I agree that content from this external source may be displayed to me: ",
+      "knownResourceContentMessageOne": "This element contains data from ",
+      "knownResourceContentMessageTwo": "You can block the embedding of such content here: ",
       "knownResourceBlocked": "has been blocked. You can allow content from this source in settings.",
       "unknownResourceBlocked": "Content from an external source has been blocked:"
     }

--- a/translations/translations.json
+++ b/translations/translations.json
@@ -8397,6 +8397,19 @@
       "showOwnLocation": "显示自己的位置"
     }
   },
+  "remoteContent": {
+    "de": {
+      "knownResourceOptIn": "Ich bin damit einverstanden, dass mir Inhalte dieser externen Quelle angezeigt werden: ",
+      "knownResourceBlocked": "wurde geblockt. Unter Einstellungen können sie diese Ressource wieder zulassen.",
+      "unknownResourceBlocked": "Ein externer Inhalt wurde geblockt:"
+    }
+  },
+  "consent": {
+    "de": {
+      "headline": "Externe Inhalte",
+      "consentDescription": "Inhalte von {{source}} zulassen"
+    }
+  },
   "search": {
     "de": {
       "nothingFound": "Es wurden leider keine passenden Ergebnisse gefunden.",
@@ -8622,7 +8635,9 @@
       "trackingLeaveDescription": "Du hast das Tracking nicht erlaubt. Das Tracking hilft uns, die {{appName}}-App zu verbessern und bessere Informationen für Einwanderer bereitzustellen. Bist du sicher, dass du den Bildschirm verlassen möchten, ohne das Tracking zu erlauben?",
       "enabled": "aktiviert",
       "disabled": "deaktiviert",
-      "decline": "Ablehnen"
+      "decline": "Ablehnen",
+      "externalResourcesTitle": "Externe Ressourcen",
+      "externalResourcesDescription": "Legen sie fest welche externen Ressourcen zugelassen werden"
     },
     "am": {
       "sentryTitle": "የመተግበሪያ መረጋጋት",

--- a/web/src/components/RemoteContent.tsx
+++ b/web/src/components/RemoteContent.tsx
@@ -158,14 +158,14 @@ const RemoteContent = ({
       if (buildConfig().allowedIframeSources.some(source => iframe.src.indexOf(source) > 0)) {
         addDoNotTrackParameter(iframe)
       } else {
-        currentSandBoxRef.removeChild(iframe)
+        iframe.remove()
       }
     })
   }, [html, handleClick, sandBoxRef])
 
   const dangerouslySetInnerHTML = {
     __html: Dompurify.sanitize(html, {
-      ALLOWED_TAGS: ['iframe'],
+      ADD_TAGS: ['iframe'],
       ADD_ATTR: ['allowfullscreen'],
     }),
   }

--- a/web/src/components/RemoteContent.tsx
+++ b/web/src/components/RemoteContent.tsx
@@ -155,7 +155,7 @@ const RemoteContent = ({
     // Remove disallowed iframes from DOM and add do not track parameter for vimeo
     const iframes = currentSandBoxRef.getElementsByTagName('iframe')
     Array.from(iframes).forEach((iframe: HTMLIFrameElement) => {
-      if (buildConfig().allowedIframeSources.some(source => iframe.src.indexOf(source) > 0)) {
+      if (buildConfig().whiteListedIframeSources.some(source => iframe.src.indexOf(source) > 0)) {
         addDoNotTrackParameter(iframe)
       } else {
         iframe.remove()


### PR DESCRIPTION
### Short description

I decided to split up this issue to web and native, since it was more effort than expected.
In this pr i implemented an `opt-in` section in settings to manage external sources for iframes. Since we may have more sources in future, the sources are easily extendible via `buildConfig`.

Important: This issue is about embedding external video sources via iframe (vimeo, youtube, etc), not making html videos working (external sources blocked by csp and video upload restricted by cms)

### Proposed changes

<!-- Describe this PR in more detail. -->

- if no permissions to external sources are set (initial state) show a opt-in with a checkbox to allow this external source
- all permission to external sources can be managed in a separate settings section to withdraw or allow a permission again

### Side effects
- hopefully none. please proper test internal/external and deep links on ios and android

### Testing
- go to http://localhost:9000/testumgebung/de/video-test-verschiedene-sources
- to get the initial unset permission state again, just copy this into `RemoteContent`
`appSettings.setExternalSourcePermissions([]).catch(reportError)`
- you can just add several more source in `build-config` f.e.
`whiteListedIframeSources: ['vimeo', 'youtube', 'tagesschau'],`

Note: For web i will create a separate issue using cookies

