### PR TITLE
2603: Screen is missing background opacity when feedback open

### DIFF
--- a/web/src/components/Modal.tsx
+++ b/web/src/components/Modal.tsx
@@ -19,6 +19,8 @@ const Overlay = styled(Button)`
   inset: 0;
   background-color: ${props => props.theme.colors.textSecondaryColor};
   opacity: 0.9;
+  width: 100%;
+  height: 100%;
 `
 
 const ModalContainer = styled.div`


### PR DESCRIPTION
### Short description

When opening the feedback modal in web the background color is missing.
The background color does not appear on Firefox but does on Chrome 

### Proposed changes

A 100% width and height to be added to the object that seems to have disappeared

### Side effects

### Resolved issues

Fixes: #2603

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
