### PR TITLE
2607: Missing purpose strings 

### DIFF
--- a/native/ios/Integreat/Info.plist
+++ b/native/ios/Integreat/Info.plist
@@ -62,6 +62,10 @@
 	<string>Integreat wants to access the calendar to add an event.</string>
 	<key>NSCalendarsFullAccessUsageDescription</key>
 	<string>Integreat wants to access the calendar to add an event.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+    <string>Integreat wants to use your location to find nearby cities.</string>
+    <key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+    <string>Integreat wants to use your location to find nearby cities.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>NotoSansArabic-Regular.ttf</string>

--- a/native/ios/Integreat/Info.plist
+++ b/native/ios/Integreat/Info.plist
@@ -63,9 +63,9 @@
 	<key>NSCalendarsFullAccessUsageDescription</key>
 	<string>Integreat wants to access the calendar to add an event.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
-    <string>Integreat wants to use your location to find nearby cities.</string>
-    <key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-    <string>Integreat wants to use your location to find nearby cities.</string>
+	<string>Integreat wants to use your location to find nearby cities.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Integreat wants to use your location to find nearby cities.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>NotoSansArabic-Regular.ttf</string>


### PR DESCRIPTION
### Short description
These purpose strings are just fallbacks for avoiding messages from apple of missing purpose strings. They shouldn't be used in the app but the localized purpose strings
Please switch your ios device language to something thats not english and test if the correct localized strings will still be used

### Proposed changes

<!-- Describe this PR in more detail. -->

- add fallbacks to the info.plist in english

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2607 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
