### PR TITLE
Upgrade Headroom to v2

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -29,7 +29,7 @@
     "postinstall": "npm-license-crawler -onlyDirectDependencies -json ./assets/licenses.json"
   },
   "dependencies": {
-    "@integreat-app/react-sticky-headroom": "^2.1.0",
+    "@integreat-app/react-sticky-headroom": "^2.2.0",
     "@math.gl/web-mercator": "^3.6.3",
     "@sentry/react": "^7.65.0",
     "@sentry/types": "^7.65.0",

--- a/web/package.json
+++ b/web/package.json
@@ -29,7 +29,7 @@
     "postinstall": "npm-license-crawler -onlyDirectDependencies -json ./assets/licenses.json"
   },
   "dependencies": {
-    "@integreat-app/react-sticky-headroom": "^1.2.3",
+    "@integreat-app/react-sticky-headroom": "^2.0.0",
     "@math.gl/web-mercator": "^3.6.3",
     "@sentry/react": "^7.65.0",
     "@sentry/types": "^7.65.0",

--- a/web/package.json
+++ b/web/package.json
@@ -29,7 +29,7 @@
     "postinstall": "npm-license-crawler -onlyDirectDependencies -json ./assets/licenses.json"
   },
   "dependencies": {
-    "@integreat-app/react-sticky-headroom": "^2.0.0",
+    "@integreat-app/react-sticky-headroom": "^2.1.0",
     "@math.gl/web-mercator": "^3.6.3",
     "@sentry/react": "^7.65.0",
     "@sentry/types": "^7.65.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2268,10 +2268,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@integreat-app/react-sticky-headroom@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@integreat-app/react-sticky-headroom/-/react-sticky-headroom-2.0.0.tgz#09de4e64dd37daaa254be968d90eccd65e2489de"
-  integrity sha512-Za29yitXaDho8c7Vz+jjb0S9ChQ6ByBcJ60jqnXmfLopRRLwkePatra6btWtdPuA2OVv1f2Qx4E1AQE1hwARlA==
+"@integreat-app/react-sticky-headroom@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@integreat-app/react-sticky-headroom/-/react-sticky-headroom-2.1.0.tgz#bf75b94765e81c7f68bca83ecd1de6c934d33fc4"
+  integrity sha512-x1DFgdVPyu+pUgtJg9FeAKlo2swgn0SxdOI+qVa/AltZmHlhDdPPCKJvB7vDEkptxu9+r83JEYnuJY3gvJn8HQ==
 
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2268,10 +2268,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@integreat-app/react-sticky-headroom@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@integreat-app/react-sticky-headroom/-/react-sticky-headroom-2.1.0.tgz#bf75b94765e81c7f68bca83ecd1de6c934d33fc4"
-  integrity sha512-x1DFgdVPyu+pUgtJg9FeAKlo2swgn0SxdOI+qVa/AltZmHlhDdPPCKJvB7vDEkptxu9+r83JEYnuJY3gvJn8HQ==
+"@integreat-app/react-sticky-headroom@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@integreat-app/react-sticky-headroom/-/react-sticky-headroom-2.2.0.tgz#2b16b06f632f785c2a882983143dd3274c89c67a"
+  integrity sha512-PqeQ8dm51f3rSZIT+XpnAHl7t2kI3bp/X3gnb6OGW6bQy8loFa5uUcSgiTZ8yRN/XoQv5mtUBStz3DaHfS9vmQ==
 
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2268,10 +2268,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@integreat-app/react-sticky-headroom@^1.2.3":
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/@integreat-app/react-sticky-headroom/-/react-sticky-headroom-1.2.3.tgz#c63f2fe55dade7072d598b6cab0b678b9e7a0b42"
-  integrity sha512-ACvlYJmfsqlfQrrTBJt+8HNkDZkb42ae0x+fLSnKXjAvknnIHgrSZGS81AP8273kYDJOSyBmiUPxnC0fR2VJxg==
+"@integreat-app/react-sticky-headroom@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@integreat-app/react-sticky-headroom/-/react-sticky-headroom-2.0.0.tgz#09de4e64dd37daaa254be968d90eccd65e2489de"
+  integrity sha512-Za29yitXaDho8c7Vz+jjb0S9ChQ6ByBcJ60jqnXmfLopRRLwkePatra6btWtdPuA2OVv1f2Qx4E1AQE1hwARlA==
 
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"


### PR DESCRIPTION
### Short description

Upgrade ReactStickyHeadroom dependency to v2



### Side effects

ReactStickyHeadroom powers the header of the web app. No changes should be visible.

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
