### PR TITLE
2647: Fix next recurrence of events

### DIFF
--- a/native/src/components/__tests__/DatesPageDetail.spec.tsx
+++ b/native/src/components/__tests__/DatesPageDetail.spec.tsx
@@ -10,7 +10,7 @@ import DatesPageDetail from '../DatesPageDetail'
 
 jest.mock('react-i18next')
 
-jest.useFakeTimers({ now: new Date('2023-10-02T15:23:57.443+02:00') })
+jest.useFakeTimers({ now: new Date('2023-10-09T15:23:57.443+02:00') })
 describe('DatesPageDetail', () => {
   const renderDatesPageDetail = (date: DateModel) => render(<DatesPageDetail date={date} languageCode='de' />)
   const date = (rrule?: string) =>

--- a/release-notes/unreleased/2647-next-recurrence.yml
+++ b/release-notes/unreleased/2647-next-recurrence.yml
@@ -1,0 +1,8 @@
+issue_key: 2467
+show_in_stores: true
+platforms:
+  - web
+  - ios
+  - android
+en: Fixed displaying of next date of an event if its near.
+de: Anzeige von baldigen Terminen behoben.

--- a/release-notes/unreleased/2647-next-recurrence.yml
+++ b/release-notes/unreleased/2647-next-recurrence.yml
@@ -4,5 +4,5 @@ platforms:
   - web
   - ios
   - android
-en: Fixed displaying of next date of an event if its near.
+en: Fixed displaying of next date of an event if it's soon.
 de: Anzeige von baldigen Terminen behoben.

--- a/shared/api/models/__tests__/DateModel.spec.ts
+++ b/shared/api/models/__tests__/DateModel.spec.ts
@@ -141,8 +141,8 @@ describe('DateModel', () => {
         recurrenceRule: rrulestr('DTSTART:20230414T050000\nRRULE:FREQ=WEEKLY;BYDAY=MO'),
       })
 
-      expect(date.startDate).toEqual(DateTime.fromISO('2023-10-09T07:00:00.000+02:00'))
-      expect(date.endDate).toEqual(DateTime.fromISO('2023-10-10T09:00:00.000+02:00'))
+      expect(date.startDate).toEqual(DateTime.fromISO('2023-10-02T07:00:00.000+02:00'))
+      expect(date.endDate).toEqual(DateTime.fromISO('2023-10-03T09:00:00.000+02:00'))
     })
 
     it('should return itself if there is no rrule set', () => {
@@ -168,6 +168,12 @@ describe('DateModel', () => {
         new DateModel({
           allDay: false,
           recurrenceRule: null,
+          startDate: DateTime.fromISO('2023-10-02T06:00:00.000+01:00'),
+          endDate: DateTime.fromISO('2023-10-03T08:00:00.000+01:00'),
+        }),
+        new DateModel({
+          allDay: false,
+          recurrenceRule: null,
           startDate: DateTime.fromISO('2023-10-09T07:00:00.000+02:00'),
           endDate: DateTime.fromISO('2023-10-10T09:00:00.000+02:00'),
         }),
@@ -183,12 +189,6 @@ describe('DateModel', () => {
           startDate: DateTime.fromISO('2023-10-23T07:00:00.000+02:00'),
           endDate: DateTime.fromISO('2023-10-24T09:00:00.000+02:00'),
         }),
-        new DateModel({
-          allDay: false,
-          recurrenceRule: null,
-          startDate: DateTime.fromISO('2023-10-30T07:00:00.000+01:00'),
-          endDate: DateTime.fromISO('2023-10-31T09:00:00.000+01:00'),
-        }),
       ])
     })
 
@@ -197,15 +197,15 @@ describe('DateModel', () => {
         startDate: DateTime.fromISO('2017-09-27T19:30:00+02:00'),
         endDate: DateTime.fromISO('2017-09-28T21:30:00+02:00'),
         allDay: false,
-        recurrenceRule: rrulestr('DTSTART:20230414T050000\nRRULE:FREQ=WEEKLY;BYDAY=MO;UNTIL=20231015T050000'),
+        recurrenceRule: rrulestr('DTSTART:20230414T050000\nRRULE:FREQ=WEEKLY;BYDAY=MO;UNTIL=20231008T050000'),
       })
 
       expect(date.recurrences(3)).toEqual([
         new DateModel({
           allDay: false,
           recurrenceRule: null,
-          startDate: DateTime.fromISO('2023-10-09T07:00:00.000+02:00'),
-          endDate: DateTime.fromISO('2023-10-10T09:00:00.000+02:00'),
+          startDate: DateTime.fromISO('2023-10-02T07:00:00.000+02:00'),
+          endDate: DateTime.fromISO('2023-10-03T09:00:00.000+02:00'),
         }),
       ])
     })

--- a/shared/api/models/__tests__/DateModel.spec.ts
+++ b/shared/api/models/__tests__/DateModel.spec.ts
@@ -3,7 +3,7 @@ import { rrulestr } from 'rrule'
 
 import DateModel from '../DateModel'
 
-jest.useFakeTimers({ now: new Date('2023-10-02T15:23:57.443+02:00') })
+jest.useFakeTimers({ now: new Date('2023-10-09T15:23:57.443+02:00') })
 describe('DateModel', () => {
   const locales = ['de', 'en', 'fr', 'ar', 'fa', 'ru']
 
@@ -100,8 +100,8 @@ describe('DateModel', () => {
 
     it('should return true if event starts on the current day', () => {
       const date = new DateModel({
-        startDate: DateTime.fromISO('2023-10-02T20:00:00.000+02:00'),
-        endDate: DateTime.fromISO('2023-10-04T07:00:00.000+02:00'),
+        startDate: DateTime.fromISO('2023-10-09T20:00:00.000+02:00'),
+        endDate: DateTime.fromISO('2023-10-11T07:00:00.000+02:00'),
         allDay: false,
         recurrenceRule: null,
       })
@@ -111,8 +111,8 @@ describe('DateModel', () => {
 
     it('should return true if event ends on the current day', () => {
       const date = new DateModel({
-        startDate: DateTime.fromISO('2023-10-01T07:00:00.000+02:00'),
-        endDate: DateTime.fromISO('2023-10-02T18:00:00.000+02:00'),
+        startDate: DateTime.fromISO('2023-10-08T07:00:00.000+02:00'),
+        endDate: DateTime.fromISO('2023-10-09T18:00:00.000+02:00'),
         allDay: false,
         recurrenceRule: null,
       })
@@ -122,8 +122,8 @@ describe('DateModel', () => {
 
     it('should return true if event started before and ends after the current day', () => {
       const date = new DateModel({
-        startDate: DateTime.fromISO('2023-10-01T07:00:00.000+02:00'),
-        endDate: DateTime.fromISO('2023-10-04T07:00:00.000+02:00'),
+        startDate: DateTime.fromISO('2023-10-08T07:00:00.000+02:00'),
+        endDate: DateTime.fromISO('2023-10-11T07:00:00.000+02:00'),
         allDay: false,
         recurrenceRule: null,
       })
@@ -141,8 +141,8 @@ describe('DateModel', () => {
         recurrenceRule: rrulestr('DTSTART:20230414T050000\nRRULE:FREQ=WEEKLY;BYDAY=MO'),
       })
 
-      expect(date.startDate).toEqual(DateTime.fromISO('2023-10-02T07:00:00.000+02:00'))
-      expect(date.endDate).toEqual(DateTime.fromISO('2023-10-03T09:00:00.000+02:00'))
+      expect(date.startDate).toEqual(DateTime.fromISO('2023-10-09T07:00:00.000+02:00'))
+      expect(date.endDate).toEqual(DateTime.fromISO('2023-10-10T09:00:00.000+02:00'))
     })
 
     it('should return itself if there is no rrule set', () => {
@@ -168,12 +168,6 @@ describe('DateModel', () => {
         new DateModel({
           allDay: false,
           recurrenceRule: null,
-          startDate: DateTime.fromISO('2023-10-02T06:00:00.000+01:00'),
-          endDate: DateTime.fromISO('2023-10-03T08:00:00.000+01:00'),
-        }),
-        new DateModel({
-          allDay: false,
-          recurrenceRule: null,
           startDate: DateTime.fromISO('2023-10-09T07:00:00.000+02:00'),
           endDate: DateTime.fromISO('2023-10-10T09:00:00.000+02:00'),
         }),
@@ -189,6 +183,12 @@ describe('DateModel', () => {
           startDate: DateTime.fromISO('2023-10-23T07:00:00.000+02:00'),
           endDate: DateTime.fromISO('2023-10-24T09:00:00.000+02:00'),
         }),
+        new DateModel({
+          allDay: false,
+          recurrenceRule: null,
+          startDate: DateTime.fromISO('2023-10-30T07:00:00.000+01:00'),
+          endDate: DateTime.fromISO('2023-10-31T09:00:00.000+01:00'),
+        }),
       ])
     })
 
@@ -197,15 +197,15 @@ describe('DateModel', () => {
         startDate: DateTime.fromISO('2017-09-27T19:30:00+02:00'),
         endDate: DateTime.fromISO('2017-09-28T21:30:00+02:00'),
         allDay: false,
-        recurrenceRule: rrulestr('DTSTART:20230414T050000\nRRULE:FREQ=WEEKLY;BYDAY=MO;UNTIL=20231008T050000'),
+        recurrenceRule: rrulestr('DTSTART:20230414T050000\nRRULE:FREQ=WEEKLY;BYDAY=MO;UNTIL=20231015T050000'),
       })
 
       expect(date.recurrences(3)).toEqual([
         new DateModel({
           allDay: false,
           recurrenceRule: null,
-          startDate: DateTime.fromISO('2023-10-02T07:00:00.000+02:00'),
-          endDate: DateTime.fromISO('2023-10-03T09:00:00.000+02:00'),
+          startDate: DateTime.fromISO('2023-10-09T07:00:00.000+02:00'),
+          endDate: DateTime.fromISO('2023-10-10T09:00:00.000+02:00'),
         }),
       ])
     })

--- a/web/src/components/__tests__/DatesPageDetail.spec.tsx
+++ b/web/src/components/__tests__/DatesPageDetail.spec.tsx
@@ -10,7 +10,7 @@ import DatesPageDetail from '../DatesPageDetail'
 
 jest.mock('react-i18next')
 
-jest.useFakeTimers({ now: new Date('2023-10-02T15:23:57.443+02:00') })
+jest.useFakeTimers({ now: new Date('2023-10-09T15:23:57.443+02:00') })
 describe('DatesPageDetail', () => {
   const renderDatesPageDetail = (date: DateModel) => renderWithTheme(<DatesPageDetail date={date} languageCode='de' />)
   const date = (rrule?: string) =>


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
Fix the displaying of the next recurrence of events if its near.

### Proposed changes

<!-- Describe this PR in more detail. -->

- Substract timezone offset difference from dates passed to rrule to account for usage of "local time" 
- Substract duration from dates passed to rrule to include currently happening events

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
None.

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2647.

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
