### PR TITLE
2652: Breadcrumbs not only list items

### DIFF
--- a/release-notes/unreleased/2652-breadcrumbs-not-only-list-items.yml
+++ b/release-notes/unreleased/2652-breadcrumbs-not-only-list-items.yml
@@ -2,4 +2,4 @@ issue_key: 2652
 show_in_stores: false
 platforms:
   - web
-en: Fixed breadcrumbs not only contain list items
+en: Fixed breadcrumbs to only contain list items

--- a/release-notes/unreleased/2652-breadcrumbs-not-only-list-items.yml
+++ b/release-notes/unreleased/2652-breadcrumbs-not-only-list-items.yml
@@ -1,0 +1,5 @@
+issue_key: 2652
+show_in_stores: false
+platforms:
+  - web
+en: Fixed breadcrumbs not only contain list items

--- a/web/src/components/Breadcrumbs.tsx
+++ b/web/src/components/Breadcrumbs.tsx
@@ -68,9 +68,11 @@ const Breadcrumbs = ({ ancestorBreadcrumbs, currentBreadcrumb }: BreadcrumbsProp
       <OrderedList>
         {ancestorBreadcrumbs.map((breadcrumb, index) =>
           ancestorBreadcrumbs.length > 1 && index === 0 ? (
-            <StyledLink to={breadcrumb.pathname} key={breadcrumb.pathname}>
-              <StyledIcon src={HouseIcon} title={breadcrumb.title} />
-            </StyledLink>
+            <li key={breadcrumb.pathname}>
+              <StyledLink to={breadcrumb.pathname}>
+                <StyledIcon src={HouseIcon} title={breadcrumb.title} />
+              </StyledLink>
+            </li>
           ) : (
             <Breadcrumb key={breadcrumb.title} shrink={breadcrumb.title.length >= MIN_SHRINK_CHARS}>
               {breadcrumb.node}


### PR DESCRIPTION
### Short description

For a11y purposes all children of an ordered or unordered list should be `<li>`

### Proposed changes

<!-- Describe this PR in more detail. -->

- wrap home icon into `<li>`


### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2652

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
