### PR TITLE
2659: Don't load other cities when fixed city is set

### DIFF
--- a/native/src/components/PoiDetails.tsx
+++ b/native/src/components/PoiDetails.tsx
@@ -49,7 +49,6 @@ type PoiDetailsProps = {
 
 const PoiDetails = ({ poi, language, distance }: PoiDetailsProps): ReactElement => {
   const { t } = useTranslation('pois')
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const thumbnail = poi.thumbnail?.replace('-150x150', '') ?? PoiThumbnailPlaceholderLarge
   const { title, content, email, website, phoneNumber, openingHours, temporarilyClosed, isCurrentlyOpen, category } =
     poi

--- a/release-notes/unreleased/2695-fix-ig-cities-available-in-halloaschaffenburg.yml
+++ b/release-notes/unreleased/2695-fix-ig-cities-available-in-halloaschaffenburg.yml
@@ -1,0 +1,7 @@
+issue_key: 2695
+show_in_stores: false
+platforms:
+  - web
+en: <your note> # english version of the note
+# de is required for notes with show_in_stores set to true
+de: <your german note> # german version of the note

--- a/release-notes/unreleased/2695-fix-ig-cities-available-in-halloaschaffenburg.yml
+++ b/release-notes/unreleased/2695-fix-ig-cities-available-in-halloaschaffenburg.yml
@@ -2,6 +2,4 @@ issue_key: 2695
 show_in_stores: false
 platforms:
   - web
-en: <your note> # english version of the note
-# de is required for notes with show_in_stores set to true
-de: <your german note> # german version of the note
+en: Avoid loading all cities when fixed city is set

--- a/web/src/CityContentSwitcher.tsx
+++ b/web/src/CityContentSwitcher.tsx
@@ -91,7 +91,7 @@ const CityContentSwitcher = ({ languageCode }: CityContentSwitcherProps): ReactE
     languageCode,
   }
 
-  // If the city is not available yet, nothing is rendered in the routes. Therefore we can render the route until we know whether the feature is enabled.
+  // If the city is not available yet, nothing is rendered in the routes. Therefore, we can render the route until we know whether the feature is enabled.
   const eventsEnabled = !city || city.eventsEnabled
   const offersEnabled = !city || city.offersEnabled
   const localNewsEnabled = buildConfig().featureFlags.newsStream && (!city || city.localNewsEnabled)

--- a/web/src/FixedCityContentSwitcher.tsx
+++ b/web/src/FixedCityContentSwitcher.tsx
@@ -1,0 +1,38 @@
+import React, { ReactElement } from 'react'
+import { useParams } from 'react-router-dom'
+
+import { CityModel, NotFoundError } from 'shared/api'
+
+import CityContentSwitcher from './CityContentSwitcher'
+import FailureSwitcher from './components/FailureSwitcher'
+import GeneralFooter from './components/GeneralFooter'
+import GeneralHeader from './components/GeneralHeader'
+import Layout from './components/Layout'
+
+type FixedCityContentSwitcherProps = {
+  languageCode: string
+  fixedCity: string
+}
+
+export type CityRouteProps = {
+  city: CityModel | null
+  pathname: string
+  cityCode: string
+  languageCode: string
+}
+
+const FixedCityContentSwitcher = ({ languageCode, fixedCity }: FixedCityContentSwitcherProps): ReactElement => {
+  const { cityCode } = useParams()
+  if (cityCode !== fixedCity) {
+    const notFoundError = new NotFoundError({ type: 'route', id: fixedCity, city: fixedCity, language: languageCode })
+
+    return (
+      <Layout header={<GeneralHeader languageCode={languageCode} />} footer={<GeneralFooter language={languageCode} />}>
+        <FailureSwitcher error={notFoundError} />
+      </Layout>
+    )
+  }
+  return <CityContentSwitcher languageCode={languageCode} />
+}
+
+export default FixedCityContentSwitcher

--- a/web/src/RootSwitcher.tsx
+++ b/web/src/RootSwitcher.tsx
@@ -15,6 +15,7 @@ import {
 } from 'shared'
 
 import CityContentSwitcher from './CityContentSwitcher'
+import FixedCityContentSwitcher from './FixedCityContentSwitcher'
 import LoadingSpinner from './components/LoadingSpinner'
 import buildConfig from './constants/buildConfig'
 import useScrollToTop from './hooks/useScrollToTop'
@@ -50,7 +51,6 @@ const RootSwitcher = ({ setContentLanguage }: RootSwitcherProps): ReactElement =
 
   const landingPath = pathnameFromRouteInformation({ route: LANDING_ROUTE, languageCode: language })
   const fixedCityPath = fixedCity ? cityContentPath({ cityCode: fixedCity, languageCode: language }) : null
-
   return (
     <Suspense fallback={<LoadingSpinner />}>
       <Routes>
@@ -59,7 +59,16 @@ const RootSwitcher = ({ setContentLanguage }: RootSwitcherProps): ReactElement =
         <Route path={RoutePatterns[NOT_FOUND_ROUTE]} element={<NotFoundPage />} />
         <Route path={RoutePatterns[CONSENT_ROUTE]} element={<ConsentPage languageCode={language} />} />
         <Route path={RoutePatterns[LICENSES_ROUTE]} element={<LicensesPage languageCode={language} />} />
-        <Route path={cityContentPattern} element={<CityContentSwitcher languageCode={language} />} />
+        <Route
+          path={cityContentPattern}
+          element={
+            fixedCity ? (
+              <FixedCityContentSwitcher languageCode={language} fixedCity={fixedCity} />
+            ) : (
+              <CityContentSwitcher languageCode={language} />
+            )
+          }
+        />
 
         {cityNotCooperating && (
           <Route

--- a/web/src/__tests__/CityContentSwitcher.spec.tsx
+++ b/web/src/__tests__/CityContentSwitcher.spec.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+
+import { DISCLAIMER_ROUTE, POIS_ROUTE, SEARCH_ROUTE } from 'shared'
+import { CityModel, CityModelBuilder } from 'shared/api'
+import {
+  mockUseLoadFromEndpointWithData,
+  mockUseLoadFromEndpointWithError,
+} from 'shared/api/endpoints/testing/mockUseLoadFromEndpoint'
+
+import CityContentSwitcher from '../CityContentSwitcher'
+import { cityContentPattern } from '../routes'
+import { renderRoute } from '../testing/render'
+
+jest.mock('shared/api', () => ({
+  ...jest.requireActual('shared/api'),
+  useLoadFromEndpoint: jest.fn(),
+}))
+jest.mock('../components/CityContentHeader')
+jest.mock('../components/CityContentLayout')
+jest.mock('react-i18next')
+
+jest.mock('../routes/SearchPage', () => () => <div>{SEARCH_ROUTE}</div>)
+jest.mock('../routes/DisclaimerPage', () => () => <div>{DISCLAIMER_ROUTE}</div>)
+jest.mock('../routes/PoisPage', () => () => <div>{POIS_ROUTE}</div>)
+
+describe('CityContentSwitcher', () => {
+  const languageCode = 'de'
+  const [city, cityWithDisabledFeatures] = new CityModelBuilder(2).build() as [CityModel, CityModel]
+  const path = (city: CityModel, routeName: string) => `/${city.code}/${languageCode}/${routeName}`
+
+  it.each([{ routeName: SEARCH_ROUTE }, { routeName: DISCLAIMER_ROUTE }, { routeName: POIS_ROUTE }])(
+    'should navigate to $routeName route',
+    async ({ routeName }) => {
+      mockUseLoadFromEndpointWithData(city)
+      const { findByText } = renderRoute(<CityContentSwitcher languageCode={languageCode} />, {
+        routePattern: cityContentPattern,
+        pathname: path(city, routeName),
+      })
+      // findByText is needed as routes are lazy loaded
+      expect(await findByText(routeName)).toBeTruthy()
+    },
+  )
+
+  it('should show an error if endpoint throws an error', () => {
+    mockUseLoadFromEndpointWithError('City cannot be loaded')
+    const { getByText } = renderRoute(<CityContentSwitcher languageCode={languageCode} />, {
+      routePattern: cityContentPattern,
+      pathname: path(city, SEARCH_ROUTE),
+    })
+    expect(getByText('error:unknownError')).toBeTruthy()
+  })
+
+  it('should show an error if city cannot be loaded', () => {
+    mockUseLoadFromEndpointWithData(null)
+    const { getByText } = renderRoute(<CityContentSwitcher languageCode={languageCode} />, {
+      routePattern: cityContentPattern,
+      pathname: path(city, SEARCH_ROUTE),
+    })
+    expect(getByText('error:notFound.city')).toBeTruthy()
+  })
+
+  it('should not navigate to event route if events are not enabled', async () => {
+    mockUseLoadFromEndpointWithData(cityWithDisabledFeatures)
+    const { queryByText } = renderRoute(<CityContentSwitcher languageCode={languageCode} />, {
+      routePattern: cityContentPattern,
+      pathname: path(cityWithDisabledFeatures, POIS_ROUTE),
+    })
+    expect(queryByText(POIS_ROUTE)).not.toBeTruthy()
+  })
+})

--- a/web/src/__tests__/FixedCityContentSwitcher.spec.tsx
+++ b/web/src/__tests__/FixedCityContentSwitcher.spec.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+
+import FixedCityContentSwitcher from '../FixedCityContentSwitcher'
+import { cityContentPattern } from '../routes'
+import { renderRoute } from '../testing/render'
+
+const renderSuccessful = 'route'
+jest.mock('react-i18next')
+jest.mock('../CityContentSwitcher', () => () => <div>{renderSuccessful}</div>)
+describe('FixedCityContentSwitcher', () => {
+  const languageCode = 'de'
+  const fixedCity = 'hallo'
+
+  it('should render the city route if city code is the fixedCity city code', () => {
+    const { getByText } = renderRoute(<FixedCityContentSwitcher languageCode={languageCode} fixedCity={fixedCity} />, {
+      pathname: `/${fixedCity}/${languageCode}/`,
+      routePattern: cityContentPattern,
+    })
+    expect(getByText(renderSuccessful)).toBeTruthy()
+  })
+
+  it('should show an error if city code is not the fixedCity city code', () => {
+    const { queryByText, getByText } = renderRoute(
+      <FixedCityContentSwitcher languageCode={languageCode} fixedCity={fixedCity} />,
+      {
+        pathname: `/not-${fixedCity}/${languageCode}/`,
+        routePattern: cityContentPattern,
+      },
+    )
+    expect(queryByText(renderSuccessful)).not.toBeTruthy()
+    expect(getByText('error:notFound.category')).toBeTruthy()
+  })
+})

--- a/web/src/components/PoiDetails.tsx
+++ b/web/src/components/PoiDetails.tsx
@@ -136,7 +136,6 @@ const PoiDetails = ({ poi, distance, toolbar }: PoiDetailsProps): ReactElement =
   const { content, location, website, phoneNumber, email, isCurrentlyOpen, openingHours, temporarilyClosed, category } =
     poi
 
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const thumbnail = poi.thumbnail?.replace('-150x150', '') ?? PoiThumbnailPlaceholderLarge
   const isAndroid = /Android/i.test(navigator.userAgent)
   const externalMapsLink = getExternalMapsLink(location, isAndroid ? 'android' : 'web')


### PR DESCRIPTION
### Short description

Currently it is possible to open IG cities in Aschaffenburg, when directly navigating to the url 
-> https://halloaschaffenburg.de/kreis-bergstrasse/de
This should be avoided, by not loading any other city than the fixed city.

### Proposed changes

<!-- Describe this PR in more detail. -->

- Add a fixedCityContentSwitcher, which checks whether the params `cityCode` is the `fixedCity`

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2659 
