### PR TITLE
2608: Add purpose strings calendar

### DIFF
--- a/translations/translations.json
+++ b/translations/translations.json
@@ -6025,7 +6025,9 @@
     "en": {
       "NSPhotoLibraryAddUsageDescription": "{{appName}} wants to save photos to your library.",
       "NSLocationWhenInUseUsageDescription": "{{appName}} wants to use your location to find nearby cities.",
-      "NSLocationAlwaysAndWhenInUseUsageDescription": "{{appName}} wants to use your location to find nearby cities."
+      "NSLocationAlwaysAndWhenInUseUsageDescription": "{{appName}} wants to use your location to find nearby cities.",
+      "NSCalendarsUsageDescription": "{{appName}} wants to access the calendar to add an event.",
+      "NSCalendarsFullAccessUsageDescription": "{{appName}} wants to access the calendar to add an event."
     },
     "es": {
       "NSPhotoLibraryAddUsageDescription": "Para guardar imágenes, {{appName}} necesita un acceso a la galería.",


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
Add purpose strings for calendar permissions to translations.

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2608.

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
