### PR TITLE
2677: Share link not clickable

### DIFF
--- a/release-notes/2024.2.5/2677-share-link-not-clickable.yml
+++ b/release-notes/2024.2.5/2677-share-link-not-clickable.yml
@@ -1,0 +1,5 @@
+issue_key: 2677
+show_in_stores: false
+platforms:
+  - web
+en: Fix share link not clickable

--- a/web/src/components/SharingPopup.tsx
+++ b/web/src/components/SharingPopup.tsx
@@ -227,7 +227,7 @@ const SharingPopup = ({ shareUrl, title, flow, portalNeeded }: SharingPopupProps
             </Tooltip>
             <Tooltip text={t('mailTooltip')} flow='up'>
               <Link
-                href={`mailto:?subject=${encodedTitle}&body=${shareMessage}${encodedShareUrl}`}
+                href={`mailto:?subject=${encodedTitle}&body=${shareMessage} ${encodedShareUrl}`}
                 aria-label={t('mailTooltip')}>
                 <StyledIcon src={MailIcon} />
               </Link>

--- a/web/src/components/__tests__/SharingPopup.spec.tsx
+++ b/web/src/components/__tests__/SharingPopup.spec.tsx
@@ -36,7 +36,7 @@ describe('SharingPopup', () => {
   })
 
   it('should render correct share link for mail', () => {
-    const mailShareLink = `mailto:?subject=Aktuelle%20Themen%20und%20Informationen&body=${shareMessage}https%3A%2F%2Fintegreat.app%2Faugsburg%2Fde%2Faktuelle-themen-und-informationen`
+    const mailShareLink = `mailto:?subject=Aktuelle%20Themen%20und%20Informationen&body=${shareMessage} https%3A%2F%2Fintegreat.app%2Faugsburg%2Fde%2Faktuelle-themen-und-informationen`
     const { getAllByLabelText, getByText } = renderWithTheme(SharingPopupComponent)
     fireEvent.click(getByText('socialMedia:layout:share'))
     expect(getAllByLabelText('socialMedia:mailTooltip')[0]).toBeTruthy()


### PR DESCRIPTION
### Short description

When a user wants to share a page f.e. via mail the link is not clickable due to missing whitespace

### Proposed changes

<!-- Describe this PR in more detail. -->

- add a whitespace

### Side effects


### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2677

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
