### PR TITLE
2475: Add list of allowed lookalikes to config & assetlinks.json

### DIFF
--- a/build-configs/BuildConfigType.ts
+++ b/build-configs/BuildConfigType.ts
@@ -51,6 +51,8 @@ export type CommonBuildConfigType = {
   hostName: string
   // Hostnames from which resources are automatically downloaded for offline usage.
   allowedHostNames: Array<string>
+  // Linked hosts that can may look similar https://chromium.googlesource.com/chromium/src/+/master/docs/security/lookalikes/lookalike-domains.md#automated-warning-removal
+  allowedLookalikes: Array<string>
   // Regex defining which urls to intercept as they are internal ones.
   supportedIframeSources: string[]
   internalLinksHijackPattern: string

--- a/build-configs/aschaffenburg/index.ts
+++ b/build-configs/aschaffenburg/index.ts
@@ -22,6 +22,7 @@ const commonAschaffenburgBuildConfig: CommonBuildConfigType = {
   cmsUrl: 'https://cms.integreat-app.de',
   hostName: 'halloaschaffenburg.de',
   allowedHostNames: ['cms.integreat-app.de', 'admin.integreat-app.de'],
+  allowedLookalikes: [],
   supportedIframeSources: ['vimeo.com'],
   translationsOverride: aschaffenburgOverrideTranslations,
   internalLinksHijackPattern:

--- a/build-configs/integreat/index.ts
+++ b/build-configs/integreat/index.ts
@@ -22,6 +22,7 @@ const commonIntegreatBuildConfig: CommonBuildConfigType = {
   switchCmsUrl: 'https://cms-test.integreat-app.de',
   hostName: 'integreat.app',
   allowedHostNames: ['cms.integreat-app.de', 'cms-test.integreat-app.de', 'admin.integreat-app.de'],
+  allowedLookalikes: ['https://integreat.app', 'https://integreat-app.de'],
   supportedIframeSources: ['vimeo.com'],
   internalLinksHijackPattern:
     'https?:\\/\\/(cms(-test)?\\.integreat-app\\.de|web\\.integreat-app\\.de|integreat\\.app)(?!\\/(media|[^/]*\\/(wp-content|wp-admin|wp-json))\\/.*).*',

--- a/build-configs/malte/index.ts
+++ b/build-configs/malte/index.ts
@@ -22,6 +22,7 @@ const commonMalteBuildConfig: CommonBuildConfigType = {
   cmsUrl: 'https://cms.malteapp.de',
   switchCmsUrl: 'https://malte-test.tuerantuer.org',
   allowedHostNames: ['cms.malteapp.de', 'malte-test.tuerantuer.org'],
+  allowedLookalikes: [],
   supportedIframeSources: ['vimeo.com'],
   translationsOverride: malteOverrideTranslations,
   internalLinksHijackPattern:

--- a/build-configs/obdach/index.ts
+++ b/build-configs/obdach/index.ts
@@ -11,6 +11,7 @@ const commonObdachBuildConfig: CommonBuildConfigType = {
   cmsUrl: 'https://cms.netzwerkobdachwohnen.de',
   hostName: 'netzwerkobdachwohnen.de',
   allowedHostNames: ['cms.netzwerkobdachwohnen.de', 'admin.netzwerkobdachwohnen.de'],
+  allowedLookalikes: [],
   supportedIframeSources: ['vimeo.com'],
   internalLinksHijackPattern:
     'https?:\\/\\/((cms\\.)?netzwerkobdachwohnen\\.de)(?!\\/(media|[^/]*\\/(wp-content|wp-admin|wp-json))\\/.*).*',

--- a/native/src/constants/__mocks__/buildConfig.ts
+++ b/native/src/constants/__mocks__/buildConfig.ts
@@ -20,6 +20,7 @@ const buildConfig = jest.fn<CommonBuildConfigType, []>(
     switchCmsUrl: 'https://cms-test.integreat-app.de',
     hostName: 'integreat.app',
     allowedHostNames: ['cms.integreat-app.de', 'cms-test.integreat-app.de', 'admin.integreat-app.de'],
+    allowedLookalikes: ['https://integreat.app', 'https://integreat-app.de'],
     supportedIframeSources: ['vimeo.com'],
     internalLinksHijackPattern:
       'https?:\\/\\/(cms(-test)?\\.integreat-app\\.de|web\\.integreat-app\\.de|integreat\\.app)(?!\\/[^/]*\\/(wp-content|wp-admin|wp-json)\\/.*).*',

--- a/web/tools/webpack.config.ts
+++ b/web/tools/webpack.config.ts
@@ -49,6 +49,10 @@ const generateAssetLinks = (buildConfig: WebBuildConfigType) => {
           sha256_cert_fingerprints: [buildConfig.apps.android.sha256CertFingerprint],
         },
       },
+      ...buildConfig.allowedLookalikes.map(lookalikeSite => ({
+        relation: ['lookalikes/allowlist'],
+        target: { namespace: 'web', site: lookalikeSite },
+      })),
     ],
     null,
     2,


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
To avoid the lookalike phishing warning I added integreat.app and integreat-app.de to assetlinks.json file.

### Proposed changes

<!-- Describe this PR in more detail. -->

- add build config property allowed lookalikes
- set lookalikes in .well-known/assetlinks.json

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2475

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
