### PR TITLE
2635: Use correct thumbnails

### DIFF
--- a/native/src/components/Categories.tsx
+++ b/native/src/components/Categories.tsx
@@ -4,10 +4,9 @@ import { View } from 'react-native'
 import { CATEGORIES_ROUTE, RouteInformationType } from 'shared'
 import { CategoriesMapModel, CategoryModel, CityModel } from 'shared/api'
 
-import { URL_PREFIX } from '../constants/webview'
 import TileModel from '../models/TileModel'
 import testID from '../testing/testID'
-import { LanguageResourceCacheStateType, PageResourceCacheStateType } from '../utils/DataContainer'
+import { LanguageResourceCacheStateType } from '../utils/DataContainer'
 import CategoryListItem from './CategoryListItem'
 import EmbeddedOffers from './EmbeddedOffers'
 import List from './List'
@@ -24,20 +23,6 @@ export type CategoriesProps = {
   resourceCache: LanguageResourceCacheStateType
   goBack: () => void
 }
-
-export const getCachedThumbnail = (thumbnail: string, resourceCache: PageResourceCacheStateType): string => {
-  const resource = resourceCache[thumbnail]
-
-  if (resource) {
-    return URL_PREFIX + resource.filePath
-  }
-
-  return thumbnail
-}
-
-/**
- * Displays a CategoryTable, CategoryList or a single category as page matching the route /<cityCode>/<language>*
- */
 
 const Categories = ({
   cityModel,
@@ -64,13 +49,18 @@ const Categories = ({
         new TileModel({
           title: category.title,
           path: category.path,
-          thumbnail: getCachedThumbnail(category.thumbnail, resourceCache[category.path] ?? {}),
+          thumbnail: category.thumbnail,
           isExternalUrl: false,
         }),
     )
     return (
       <View {...testID('Dashboard-Page')}>
-        <Tiles tiles={tiles} language={language} onTilePress={navigateToCategory} />
+        <Tiles
+          tiles={tiles}
+          language={language}
+          onTilePress={navigateToCategory}
+          resourceCache={resourceCache[category.path]}
+        />
       </View>
     )
   }

--- a/native/src/components/CategoryListItem.tsx
+++ b/native/src/components/CategoryListItem.tsx
@@ -6,7 +6,6 @@ import { CategoryModel } from 'shared/api'
 import { contentDirection, isContentDirectionReversalRequired } from '../constants/contentDirection'
 import dimensions from '../constants/dimensions'
 import { LanguageResourceCacheStateType } from '../utils/DataContainer'
-import { getCachedThumbnail } from './Categories'
 import List from './List'
 import SimpleImage from './SimpleImage'
 import SubCategoryListItem from './SubCategoryListItem'
@@ -72,12 +71,11 @@ const CategoryListItem = ({
       <DirectionContainer language={language}>
         <CategoryEntryContainer>
           <TitleDirectionContainer language={language}>
-            {!!category.thumbnail && (
-              <CategoryThumbnail
-                language={language}
-                source={getCachedThumbnail(category.thumbnail, resourceCache[category.path] ?? {})}
-              />
-            )}
+            <CategoryThumbnail
+              language={language}
+              source={category.thumbnail}
+              resourceCache={resourceCache[category.path]}
+            />
             <CategoryTitle language={language}>{category.title}</CategoryTitle>
           </TitleDirectionContainer>
         </CategoryEntryContainer>

--- a/native/src/components/NavigationTile.tsx
+++ b/native/src/components/NavigationTile.tsx
@@ -1,16 +1,13 @@
-import * as React from 'react'
-import { ReactNode } from 'react'
+import React, { ReactElement } from 'react'
 import { View } from 'react-native'
 import styled from 'styled-components/native'
 
-import { ThemeType } from 'build-configs'
-
 import TileModel from '../models/TileModel'
-import Icon from './base/Icon'
+import SimpleImage from './SimpleImage'
 import Pressable from './base/Pressable'
 
-const NEWS_DOT_RADIUS = 20
 const ICON_SIZE = 50
+
 const Circle = styled(View)`
   margin-top: 9px;
   margin-bottom: 5px;
@@ -33,74 +30,30 @@ const TileTitle = styled.Text`
   font-size: 11px;
   margin-bottom: 5px;
 `
+
 const StyledPressable = styled(Pressable)<{ width: number }>`
   padding: 10px 3px;
   width: ${props => props.width}px;
   align-items: center;
 `
-const NewsDot = styled.Text`
-  position: absolute;
-  top: ${-NEWS_DOT_RADIUS / 2};
-  end: ${-NEWS_DOT_RADIUS / 2};
-  text-align: center;
-  line-height: ${NEWS_DOT_RADIUS}px;
-  height: ${NEWS_DOT_RADIUS}px;
-  width: ${NEWS_DOT_RADIUS}px;
-  border-radius: ${NEWS_DOT_RADIUS / 2}px;
-  background-color: #ee5353;
-  color: #ffffff;
-  elevation: 5;
-  shadow-color: #000;
-  shadow-offset: 0px 2px;
-  shadow-opacity: 0.25;
-  shadow-radius: 3.84px;
-`
 
-const StyledIcon = styled(Icon)`
+const StyledIcon = styled(SimpleImage)`
   width: ${ICON_SIZE / Math.sqrt(2)}px;
   height: ${ICON_SIZE / Math.sqrt(2)}px;
 `
 
 type NavigationTileProps = {
   tile: TileModel
-  theme: ThemeType
   width: number
 }
 
-class NavigationTile extends React.Component<NavigationTileProps> {
-  getNewsDot(): ReactNode {
-    const {
-      tile: { notifications },
-      theme,
-    } = this.props
-
-    if (notifications && notifications > 0) {
-      return <NewsDot theme={theme}>{notifications}</NewsDot>
-    }
-    return null
-  }
-
-  getTileContent(): ReactNode {
-    const { tile, theme } = this.props
-    return (
-      <>
-        <Circle theme={theme}>
-          {typeof tile.thumbnail === 'string' ? <tile.thumbnail /> : <StyledIcon Icon={tile.thumbnail} />}
-          {this.getNewsDot()}
-        </Circle>
-        <TileTitle theme={theme}>{tile.title}</TileTitle>
-      </>
-    )
-  }
-
-  render(): ReactNode {
-    const { tile, theme, width } = this.props
-    return (
-      <StyledPressable theme={theme} onPress={tile.onTilePress} width={width}>
-        {this.getTileContent()}
-      </StyledPressable>
-    )
-  }
-}
+const NavigationTile = ({ tile, width }: NavigationTileProps): ReactElement => (
+  <StyledPressable onPress={tile.onTilePress} width={width}>
+    <Circle>
+      <StyledIcon source={tile.thumbnail} />
+    </Circle>
+    <TileTitle>{tile.title}</TileTitle>
+  </StyledPressable>
+)
 
 export default NavigationTile

--- a/native/src/components/NavigationTiles.tsx
+++ b/native/src/components/NavigationTiles.tsx
@@ -1,7 +1,6 @@
 import React, { ReactElement, useRef, useState } from 'react'
 import { Dimensions, NativeScrollEvent, NativeSyntheticEvent, ScrollView } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
-import { useTheme } from 'styled-components'
 import styled from 'styled-components/native'
 
 import { ArrowBackIcon } from '../assets'
@@ -34,7 +33,7 @@ const StyledIcon = styled(Icon)<{ disabled: boolean }>`
 `
 
 type NavigationTilesProps = {
-  tiles: Array<TileModel>
+  tiles: TileModel[]
 }
 
 const NavigationTiles = ({ tiles }: NavigationTilesProps): ReactElement => {
@@ -48,7 +47,6 @@ const NavigationTiles = ({ tiles }: NavigationTilesProps): ReactElement => {
     : scrollViewWidth / smallScreenItemsCount
   const allTilesWidth = tiles.length * navigationItemWidth
   const isScrollable = allTilesWidth > layoutWidth
-  const theme = useTheme()
 
   const scrollViewRef = useRef<ScrollView>(null)
   const [percentageScrolled, setPercentageScrolled] = useState<number>(0)
@@ -90,7 +88,7 @@ const NavigationTiles = ({ tiles }: NavigationTilesProps): ReactElement => {
         onScroll={handleScroll}
         scrollEventThrottle={16}>
         {tiles.map(tile => (
-          <NavigationTile key={tile.path} tile={tile} theme={theme} width={navigationItemWidth} />
+          <NavigationTile key={tile.path} tile={tile} width={navigationItemWidth} />
         ))}
       </ScrollView>
       {isScrollable && (

--- a/native/src/components/PoiDetails.tsx
+++ b/native/src/components/PoiDetails.tsx
@@ -49,7 +49,7 @@ type PoiDetailsProps = {
 
 const PoiDetails = ({ poi, language, distance }: PoiDetailsProps): ReactElement => {
   const { t } = useTranslation('pois')
-  const thumbnail = poi.thumbnail?.replace('-150x150', '') ?? PoiThumbnailPlaceholderLarge
+  const thumbnail = poi.thumbnail ?? PoiThumbnailPlaceholderLarge
   const { title, content, email, website, phoneNumber, openingHours, temporarilyClosed, isCurrentlyOpen, category } =
     poi
 

--- a/native/src/components/PoiListItem.tsx
+++ b/native/src/components/PoiListItem.tsx
@@ -58,7 +58,7 @@ const PoiListItem = ({ poi, language, navigateToPoi, distance }: PoiListItemProp
   const { t } = useTranslation('pois')
   return (
     <StyledPressable onPress={navigateToPoi} language={language}>
-      <Thumbnail source={poi.thumbnail || PoiThumbnailPlaceholder} resizeMode='cover' />
+      <Thumbnail source={poi.thumbnail ?? PoiThumbnailPlaceholder} resizeMode='cover' />
       <Description>
         <Title>{poi.title}</Title>
         {distance !== null && <Distance>{t('distanceKilometre', { distance: distance.toFixed(1) })}</Distance>}

--- a/native/src/components/SearchListItem.tsx
+++ b/native/src/components/SearchListItem.tsx
@@ -13,7 +13,6 @@ import useNavigate from '../hooks/useNavigate'
 import urlFromRouteInformation from '../navigation/url'
 import { PageResourceCacheStateType } from '../utils/DataContainer'
 import sendTrackingSignal from '../utils/sendTrackingSignal'
-import { getCachedThumbnail } from './Categories'
 import { CategoryThumbnail } from './CategoryListItem'
 import Pressable from './base/Pressable'
 
@@ -22,6 +21,7 @@ const FlexStyledLink = styled(Pressable)`
   flex-direction: column;
   margin: 0 20px;
 `
+
 const DirectionContainer = styled.View<{ language: string }>`
   display: flex;
   flex-direction: ${props => contentDirection(props.language)};
@@ -55,7 +55,7 @@ type SearchListItemProps = {
   language: string
   query: string
   path: string
-  thumbnail?: string
+  thumbnail: string | null
 }
 
 const SearchListItem = ({
@@ -117,9 +117,7 @@ const SearchListItem = ({
       <DirectionContainer language={language}>
         <SearchEntryContainer>
           <TitleDirectionContainer language={language}>
-            {!!thumbnail && (
-              <CategoryThumbnail language={language} source={getCachedThumbnail(thumbnail, resourceCache)} />
-            )}
+            <CategoryThumbnail language={language} source={thumbnail} resourceCache={resourceCache} />
             {Title}
           </TitleDirectionContainer>
           {Content}

--- a/native/src/components/SubCategoryListItem.tsx
+++ b/native/src/components/SubCategoryListItem.tsx
@@ -5,7 +5,6 @@ import { CategoryModel } from 'shared/api'
 
 import { contentDirection } from '../constants/contentDirection'
 import { PageResourceCacheStateType } from '../utils/DataContainer'
-import { getCachedThumbnail } from './Categories'
 import { CategoryThumbnail } from './CategoryListItem'
 import Pressable from './base/Pressable'
 
@@ -44,9 +43,7 @@ const SubCategoryListItem = ({
 }: SubCategoryListItemProps): ReactElement => (
   <FlexStyledLink onPress={() => onItemPress(subCategory)} language={language}>
     <SubCategoryTitleContainer language={language}>
-      {!!subCategory.thumbnail && (
-        <CategoryThumbnail language={language} source={getCachedThumbnail(subCategory.thumbnail, resourceCache)} />
-      )}
+      <CategoryThumbnail language={language} source={subCategory.thumbnail} resourceCache={resourceCache} />
       <SubCategoryTitle>{subCategory.title}</SubCategoryTitle>
     </SubCategoryTitleContainer>
   </FlexStyledLink>

--- a/native/src/components/Tile.tsx
+++ b/native/src/components/Tile.tsx
@@ -2,36 +2,37 @@ import React, { ReactElement } from 'react'
 import styled from 'styled-components/native'
 
 import TileModel from '../models/TileModel'
+import { PageResourceCacheStateType } from '../utils/DataContainer'
 import SimpleImage from './SimpleImage'
 import Pressable from './base/Pressable'
 
-type TileProps = {
-  tile: TileModel
-  onTilePress: (tile: TileModel) => void
-}
-const ThumbnailContainer = styled(SimpleImage)`
+const Thumbnail = styled(SimpleImage)`
   height: 150px;
   width: 150px;
   align-self: center;
 `
+
 const TileTitle = styled.Text`
   margin: 5px;
   color: ${props => props.theme.colors.textColor};
   text-align: center;
   font-family: ${props => props.theme.fonts.native.decorativeFontRegular};
 `
+
 const TileContainer = styled(Pressable)`
   margin-bottom: 20px;
   width: 50%;
 `
 
-const Tile = ({ onTilePress, tile }: TileProps): ReactElement => (
+type TileProps = {
+  tile: TileModel
+  onTilePress: (tile: TileModel) => void
+  resourceCache: PageResourceCacheStateType | undefined
+}
+
+const Tile = ({ onTilePress, tile, resourceCache }: TileProps): ReactElement => (
   <TileContainer onPress={() => onTilePress(tile)}>
-    {!tile.thumbnail || typeof tile.thumbnail === 'string' ? (
-      <ThumbnailContainer source={tile.thumbnail} />
-    ) : (
-      <tile.thumbnail height={150} />
-    )}
+    <Thumbnail source={tile.thumbnail} resourceCache={resourceCache} />
     <TileTitle android_hyphenationFrequency='full'>{tile.title}</TileTitle>
   </TileContainer>
 )

--- a/native/src/components/Tiles.tsx
+++ b/native/src/components/Tiles.tsx
@@ -3,15 +3,9 @@ import styled from 'styled-components/native'
 
 import { contentDirection } from '../constants/contentDirection'
 import TileModel from '../models/TileModel'
+import { PageResourceCacheStateType } from '../utils/DataContainer'
 import Caption from './Caption'
 import Tile from './Tile'
-
-type TilesProps = {
-  title?: string
-  tiles: TileModel[]
-  onTilePress: (tile: TileModel) => void
-  language: string
-}
 
 const TilesRow = styled.View<{ language: string }>`
   display: flex;
@@ -22,12 +16,20 @@ const TilesRow = styled.View<{ language: string }>`
   padding: 10px 0;
 `
 
-const Tiles = ({ title, language, tiles, onTilePress }: TilesProps): ReactElement => (
+type TilesProps = {
+  title?: string
+  tiles: TileModel[]
+  onTilePress: (tile: TileModel) => void
+  language: string
+  resourceCache: PageResourceCacheStateType | undefined
+}
+
+const Tiles = ({ title, language, tiles, onTilePress, resourceCache }: TilesProps): ReactElement => (
   <>
     {!!title && <Caption title={title} />}
     <TilesRow language={language}>
       {tiles.map(tile => (
-        <Tile key={tile.path} tile={tile} onTilePress={onTilePress} />
+        <Tile key={tile.path} tile={tile} onTilePress={onTilePress} resourceCache={resourceCache} />
       ))}
     </TilesRow>
   </>

--- a/native/src/components/__tests__/SearchListItem.spec.tsx
+++ b/native/src/components/__tests__/SearchListItem.spec.tsx
@@ -34,19 +34,18 @@ describe('SearchListItem', () => {
       ? expect(instance.props.style?.fontWeight).toBe('bold')
       : expect(instance.props.style?.fontWeight).toBeUndefined()
 
-  const props = {
-    contentWithoutHtml,
-    resourceCache: resourceCache[category.path]!,
-    language: language.code,
-    title: category.title,
-    city: cityModel.code,
-    path: category.path,
-  }
-
   const renderWithNavigator = (query: string) =>
     render(
       <NavigationContainer>
-        <SearchListItem {...props} query={query} />
+        <SearchListItem
+          contentWithoutHtml={contentWithoutHtml}
+          query={query}
+          language={language.code}
+          title={category.title}
+          path={category.path}
+          thumbnail={category.thumbnail}
+          resourceCache={resourceCache[category.path]!}
+        />
       </NavigationContainer>,
     )
 

--- a/native/src/models/TileModel.ts
+++ b/native/src/models/TileModel.ts
@@ -1,9 +1,10 @@
+import { JSXElementConstructor } from 'react'
 import { SvgProps } from 'react-native-svg'
 
 export default class TileModel {
   _title: string
   _path: string
-  _thumbnail: React.JSXElementConstructor<SVGElement> | string
+  _thumbnail: JSXElementConstructor<SvgProps> | string | null
   _isExternalUrl: boolean
   _postData?: Map<string, string>
   _onTilePress?: () => void
@@ -12,7 +13,7 @@ export default class TileModel {
   constructor(params: {
     title: string
     path: string
-    thumbnail: React.JSXElementConstructor<SvgProps> | string
+    thumbnail: JSXElementConstructor<SvgProps> | string | null
     isExternalUrl: boolean
     postData?: Map<string, string>
     onTilePress?: () => void
@@ -27,7 +28,7 @@ export default class TileModel {
     this._notifications = params.notifications
   }
 
-  get thumbnail(): React.JSXElementConstructor<SvgProps> | string {
+  get thumbnail(): JSXElementConstructor<SvgProps> | string | null {
     return this._thumbnail
   }
 

--- a/native/src/routes/Offers.tsx
+++ b/native/src/routes/Offers.tsx
@@ -37,7 +37,13 @@ const Offers = ({ offers, navigateToOffer, languageCode }: OffersProps): ReactEl
 
   return (
     <View>
-      <Tiles title={t('offers')} tiles={tiles} onTilePress={navigateToOffer} language={languageCode} />
+      <Tiles
+        title={t('offers')}
+        tiles={tiles}
+        onTilePress={navigateToOffer}
+        language={languageCode}
+        resourceCache={undefined}
+      />
     </View>
   )
 }

--- a/native/src/utils/DatabaseConnector.ts
+++ b/native/src/utils/DatabaseConnector.ts
@@ -52,7 +52,7 @@ type ContentCategoryJsonType = {
   title: string
   content: string
   last_update: string
-  thumbnail: string
+  thumbnail: string | null
   available_languages: Record<string, string>
   parent_path: string
   children: Array<string>
@@ -99,7 +99,7 @@ type ContentEventJsonType = {
   title: string
   content: string
   last_update: string
-  thumbnail: string
+  thumbnail: string | null
   available_languages: Record<string, string>
   excerpt: string
   date: {
@@ -136,7 +136,7 @@ type ContentPoiJsonType = {
   path: string
   title: string
   content: string
-  thumbnail: string
+  thumbnail: string | null
   website: string | null
   phoneNumber: string | null
   email: string | null

--- a/native/src/utils/ResourceURLFinder.ts
+++ b/native/src/utils/ResourceURLFinder.ts
@@ -11,7 +11,7 @@ const RESOURCE_EXTENSIONS = ['png', 'jpg', 'jpeg', 'pdf', 'svg']
 type InputEntryType = {
   path: string
   content: string
-  thumbnail: string
+  thumbnail: string | null
 }
 /**
  * A ResourceURLFinder allows to find resource urls in html source code.
@@ -73,7 +73,7 @@ export default class ResourceURLFinder {
     return this._foundUrls
   }
 
-  buildFetchMap(inputs: Array<InputEntryType>, buildFilePath: (url: string, urlHash: string) => string): FetchMapType {
+  buildFetchMap(inputs: InputEntryType[], buildFilePath: (url: string, urlHash: string) => string): FetchMapType {
     return reduce<InputEntryType, FetchMapType>(
       inputs,
       (fetchMap, input: InputEntryType) => {

--- a/native/src/utils/__tests__/getCachedThumbnail.spec.ts
+++ b/native/src/utils/__tests__/getCachedThumbnail.spec.ts
@@ -1,0 +1,40 @@
+import { Platform } from 'react-native'
+
+import getCachedThumbnail from '../getCachedThumbnail'
+
+describe('getCachedThumbnail', () => {
+  const thumbnail = 'https://example.com/asdf.jpg'
+  const cachedThumbnail = 'resource-cache/v1/testumgebung/files/resource-cache/v1/asdf.png'
+  const cachedThumbnailAndroid = `/data/user/0/app.integreat.test/files/${cachedThumbnail}`
+  const cachedThumbnailIos = `Users/user/Library/Developer/CoreSimulator/Devices/977988DF-A8BC-4CE5-A27A-75807A6DF085/data/Containers/Data/Application/CBEFC261-5900-4EF9-8646-603BC57B094A/Documents/${cachedThumbnail}`
+  const expectedCachedThumbnailAndroid = `file:///data/user/0/app.integreat.test/files/${cachedThumbnail}`
+  const expectedCachedThumbnailIos = `~/Documents/${cachedThumbnail}`
+
+  it('should return cached thumbnail for android', () => {
+    Platform.OS = 'android'
+    expect(
+      getCachedThumbnail(thumbnail, {
+        [thumbnail]: {
+          filePath: cachedThumbnailAndroid,
+          hash: 'f325a546afbf8045765887a160251552',
+        },
+      }),
+    ).toBe(expectedCachedThumbnailAndroid)
+  })
+
+  it('should return cached thumbnail for ios', () => {
+    Platform.OS = 'ios'
+    expect(
+      getCachedThumbnail(thumbnail, {
+        [thumbnail]: {
+          filePath: cachedThumbnailIos,
+          hash: 'f325a546afbf8045765887a160251552',
+        },
+      }),
+    ).toBe(expectedCachedThumbnailIos)
+  })
+
+  it('should return thumbnail if not cached', () => {
+    expect(getCachedThumbnail(thumbnail, {})).toBe(thumbnail)
+  })
+})

--- a/native/src/utils/getCachedThumbnail.ts
+++ b/native/src/utils/getCachedThumbnail.ts
@@ -1,0 +1,20 @@
+import { Platform } from 'react-native'
+
+import { URL_PREFIX } from '../constants/webview'
+import { PageResourceCacheStateType } from './DataContainer'
+
+const getCachedThumbnail = (thumbnail: string, resourceCache: PageResourceCacheStateType | undefined): string => {
+  const cachedThumbnail = resourceCache?.[thumbnail]?.filePath
+  if (!cachedThumbnail) {
+    return thumbnail
+  }
+
+  // For ios you should not use the absolute path, since it can change with a future build version, therefore we use home directory
+  // https://github.com/facebook/react-native/commit/23909cd6f62056de0cd0f7c06e3997dd967c139a
+  if (Platform.OS === 'ios') {
+    return `~${cachedThumbnail.substring(cachedThumbnail.indexOf('/Documents'))}`
+  }
+  return `${URL_PREFIX}${cachedThumbnail}`
+}
+
+export default getCachedThumbnail

--- a/shared/api/models/CategoryModel.ts
+++ b/shared/api/models/CategoryModel.ts
@@ -18,7 +18,7 @@ class CategoryModel extends ExtendedPageModel {
     path: string
     title: string
     content: string
-    thumbnail: string
+    thumbnail: string | null
     parentPath: string
     order: number
     availableLanguages: Map<string, string>

--- a/shared/api/models/EventModel.ts
+++ b/shared/api/models/EventModel.ts
@@ -14,19 +14,19 @@ class EventModel extends ExtendedPageModel {
   _date: DateModel
   _location: LocationModel<number | null> | null
   _excerpt: string
-  _featuredImage: FeaturedImageModel | null | undefined
+  _featuredImage: FeaturedImageModel | null
 
   constructor(params: {
     path: string
     title: string
     content: string
-    thumbnail: string
+    thumbnail: string | null
     date: DateModel
     location: LocationModel<number | null> | null
     excerpt: string
     availableLanguages: Map<string, string>
     lastUpdate: DateTime
-    featuredImage: FeaturedImageModel | null | undefined
+    featuredImage: FeaturedImageModel | null
   }) {
     const { date, location, excerpt, featuredImage, ...other } = params
     super(other)
@@ -48,7 +48,7 @@ class EventModel extends ExtendedPageModel {
     return this._excerpt
   }
 
-  get featuredImage(): FeaturedImageModel | null | undefined {
+  get featuredImage(): FeaturedImageModel | null {
     return this._featuredImage
   }
 

--- a/shared/api/models/ExtendedPageModel.ts
+++ b/shared/api/models/ExtendedPageModel.ts
@@ -5,14 +5,14 @@ import { getSlugFromPath } from '../../utils'
 import PageModel from './PageModel'
 
 class ExtendedPageModel extends PageModel {
-  _thumbnail: string
+  _thumbnail: string | null
   _availableLanguages: Map<string, string>
 
   constructor(params: {
     path: string
     title: string
     content: string
-    thumbnail: string
+    thumbnail: string | null
     lastUpdate: DateTime
     availableLanguages: Map<string, string>
   }) {
@@ -22,7 +22,7 @@ class ExtendedPageModel extends PageModel {
     this._availableLanguages = availableLanguages
   }
 
-  get thumbnail(): string {
+  get thumbnail(): string | null {
     return this._thumbnail
   }
 

--- a/shared/api/models/PoiModel.ts
+++ b/shared/api/models/PoiModel.ts
@@ -23,7 +23,7 @@ class PoiModel extends ExtendedPageModel {
     path: string
     title: string
     content: string
-    thumbnail: string
+    thumbnail: string | null
     availableLanguages: Map<string, string>
     metaDescription: string | null
     excerpt: string

--- a/shared/api/types.ts
+++ b/shared/api/types.ts
@@ -58,7 +58,7 @@ export type JsonCategoryType = {
   excerpt: string
   content: string
   available_languages: JsonAvailableLanguagesType
-  thumbnail: string
+  thumbnail: string | null
   parent: {
     id: number
     url: string | null
@@ -83,7 +83,7 @@ export type JsonPoiType = {
   meta_description: string | null
   content: string
   available_languages: JsonAvailableLanguagesType
-  thumbnail: string
+  thumbnail: string | null
   location: JsonLocationType<number>
   website: string | null
   email: string | null
@@ -101,7 +101,7 @@ export type JsonEventType = {
   excerpt: string
   content: string
   available_languages: JsonAvailableLanguagesType
-  thumbnail: string
+  thumbnail: string | null
   event: JsonEventInfoType
   location: JsonLocationType<number | null>
   featured_image: JsonFeaturedImageType | null | undefined

--- a/shared/hooks/useSearch.ts
+++ b/shared/hooks/useSearch.ts
@@ -3,7 +3,7 @@ import { useMemo } from 'react'
 
 export type SearchResult = {
   title: string
-  thumbnail?: string
+  thumbnail: string | null
   content: string
   path: string
 }

--- a/web/src/components/Page.tsx
+++ b/web/src/components/Page.tsx
@@ -19,7 +19,6 @@ const Thumbnail = styled.img`
 
 type PageProps = {
   title: string
-  defaultThumbnailSrc?: string // necessary for IE11 support
   thumbnailSrcSet?: string
   content: string
   lastUpdate?: DateTime
@@ -32,7 +31,6 @@ type PageProps = {
 
 const Page = ({
   title,
-  defaultThumbnailSrc,
   thumbnailSrcSet,
   content,
   lastUpdate,
@@ -43,7 +41,7 @@ const Page = ({
   Footer,
 }: PageProps): ReactElement => (
   <>
-    {!!defaultThumbnailSrc && <Thumbnail alt='' src={defaultThumbnailSrc} srcSet={thumbnailSrcSet} />}
+    {!!thumbnailSrcSet && <Thumbnail alt='' srcSet={thumbnailSrcSet} />}
     <Caption title={title} />
     {BeforeContent}
     <RemoteContent html={content} onInternalLinkClick={onInternalLinkClick} />

--- a/web/src/components/PoiDetails.tsx
+++ b/web/src/components/PoiDetails.tsx
@@ -136,7 +136,7 @@ const PoiDetails = ({ poi, distance, toolbar }: PoiDetailsProps): ReactElement =
   const { content, location, website, phoneNumber, email, isCurrentlyOpen, openingHours, temporarilyClosed, category } =
     poi
 
-  const thumbnail = poi.thumbnail?.replace('-150x150', '') ?? PoiThumbnailPlaceholderLarge
+  const thumbnail = poi.thumbnail ?? PoiThumbnailPlaceholderLarge
   const isAndroid = /Android/i.test(navigator.userAgent)
   const externalMapsLink = getExternalMapsLink(location, isAndroid ? 'android' : 'web')
 

--- a/web/src/components/SearchListItem.tsx
+++ b/web/src/components/SearchListItem.tsx
@@ -60,7 +60,7 @@ type SearchListItemProps = {
   contentWithoutHtml: string
   query: string
   path: string
-  thumbnail?: string
+  thumbnail: string | null
 }
 
 const SearchListItem = ({ title, contentWithoutHtml, query, path, thumbnail }: SearchListItemProps): ReactElement => {

--- a/web/src/components/Tile.tsx
+++ b/web/src/components/Tile.tsx
@@ -61,21 +61,20 @@ const TileContainer = styled.div`
   }
 `
 
-/**
- * Displays a single Tile
- */
 const Tile = (props: TileProps): ReactElement => {
   const imageRef = useRef<HTMLImageElement>(null)
   const { tile } = props
 
   const fetchImageWithCaching = (): void => {
-    request(tile.thumbnail, {})
-      .then(res => res.blob())
-      .then(blob => {
-        if (imageRef.current) {
-          imageRef.current.src = URL.createObjectURL(blob)
-        }
-      })
+    if (tile.thumbnail) {
+      request(tile.thumbnail, {})
+        .then(res => res.blob())
+        .then(blob => {
+          if (imageRef.current) {
+            imageRef.current.src = URL.createObjectURL(blob)
+          }
+        })
+    }
   }
 
   const getTileContent = (): ReactNode => {

--- a/web/src/models/TileModel.ts
+++ b/web/src/models/TileModel.ts
@@ -1,17 +1,17 @@
 export default class TileModel {
   _title: string
   _path: string
-  _thumbnail: string
+  _thumbnail: string | null
   _postData?: Map<string, string>
 
-  constructor(params: { title: string; path: string; thumbnail: string; postData?: Map<string, string> }) {
+  constructor(params: { title: string; path: string; thumbnail: string | null; postData?: Map<string, string> }) {
     this._title = params.title
     this._path = params.path
     this._thumbnail = params.thumbnail
     this._postData = params.postData
   }
 
-  get thumbnail(): string {
+  get thumbnail(): string | null {
     return this._thumbnail
   }
 

--- a/web/src/routes/EventsPage.tsx
+++ b/web/src/routes/EventsPage.tsx
@@ -105,15 +105,13 @@ const EventsPage = ({ city, pathname, languageCode, cityCode }: CityRouteProps):
   }
 
   if (event) {
-    const { featuredImage, thumbnail, lastUpdate, content, title, location, date } = event
-    const defaultThumbnail = featuredImage ? featuredImage.medium.url : thumbnail
+    const { featuredImage, lastUpdate, content, title, location, date } = event
 
     return (
       <CityContentLayout isLoading={false} {...locationLayoutParams}>
         <Helmet pageTitle={pageTitle} languageChangePaths={languageChangePaths} cityModel={city} />
         <JsonLdEvent event={event} />
         <Page
-          defaultThumbnailSrc={defaultThumbnail}
           thumbnailSrcSet={featuredImage ? featuredImageToSrcSet(featuredImage, THUMBNAIL_WIDTH) : undefined}
           lastUpdate={lastUpdate}
           content={content}


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
Use correct thumbnails for pois and fix thumbnail type.

### Proposed changes

<!-- Describe this PR in more detail. -->

- Remove unnecessary `.replace('150x150', '')` for poi thumbnails
- Make thumbnail type optional for categories, events and pois to match api
- Refactor `SimpleImage` to support local svg icons
- Refactor `NavigationTile`

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

Hopefully none.

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2635.

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
