### PR TITLE
2687: Support language independent urls

### DIFF
--- a/release-notes/unreleased/2687-language-independent-urls.yml
+++ b/release-notes/unreleased/2687-language-independent-urls.yml
@@ -1,0 +1,7 @@
+issue_key: 2687
+show_in_stores: false
+platforms:
+  - android
+  - ios
+  - web
+en: Language independent urls are now supported.

--- a/shared/routes/InternalPathnameParser.ts
+++ b/shared/routes/InternalPathnameParser.ts
@@ -7,9 +7,11 @@ import {
   LANDING_ROUTE,
   LOCAL_NEWS_TYPE,
   LocalNewsType,
+  MALTE_HELP_FORM_OFFER_ROUTE,
   NEWS_ROUTE,
   OFFERS_ROUTE,
   POIS_ROUTE,
+  RESERVED_CITY_CONTENT_SLUGS,
   SEARCH_ROUTE,
   SPRUNGBRETT_OFFER_ROUTE,
   TU_NEWS_TYPE,
@@ -23,7 +25,6 @@ import { parseQueryParams } from './query'
 const ENTITY_ID_INDEX = 3
 
 class InternalPathnameParser {
-  _pathname: string
   _parts: Array<string>
   _length: number
   _fallbackLanguageCode: string
@@ -31,15 +32,24 @@ class InternalPathnameParser {
   _queryParams: URLSearchParams
 
   constructor(pathname: string, languageCode: string, fixedCity: string | null, query?: string) {
-    this._pathname = normalizePath(pathname)
     this._fixedCity = fixedCity
-    this._parts = this.pathnameParts(this._pathname)
-    this._length = this._parts.length
     this._fallbackLanguageCode = languageCode
+    this._parts = this.pathnameParts(normalizePath(pathname))
+    this._length = this._parts.length
     this._queryParams = new URLSearchParams(query)
   }
 
-  pathnameParts = (pathname: string): string[] => pathname.split('/').filter(Boolean)
+  pathnameParts = (pathname: string): string[] => {
+    const parts = pathname.split('/').filter(Boolean)
+    const [first, second, ...rest] = parts
+
+    const isLanguageIndependentUrl = !!first && !!second && (RESERVED_CITY_CONTENT_SLUGS as string[]).includes(second)
+    if (isLanguageIndependentUrl) {
+      return [first, this._fallbackLanguageCode, second, ...rest]
+    }
+
+    return parts
+  }
 
   isFixedCity = (): boolean => !!this._fixedCity && this._length >= 1 && this._parts[0] === this._fixedCity
 
@@ -177,18 +187,10 @@ class InternalPathnameParser {
     const params = this.cityContentParams(OFFERS_ROUTE)
     const route = this._length > ENTITY_ID_INDEX ? this._parts[ENTITY_ID_INDEX] : OFFERS_ROUTE
 
-    if (params) {
-      if (route === OFFERS_ROUTE) {
-        return {
-          route: OFFERS_ROUTE,
-          ...params,
-        }
-      }
-      if (route === SPRUNGBRETT_OFFER_ROUTE) {
-        return {
-          route: SPRUNGBRETT_OFFER_ROUTE,
-          ...params,
-        }
+    if (params && (route === OFFERS_ROUTE || route === SPRUNGBRETT_OFFER_ROUTE)) {
+      return {
+        route,
+        ...params,
       }
     }
 
@@ -237,7 +239,7 @@ class InternalPathnameParser {
         route: CATEGORIES_ROUTE,
         cityCode: this._parts[0]!,
         languageCode: this._parts[1]!,
-        cityContentPath: this._pathname,
+        cityContentPath: `/${this._parts.join('/')}`,
       }
     }
 

--- a/shared/routes/__tests__/InternalPathnameParser.spec.ts
+++ b/shared/routes/__tests__/InternalPathnameParser.spec.ts
@@ -243,6 +243,7 @@ describe('InternalPathnameParser', () => {
       cityContentPath: pathname2,
     })
   })
+
   describe('fixed city', () => {
     const fixedCity = 'aschaffenburg'
     it('should match categories route if pathname is emtpy', () => {
@@ -495,6 +496,87 @@ describe('InternalPathnameParser', () => {
       expect(parser8.route()).toBeNull()
       const parser9 = new InternalPathnameParser(`/${cityCode}/${languageCode}/some-category`, languageCode, fixedCity)
       expect(parser9.route()).toBeNull()
+    })
+  })
+
+  describe('language independent urls', () => {
+    it('should match events route', () => {
+      const pathname = `/${cityCode}/${EVENTS_ROUTE}`
+      const parser = new InternalPathnameParser(pathname, languageCode, null)
+      expect(parser.route()).toEqual({
+        route: EVENTS_ROUTE,
+        languageCode,
+        cityCode,
+      })
+    })
+    it('should match single events route', () => {
+      const pathname = `/${cityCode}/${EVENTS_ROUTE}/1234`
+      const parser = new InternalPathnameParser(pathname, languageCode, null)
+      expect(parser.route()).toEqual({
+        route: EVENTS_ROUTE,
+        languageCode,
+        cityCode,
+        slug: '1234',
+      })
+    })
+    it('should match pois route', () => {
+      const pathname = `/${cityCode}/${POIS_ROUTE}`
+      const parser = new InternalPathnameParser(pathname, languageCode, null)
+      expect(parser.route()).toEqual({
+        route: POIS_ROUTE,
+        languageCode,
+        cityCode,
+      })
+    })
+    it('should match single pois route', () => {
+      const slug = 'tuer-an-tuer'
+      const pathname = `/${cityCode}/${POIS_ROUTE}/${slug}`
+      const parser = new InternalPathnameParser(pathname, languageCode, null)
+      expect(parser.route()).toEqual({
+        route: POIS_ROUTE,
+        languageCode,
+        cityCode,
+        slug,
+      })
+    })
+    it('should match multipoi route', () => {
+      const pathname = `/${cityCode}/${POIS_ROUTE}`
+      const query = `?${MULTIPOI_QUERY_KEY}=1&${POI_CATEGORY_QUERY_KEY}=8`
+      const parser = new InternalPathnameParser(pathname, languageCode, null, query)
+      expect(parser.route()).toEqual({
+        route: POIS_ROUTE,
+        languageCode,
+        cityCode,
+        multipoi: 1,
+        poiCategoryId: 8,
+      })
+    })
+    it('should match disclaimer route', () => {
+      const pathname = `/${cityCode}/${DISCLAIMER_ROUTE}`
+      const parser = new InternalPathnameParser(pathname, languageCode, null)
+      expect(parser.route()).toEqual({
+        route: DISCLAIMER_ROUTE,
+        languageCode,
+        cityCode,
+      })
+    })
+    it('should match offers route', () => {
+      const pathname = `/${cityCode}/${OFFERS_ROUTE}`
+      const parser = new InternalPathnameParser(pathname, languageCode, null)
+      expect(parser.route()).toEqual({
+        route: OFFERS_ROUTE,
+        languageCode,
+        cityCode,
+      })
+    })
+    it('should match sprungbrett offers route', () => {
+      const pathname = `/${cityCode}/${OFFERS_ROUTE}/${SPRUNGBRETT_OFFER_ROUTE}`
+      const parser = new InternalPathnameParser(pathname, languageCode, null)
+      expect(parser.route()).toEqual({
+        route: SPRUNGBRETT_OFFER_ROUTE,
+        languageCode,
+        cityCode,
+      })
     })
   })
 })

--- a/shared/routes/index.ts
+++ b/shared/routes/index.ts
@@ -81,3 +81,24 @@ export const MAIN_DISCLAIMER_ROUTE: MainDisclaimerRouteType = 'main-disclaimer'
 
 export type NotFoundRouteType = 'not-found'
 export const NOT_FOUND_ROUTE: NotFoundRouteType = 'not-found'
+
+// Adding new routes should be mentioned to the CMS team if the route has to be reserved
+export const RESERVED_TOP_LEVEL_SLUGS = [
+  LANDING_ROUTE,
+  MAIN_DISCLAIMER_ROUTE,
+  NOT_FOUND_ROUTE,
+  CONSENT_ROUTE,
+  LICENSES_ROUTE,
+  CITY_NOT_COOPERATING_ROUTE,
+  JPAL_TRACKING_ROUTE,
+]
+
+// Adding new routes should be mentioned to the CMS team if the route has to be reserved
+export const RESERVED_CITY_CONTENT_SLUGS = [
+  SEARCH_ROUTE,
+  DISCLAIMER_ROUTE,
+  EVENTS_ROUTE,
+  NEWS_ROUTE,
+  POIS_ROUTE,
+  OFFERS_ROUTE,
+]

--- a/web/src/CityContentSwitcher.tsx
+++ b/web/src/CityContentSwitcher.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, ReactElement, Suspense } from 'react'
-import { Route, Routes, useLocation, useParams } from 'react-router-dom'
+import { Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom'
 
 import {
   CATEGORIES_ROUTE,
@@ -7,6 +7,7 @@ import {
   DISCLAIMER_ROUTE,
   EVENTS_ROUTE,
   MALTE_HELP_FORM_OFFER_ROUTE,
+  NEWS_ROUTE,
   normalizePath,
   OFFERS_ROUTE,
   POIS_ROUTE,
@@ -144,6 +145,13 @@ const CityContentSwitcher = ({ languageCode }: CityContentSwitcherProps): ReactE
 
       {tuNewsEnabled && render(TU_NEWS_ROUTE, TuNewsPage)}
       {tuNewsEnabled && render(TU_NEWS_DETAIL_ROUTE, TuNewsDetailPage)}
+
+      {(localNewsEnabled || tuNewsEnabled) && (
+        <Route
+          path={NEWS_ROUTE}
+          element={<Navigate to={localNewsEnabled ? LOCAL_NEWS_ROUTE : TU_NEWS_ROUTE} replace />}
+        />
+      )}
     </Routes>
   )
 }

--- a/web/src/RootSwitcher.tsx
+++ b/web/src/RootSwitcher.tsx
@@ -10,8 +10,10 @@ import {
   LANDING_ROUTE,
   LICENSES_ROUTE,
   MAIN_DISCLAIMER_ROUTE,
+  NEWS_ROUTE,
   NOT_FOUND_ROUTE,
   pathnameFromRouteInformation,
+  RESERVED_CITY_CONTENT_SLUGS,
 } from 'shared'
 
 import CityContentSwitcher from './CityContentSwitcher'
@@ -37,11 +39,11 @@ const LicensesPage = lazyWithRetry(() => import('./routes/LicensesPage'))
 const RootSwitcher = ({ setContentLanguage }: RootSwitcherProps): ReactElement => {
   const { i18n } = useTranslation()
   const { fixedCity, cityNotCooperating, jpalTracking } = buildConfig().featureFlags
-  const languageCode = useMatch('/:slug/:languageCode/*')?.params.languageCode
+  const { routeParam0, routeParam1, '*': splat } = useMatch('/:routeParam0/:routeParam1/*')?.params ?? {}
   useScrollToTop()
 
   const detectedLanguageCode = i18n.language
-  const language = languageCode ?? detectedLanguageCode
+  const language = routeParam1 ?? detectedLanguageCode
 
   useEffect(() => {
     if (language !== detectedLanguageCode) {
@@ -89,6 +91,15 @@ const RootSwitcher = ({ setContentLanguage }: RootSwitcherProps): ReactElement =
         )}
         {/* also handles redirects from /landing to /landing/de */}
         <Route path='/:cityCode' element={<Navigate to={fixedCityPath ?? language} replace />} />
+
+        {/* Language independent urls */}
+        {RESERVED_CITY_CONTENT_SLUGS.map(slug => (
+          <Route
+            key={slug}
+            path={`/:cityCode/${slug}/*`}
+            element={<Navigate to={`/${routeParam0}/${detectedLanguageCode}/${slug}/${splat ?? ''}`} replace />}
+          />
+        ))}
       </Routes>
     </Suspense>
   )

--- a/web/src/__tests__/RootSwitcher.spec.tsx
+++ b/web/src/__tests__/RootSwitcher.spec.tsx
@@ -56,46 +56,55 @@ describe('RootSwitcher', () => {
     await waitFor(() => expect(getByText('/landing/de')).toBeTruthy())
   })
 
-  it.each`
-    from              | to
-    ${'/'}            | ${'/landing/de'}
-    ${'/landing'}     | ${'/landing/de'}
-    ${'/augsburg'}    | ${'/augsburg/de'}
-    ${'/augsburg/de'} | ${'/augsburg/de'}
-  `('should redirect from $from to $to', ({ from, to }) => {
-    mockUseLoadFromEndpointWithData(cities)
-
-    const { getByText } = renderRootSwitcher(from)
-
-    expect(getByText(to)).toBeTruthy()
-  })
-
-  describe('fixedCity', () => {
-    const previousConfig = buildConfig()
-    let config = previousConfig
-
-    beforeAll(() => {
-      config.featureFlags.fixedCity = 'augsburg'
-    })
-
-    afterAll(() => {
-      config = previousConfig
-    })
-
+  describe('redirects', () => {
     it.each`
-      from              | to
-      ${'/'}            | ${'/augsburg/de'}
-      ${'/landing'}     | ${'/augsburg/de'}
-      ${'/augsburg'}    | ${'/augsburg/de'}
-      ${'/augsburg/de'} | ${'/augsburg/de'}
-      ${'/oldtown'}     | ${'/augsburg/de'}
-      ${'/oldtown/de'}  | ${'/oldtown/de'}
-    `('should redirect from $from to $to for fixedCity', async ({ from, to }) => {
+      from                          | to
+      ${'/'}                        | ${'/landing/de'}
+      ${'/landing'}                 | ${'/landing/de'}
+      ${'/augsburg'}                | ${'/augsburg/de'}
+      ${'/augsburg/de'}             | ${'/augsburg/de'}
+      ${'/augsburg/events'}         | ${'/augsburg/de/events'}
+      ${'/augsburg/events/event-1'} | ${'/augsburg/de/events/event-1'}
+      ${'/augsburg/news'}           | ${'/augsburg/de/news'}
+      ${'/augsburg/news/local'}     | ${'/augsburg/de/news/local'}
+      ${'/augsburg/news/tu-news'}   | ${'/augsburg/de/news/tu-news'}
+    `('should redirect from $from to $to', ({ from, to }) => {
       mockUseLoadFromEndpointWithData(cities)
 
       const { getByText } = renderRootSwitcher(from)
 
-      await waitFor(() => expect(getByText(to)).toBeTruthy())
+      expect(getByText(to)).toBeTruthy()
+    })
+
+    describe('fixedCity', () => {
+      const previousConfig = buildConfig()
+      let config = previousConfig
+
+      beforeAll(() => {
+        config.featureFlags.fixedCity = 'augsburg'
+      })
+
+      afterAll(() => {
+        config = previousConfig
+      })
+
+      it.each`
+        from                     | to
+        ${'/'}                   | ${'/augsburg/de'}
+        ${'/landing'}            | ${'/augsburg/de'}
+        ${'/augsburg'}           | ${'/augsburg/de'}
+        ${'/augsburg/de'}        | ${'/augsburg/de'}
+        ${'/oldtown'}            | ${'/augsburg/de'}
+        ${'/oldtown/de'}         | ${'/oldtown/de'}
+        ${'/oldtown/news'}       | ${'/oldtown/de/news'}
+        ${'/oldtown/news/local'} | ${'/oldtown/de/news/local'}
+      `('should redirect from $from to $to for fixedCity', async ({ from, to }) => {
+        mockUseLoadFromEndpointWithData(cities)
+
+        const { getByText } = renderRootSwitcher(from)
+
+        await waitFor(() => expect(getByText(to)).toBeTruthy())
+      })
     })
   })
 })


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
Support language independent urls for reserved routes such as events, news, pois, offers, search and disclaimer.

### Proposed changes

<!-- Describe this PR in more detail. -->

- Add redirects from language-independent urls (web)
- Adjust InternalPathnameParser to support language-independent urls
- Add documentation about reserved slugs

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

Hopefully none.

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2687, #2683.

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
