### PR TITLE
2727: Search result pois events missing

### DIFF
--- a/native/src/routes/SearchModal.tsx
+++ b/native/src/routes/SearchModal.tsx
@@ -44,7 +44,7 @@ const SearchModal = ({
   const theme = useContext(ThemeContext)
   const { t } = useTranslation('search')
 
-  const searchResults = useSearch(allPossibleResults, query, 'async')
+  const searchResults = useSearch(allPossibleResults, query, true)
 
   const onClose = (): void => {
     sendTrackingSignal({

--- a/native/src/routes/SearchModal.tsx
+++ b/native/src/routes/SearchModal.tsx
@@ -44,7 +44,7 @@ const SearchModal = ({
   const theme = useContext(ThemeContext)
   const { t } = useTranslation('search')
 
-  const searchResults = useSearch(allPossibleResults, query, true)
+  const searchResults = useSearch(allPossibleResults, query)
 
   const onClose = (): void => {
     sendTrackingSignal({

--- a/release-notes/unreleased/2727-search-result-pois-events-missing.yml
+++ b/release-notes/unreleased/2727-search-result-pois-events-missing.yml
@@ -1,0 +1,7 @@
+issue_key: 2727
+show_in_stores: false
+platforms:
+  - android
+  - ios
+  - web
+en: Fix search results missing on initial search

--- a/shared/hooks/useSearch.ts
+++ b/shared/hooks/useSearch.ts
@@ -1,14 +1,9 @@
 import MiniSearch from 'minisearch'
 import { useCallback } from 'react'
 
-import { useLoadAsync } from '../api'
+import { CategoryModel, EventModel, PoiModel, useLoadAsync } from '../api'
 
-export type SearchResult = {
-  title: string
-  thumbnail?: string
-  content: string
-  path: string
-}
+export type SearchResult = EventModel | PoiModel | CategoryModel
 
 const useSearch = (allPossibleResults: SearchResult[], query: string): SearchResult[] => {
   const initializeMiniSearch = useCallback(async () => {
@@ -26,8 +21,9 @@ const useSearch = (allPossibleResults: SearchResult[], query: string): SearchRes
     return search
   }, [allPossibleResults])
   const { data: minisearch } = useLoadAsync(initializeMiniSearch)
-  // @ts-expect-error minisearch doesn't add the returned storeFields (e.g. title or path) to its typing
-  return query.length === 0 || !minisearch ? allPossibleResults : minisearch.search(query)
+  return query.length === 0 || !minisearch
+    ? allPossibleResults
+    : (minisearch.search(query) as unknown as SearchResult[])
 }
 
 export default useSearch

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{"versionName":"2024.3.5","versionCode":100042364}
+{"versionName":"2024.3.6","versionCode":100042365}

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{"versionName":"2024.3.4","versionCode":100042363}
+{"versionName":"2024.3.5","versionCode":100042364}

--- a/web/src/hooks/useAllPossibleSearchResults.ts
+++ b/web/src/hooks/useAllPossibleSearchResults.ts
@@ -39,8 +39,11 @@ const useAllPossibleSearchResults = ({
   } = useLoadFromEndpoint(createPOIsEndpoint, cmsApiBaseUrl, params)
 
   const allPossibleResults = useMemo(
-    () => [...(categories?.toArray().filter(category => !category.isRoot()) || []), ...(events || []), ...(pois || [])],
-    [categories, events, pois],
+    () =>
+      !(poisLoading && eventsLoading && categoriesLoading)
+        ? [...(categories?.toArray().filter(category => !category.isRoot()) || []), ...(events || []), ...(pois || [])]
+        : [],
+    [categories, categoriesLoading, events, eventsLoading, pois, poisLoading],
   )
 
   return {


### PR DESCRIPTION
### Short description

Currently for async search not all search results were found with `minisearch`. The issue is that the indexing was not ready when the query was typed and missing results were not reloaded.

### Proposed changes

<!-- Describe this PR in more detail. -->

- reload search results when indexing has finished

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- during typing search query the search results change but if we want it async/non blocking, i think we can't find a better solution

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2727

### Testing
- Go to a location
- open the search and type in immediately your search query. All results should be shown
