### PR TITLE
2747: Fix wrong event times

### DIFF
--- a/native/src/utils/DatabaseConnector.ts
+++ b/native/src/utils/DatabaseConnector.ts
@@ -32,7 +32,7 @@ import {
 import { deleteIfExists } from './helpers'
 import { log, reportError } from './sentry'
 
-export const CONTENT_VERSION = 'v5'
+export const CONTENT_VERSION = 'v6'
 export const RESOURCE_CACHE_VERSION = 'v1'
 
 // Our pdf view can only load from DocumentDir. Therefore we need to use that

--- a/release-notes/unreleased/2747-wrong-times.yml
+++ b/release-notes/unreleased/2747-wrong-times.yml
@@ -1,0 +1,7 @@
+issue_key: 2747
+show_in_stores: true
+platforms:
+  - android
+  - ios
+en: Fixed wrong event times.
+de: Falsche Versanstaltungsuhrzeiten behoben.

--- a/shared/api/models/DateModel.ts
+++ b/shared/api/models/DateModel.ts
@@ -28,17 +28,18 @@ class DateModel {
     this._offset = startDate.offset
     this._allDay = allDay
     this._duration = endDate.diff(startDate)
-    // If there is a recurrence rule, the start and end dates are not updated in the CMS and are therefore most of the time outdated
-    // Therefore calculate the (next) correct start and end date based on the recurrence rule if available
-    const first = recurrenceRule?.after(this.currentDateToRrule())
-    this._startDate = first ? this.rruleToDateTime(first) : startDate
-    this._endDate = this._startDate.plus(this._duration)
+    this._startDate = startDate
+    this._endDate = endDate
   }
 
+  // This should only be called on recurrences as start dates are not updated in the CMS
+  // E.g. date.recurrences(1)[0]?.startDate
   get startDate(): DateTime {
     return this._startDate
   }
 
+  // This should only be called on recurrences as end dates are not updated in the CMS
+  // E.g. date.recurrences(1)[0]?.endDate
   get endDate(): DateTime {
     return this._endDate
   }
@@ -78,7 +79,7 @@ class DateModel {
             allDay: this._allDay,
             startDate: it,
             endDate: it.plus(duration),
-            recurrenceRule: null,
+            recurrenceRule: this.recurrenceRule,
           }),
       )
   }

--- a/shared/api/models/EventModel.ts
+++ b/shared/api/models/EventModel.ts
@@ -37,7 +37,7 @@ class EventModel extends ExtendedPageModel {
   }
 
   get date(): DateModel {
-    return this._date
+    return this._date.recurrences(1)[0] ?? this._date
   }
 
   get location(): LocationModel<number | null> | null {

--- a/shared/api/models/__tests__/DateModel.spec.ts
+++ b/shared/api/models/__tests__/DateModel.spec.ts
@@ -156,7 +156,7 @@ describe('DateModel', () => {
       expect(date.recurrences(4)).toEqual([
         new DateModel({
           allDay: false,
-          recurrenceRule: null,
+          recurrenceRule,
           startDate: DateTime.fromISO('2023-10-09T07:00:00.000+02:00'),
           endDate: DateTime.fromISO('2023-10-10T09:00:00.000+02:00'),
         }),
@@ -193,7 +193,7 @@ describe('DateModel', () => {
       expect(date.recurrences(3)).toEqual([
         new DateModel({
           allDay: false,
-          recurrenceRule: null,
+          recurrenceRule,
           startDate: DateTime.fromISO('2023-10-09T07:00:00.000+02:00'),
           endDate: DateTime.fromISO('2023-10-10T09:00:00.000+02:00'),
         }),
@@ -212,19 +212,19 @@ describe('DateModel', () => {
       expect(date.recurrences(3)).toEqual([
         new DateModel({
           allDay: false,
-          recurrenceRule: null,
+          recurrenceRule,
           startDate: DateTime.fromISO('2024-03-25T14:00:00.000+01:00'),
           endDate: DateTime.fromISO('2024-03-25T16:00:00.000+01:00'),
         }),
         new DateModel({
           allDay: false,
-          recurrenceRule: null,
+          recurrenceRule,
           startDate: DateTime.fromISO('2024-04-01T14:00:00.000+02:00'),
           endDate: DateTime.fromISO('2024-04-01T16:00:00.000+02:00'),
         }),
         new DateModel({
           allDay: false,
-          recurrenceRule: null,
+          recurrenceRule,
           startDate: DateTime.fromISO('2024-04-08T14:00:00.000+02:00'),
           endDate: DateTime.fromISO('2024-04-08T16:00:00.000+02:00'),
         }),

--- a/shared/api/models/__tests__/DateModel.spec.ts
+++ b/shared/api/models/__tests__/DateModel.spec.ts
@@ -133,18 +133,6 @@ describe('DateModel', () => {
   })
 
   describe('recurrences', () => {
-    it('should update start and end date according to recurrence rule and ignore delivered dates', () => {
-      const date = new DateModel({
-        startDate: DateTime.fromISO('2017-09-27T19:30:00+02:00'),
-        endDate: DateTime.fromISO('2017-09-28T21:30:00+02:00'),
-        allDay: false,
-        recurrenceRule: rrulestr('DTSTART:20230414T050000\nRRULE:FREQ=WEEKLY;BYDAY=MO'),
-      })
-
-      expect(date.startDate).toEqual(DateTime.fromISO('2023-10-09T07:00:00.000+02:00'))
-      expect(date.endDate).toEqual(DateTime.fromISO('2023-10-10T09:00:00.000+02:00'))
-    })
-
     it('should return itself if there is no rrule set', () => {
       const date = new DateModel({
         startDate: DateTime.fromISO('2017-11-27T19:30:00+02:00'),
@@ -157,11 +145,12 @@ describe('DateModel', () => {
     })
 
     it('should return exactly count recurrences', () => {
+      const recurrenceRule = rrulestr('DTSTART:20230414T050000\nRRULE:FREQ=WEEKLY;BYDAY=MO')
       const date = new DateModel({
         startDate: DateTime.fromISO('2017-09-27T19:30:00+02:00'),
         endDate: DateTime.fromISO('2017-09-28T21:30:00+02:00'),
         allDay: false,
-        recurrenceRule: rrulestr('DTSTART:20230414T050000\nRRULE:FREQ=WEEKLY;BYDAY=MO'),
+        recurrenceRule,
       })
 
       expect(date.recurrences(4)).toEqual([
@@ -173,19 +162,19 @@ describe('DateModel', () => {
         }),
         new DateModel({
           allDay: false,
-          recurrenceRule: null,
+          recurrenceRule,
           startDate: DateTime.fromISO('2023-10-16T07:00:00.000+02:00'),
           endDate: DateTime.fromISO('2023-10-17T09:00:00.000+02:00'),
         }),
         new DateModel({
           allDay: false,
-          recurrenceRule: null,
+          recurrenceRule,
           startDate: DateTime.fromISO('2023-10-23T07:00:00.000+02:00'),
           endDate: DateTime.fromISO('2023-10-24T09:00:00.000+02:00'),
         }),
         new DateModel({
           allDay: false,
-          recurrenceRule: null,
+          recurrenceRule,
           startDate: DateTime.fromISO('2023-10-30T07:00:00.000+01:00'),
           endDate: DateTime.fromISO('2023-10-31T09:00:00.000+01:00'),
         }),
@@ -193,11 +182,12 @@ describe('DateModel', () => {
     })
 
     it('should return less recurrences if rrule ends', () => {
+      const recurrenceRule = rrulestr('DTSTART:20230414T050000\nRRULE:FREQ=WEEKLY;BYDAY=MO;UNTIL=20231015T050000')
       const date = new DateModel({
         startDate: DateTime.fromISO('2017-09-27T19:30:00+02:00'),
         endDate: DateTime.fromISO('2017-09-28T21:30:00+02:00'),
         allDay: false,
-        recurrenceRule: rrulestr('DTSTART:20230414T050000\nRRULE:FREQ=WEEKLY;BYDAY=MO;UNTIL=20231015T050000'),
+        recurrenceRule,
       })
 
       expect(date.recurrences(3)).toEqual([
@@ -206,6 +196,37 @@ describe('DateModel', () => {
           recurrenceRule: null,
           startDate: DateTime.fromISO('2023-10-09T07:00:00.000+02:00'),
           endDate: DateTime.fromISO('2023-10-10T09:00:00.000+02:00'),
+        }),
+      ])
+    })
+
+    it('should correctly offset start and end times also over DST changes', () => {
+      const recurrenceRule = rrulestr('DTSTART:20240323T130000\nRRULE:FREQ=WEEKLY;BYDAY=MO;UNTIL=20250109T140000')
+      const date = new DateModel({
+        startDate: DateTime.fromISO('2024-01-09T14:00:00.000+01:00'),
+        endDate: DateTime.fromISO('2024-01-09T16:00:00.000+01:00'),
+        allDay: false,
+        recurrenceRule,
+      })
+
+      expect(date.recurrences(3)).toEqual([
+        new DateModel({
+          allDay: false,
+          recurrenceRule: null,
+          startDate: DateTime.fromISO('2024-03-25T14:00:00.000+01:00'),
+          endDate: DateTime.fromISO('2024-03-25T16:00:00.000+01:00'),
+        }),
+        new DateModel({
+          allDay: false,
+          recurrenceRule: null,
+          startDate: DateTime.fromISO('2024-04-01T14:00:00.000+02:00'),
+          endDate: DateTime.fromISO('2024-04-01T16:00:00.000+02:00'),
+        }),
+        new DateModel({
+          allDay: false,
+          recurrenceRule: null,
+          startDate: DateTime.fromISO('2024-04-08T14:00:00.000+02:00'),
+          endDate: DateTime.fromISO('2024-04-08T16:00:00.000+02:00'),
         }),
       ])
     })


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
Fix wrong event times by calculating offset difference from current date.

### Proposed changes

<!-- Describe this PR in more detail. -->

- Always store the start date from the CMS
- Only access start and end date of recurrences
- Invalidate offline content

### Explanation

The current problem was that we set the first recurrence as start date with an adjusted offset calculated from the start date. This adjusted start date is saved to the offline content. Next time we load a start date with already adjusted offset and adjust the offset again leading to wrong times.

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
The offline content will be deleted.

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2747.

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
