### PR TITLE
2719: Fix missing api declarations

### DIFF
--- a/native/ios/Integreat/Info.plist
+++ b/native/ios/Integreat/Info.plist
@@ -81,7 +81,7 @@
 				<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
 				<key>NSPrivacyAccessedAPITypeReasons</key>
 				<array>
-					<string>3B52.1</string>
+					<string>C617.1</string>
 				</array>
 			</dict>
 			<dict>


### PR DESCRIPTION
### Short description

Apple wants all  accessed apis to be declared

### Proposed changes

<!-- Describe this PR in more detail. -->

- add an array of values for the different api types according to docs. See additional info

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2719

### Testing
Please properly check if the reasons are fine. I'm not really sure about them.
Find information here:
https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api
