### PR TITLE
2674: Add accessibility declaration to the footer

### DIFF
--- a/build-configs/BuildConfigType.ts
+++ b/build-configs/BuildConfigType.ts
@@ -75,6 +75,11 @@ export type CommonBuildConfigType = {
     default: string
     [language: string]: string
   }
+  // Urls with (localized) accessibility information
+  accessibilityUrls?: {
+    default: string
+    [language: string]: string
+  }
 }
 // Available only on web
 export type WebBuildConfigType = CommonBuildConfigType & {

--- a/build-configs/integreat/index.ts
+++ b/build-configs/integreat/index.ts
@@ -47,6 +47,9 @@ const commonIntegreatBuildConfig: CommonBuildConfigType = {
     default: 'https://integreat-app.de/datenschutz/',
     en: 'https://integreat-app.de/en/privacy/',
   },
+  accessibilityUrls: {
+    default: 'https://integreat-app.de/barrierefreiheit/',
+  },
 }
 export const androidIntegreatBuildConfig: AndroidBuildConfigType = {
   ...commonIntegreatBuildConfig,

--- a/release-notes/unreleased/2674-add-accessibility-to-footer.yml
+++ b/release-notes/unreleased/2674-add-accessibility-to-footer.yml
@@ -1,0 +1,5 @@
+issue_key: 2674
+show_in_stores: false
+platforms:
+  - web
+en: There is now a link to the accessibility declaration in the footer

--- a/translations/translations.json
+++ b/translations/translations.json
@@ -5319,7 +5319,8 @@
       "shareFailDefaultMessage": "Das Teilen des Inhalts ist leider fehlgeschlagen.",
       "disclaimer": "Impressum",
       "sideBarOpenAriaLabel": "Seitenleiste öffnen",
-      "sideBarCloseAriaLabel": "Seitenleiste schließen"
+      "sideBarCloseAriaLabel": "Seitenleiste schließen",
+      "accessibility": "Barrierefreiheit"
     },
     "am": {
       "imprintAndContact": "ዕትም እና የግንኙነት መረጃ",
@@ -5494,7 +5495,8 @@
       "shareFailDefaultMessage": "Unfortunately an error occurred when sharing the content.",
       "disclaimer": "Imprint",
       "sideBarOpenAriaLabel": "Open sidebar",
-      "sideBarCloseAriaLabel": "Close sidebar"
+      "sideBarCloseAriaLabel": "Close sidebar",
+      "accessibility": "Accessibility"
     },
     "es": {
       "imprintAndContact": "Aviso legal y contacto",

--- a/web/src/components/CityContentFooter.tsx
+++ b/web/src/components/CityContentFooter.tsx
@@ -38,7 +38,7 @@ const CityContentFooter = ({ city, language, mode = 'normal' }: CityContentFoote
   const { t } = useTranslation(['layout', 'settings'])
   const aboutUrl = aboutUrls[language] || aboutUrls.default
   const privacyUrl = privacyUrls[language] || privacyUrls.default
-  const accessibilityUrl: string | undefined = accessibilityUrls?.[language] ?? accessibilityUrls?.default
+  const accessibilityUrl = accessibilityUrls?.[language] ?? accessibilityUrls?.default
   const disclaimerPath = pathnameFromRouteInformation({
     route: DISCLAIMER_ROUTE,
     cityCode: city,

--- a/web/src/components/CityContentFooter.tsx
+++ b/web/src/components/CityContentFooter.tsx
@@ -34,10 +34,11 @@ type CityContentFooterProps = {
 }
 
 const CityContentFooter = ({ city, language, mode = 'normal' }: CityContentFooterProps): ReactElement => {
-  const { aboutUrls, privacyUrls } = buildConfig()
+  const { aboutUrls, privacyUrls, accessibilityUrls } = buildConfig()
   const { t } = useTranslation(['layout', 'settings'])
   const aboutUrl = aboutUrls[language] || aboutUrls.default
   const privacyUrl = privacyUrls[language] || privacyUrls.default
+  const accessibilityUrl: string | undefined = accessibilityUrls?.[language] ?? accessibilityUrls?.default
   const disclaimerPath = pathnameFromRouteInformation({
     route: DISCLAIMER_ROUTE,
     cityCode: city,
@@ -53,6 +54,7 @@ const CityContentFooter = ({ city, language, mode = 'normal' }: CityContentFoote
       <CleanLink to={aboutUrl}>{t('settings:about', { appName: buildConfig().appName })}</CleanLink>
       <CleanLink to={privacyUrl}>{t('privacy')}</CleanLink>
       <CleanLink to={licensesPath}>{t('settings:openSourceLicenses')}</CleanLink>
+      {!!accessibilityUrl && <CleanLink to={accessibilityUrl}>{t('accessibility')}</CleanLink>}
     </>
   )
 

--- a/web/src/components/GeneralFooter.tsx
+++ b/web/src/components/GeneralFooter.tsx
@@ -13,11 +13,12 @@ type GeneralFooterProps = {
 }
 
 const GeneralFooter = ({ language }: GeneralFooterProps): ReactElement => {
-  const { aboutUrls, privacyUrls } = buildConfig()
+  const { aboutUrls, privacyUrls, accessibilityUrls } = buildConfig()
   const { t } = useTranslation('layout')
 
   const aboutUrl = aboutUrls[language] || aboutUrls.default
   const privacyUrl = privacyUrls[language] || privacyUrls.default
+  const accessibilityUrl: string | undefined = accessibilityUrls?.[language] ?? accessibilityUrls?.default
 
   return (
     <Footer>
@@ -25,6 +26,7 @@ const GeneralFooter = ({ language }: GeneralFooterProps): ReactElement => {
       <CleanLink to={aboutUrl}>{t('settings:about', { appName: buildConfig().appName })}</CleanLink>
       <CleanLink to={privacyUrl}>{t('privacy')}</CleanLink>
       <CleanLink to={RoutePatterns[LICENSES_ROUTE]}>{t('settings:openSourceLicenses')}</CleanLink>
+      {!!accessibilityUrl && <CleanLink to={accessibilityUrl}>{t('accessibility')}</CleanLink>}
     </Footer>
   )
 }

--- a/web/src/components/GeneralFooter.tsx
+++ b/web/src/components/GeneralFooter.tsx
@@ -18,7 +18,7 @@ const GeneralFooter = ({ language }: GeneralFooterProps): ReactElement => {
 
   const aboutUrl = aboutUrls[language] || aboutUrls.default
   const privacyUrl = privacyUrls[language] || privacyUrls.default
-  const accessibilityUrl: string | undefined = accessibilityUrls?.[language] ?? accessibilityUrls?.default
+  const accessibilityUrl = accessibilityUrls?.[language] ?? accessibilityUrls?.default
 
   return (
     <Footer>


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
Adding the accessibility declaration to the footer for Integreat.

### Proposed changes

<!-- Describe this PR in more detail. -->

- Adding the accessibility declaration to the build config for Integreat. We probably need a separate one for Aschaffenburg at some point, and Malte doesn't need one.

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2674 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
