### PR TITLE
2767: Fix text cut of proposal

### DIFF
--- a/native/src/components/CategoryListItem.tsx
+++ b/native/src/components/CategoryListItem.tsx
@@ -38,6 +38,7 @@ const CategoryTitle = styled.Text<{ language: string }>`
   flex-direction: ${props => contentDirection(props.language)};
   font-family: ${props => props.theme.fonts.native.decorativeFontBold};
   color: ${props => props.theme.colors.textColor};
+  flex-shrink: 1;
 `
 
 export const CategoryThumbnail = styled(SimpleImage)<{ language: string }>`

--- a/native/src/components/SearchListItem.tsx
+++ b/native/src/components/SearchListItem.tsx
@@ -42,6 +42,7 @@ const TitleDirectionContainer = styled.View<{ language: string }>`
 `
 
 const HighlighterCategoryTitle = styled(Highlighter)<{ language: string }>`
+  flex-shrink: 1;
   flex-direction: ${props => contentDirection(props.language)};
   font-family: ${props => props.theme.fonts.native.decorativeFontRegular};
   color: ${props => props.theme.colors.textColor};

--- a/native/src/components/SubCategoryListItem.tsx
+++ b/native/src/components/SubCategoryListItem.tsx
@@ -10,9 +10,8 @@ import Pressable from './base/Pressable'
 
 const FlexStyledLink = styled(Pressable)<{ language: string }>`
   display: flex;
-  flex-flow: row nowrap;
   flex-direction: ${props => contentDirection(props.language)};
-  margin: 8px 0 8px 24px;
+  margin-left: 24px;
   border-bottom-width: 1px;
   border-bottom-color: ${props => props.theme.colors.themeColor};
 `


### PR DESCRIPTION
### Short description
Removed the adjusted styles and added `flex-shrink:1` to the title container, because there is a `flex-shrink:0` on the category icon container. Same issue for the search item.
You can not tell one item in a row not to shrink and the other to increase. Thats the issue i think
Tested on android and ios

<img width="698" alt="image" src="https://github.com/digitalfabrik/integreat-app/assets/37902063/da9d7f06-1ce1-41d3-a659-11a6f1ebcda1">

<img width="740" alt="image" src="https://github.com/digitalfabrik/integreat-app/assets/37902063/27dcc871-7a5d-4b66-b95a-9811bab6bbd2">

