### PR TITLE
2767: Fix cut off texts in category list

### DIFF
--- a/native/src/components/CategoryListItem.tsx
+++ b/native/src/components/CategoryListItem.tsx
@@ -38,6 +38,7 @@ const CategoryTitle = styled.Text<{ language: string }>`
   flex-direction: ${props => contentDirection(props.language)};
   font-family: ${props => props.theme.fonts.native.decorativeFontBold};
   color: ${props => props.theme.colors.textColor};
+  flex-shrink: 1;
 `
 
 export const CategoryThumbnail = styled(SimpleImage)<{ language: string }>`

--- a/native/src/components/SearchListItem.tsx
+++ b/native/src/components/SearchListItem.tsx
@@ -46,6 +46,7 @@ const HighlighterCategoryTitle = styled(Highlighter)<{ language: string }>`
   font-family: ${props => props.theme.fonts.native.decorativeFontRegular};
   color: ${props => props.theme.colors.textColor};
   font-weight: bold;
+  flex-shrink: 1;
 `
 
 type SearchListItemProps = {
@@ -117,7 +118,7 @@ const SearchListItem = ({
       <DirectionContainer language={language}>
         <SearchEntryContainer>
           <TitleDirectionContainer language={language}>
-            <CategoryThumbnail language={language} source={thumbnail} resourceCache={resourceCache} />
+            {!!thumbnail && <CategoryThumbnail language={language} source={thumbnail} resourceCache={resourceCache} />}
             {Title}
           </TitleDirectionContainer>
           {Content}

--- a/native/src/components/SubCategoryListItem.tsx
+++ b/native/src/components/SubCategoryListItem.tsx
@@ -26,6 +26,7 @@ const FlexStyledLink = styled(Pressable)<{ language: string }>`
 const SubCategoryTitle = styled.Text`
   color: ${props => props.theme.colors.textColor};
   font-family: ${props => props.theme.fonts.native.decorativeFontRegular};
+  flex-shrink: 1;
 `
 
 type SubCategoryListItemProps = {

--- a/release-notes/unreleased/2767-cut-off-text.yml
+++ b/release-notes/unreleased/2767-cut-off-text.yml
@@ -1,0 +1,7 @@
+issue_key: 2767
+show_in_stores: true
+platforms:
+  - android
+  - ios
+en: Fix cut off text in categories list and the search.
+de: Abgeschnittene Texte in der Kategorienliste und der Suche behoben.


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
Fix cut off texts in category list. Both #2769 and #2771 did not work for me/broke some other styling. This PR should resolve all those problems with minimal changes.

### Proposed changes

<!-- Describe this PR in more detail. -->

- Remove unused thumbnail for SubCategoryListItem
- Set `flex-shrink: 1` on `CategoryListTitle` to fix wrapping

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

None.

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2767.

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
