### PR TITLE
2739: Fix e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,14 +146,16 @@ commands:
         steps:
             - restore_cache:
                 keys:
-                    - 3-gems-{{ arch }}-{{ checksum "<< parameters.directory >>/Gemfile.lock" }}
-                    - 3-gems-{{ arch }}-
+                    - 4-gems-{{ arch }}-{{ checksum "<< parameters.directory >>/Gemfile.lock" }}
+                    - 4-gems-{{ arch }}-
+                name: Restore Ruby Cache
             - run:
                 command: bundle check || bundle install
                 name: '[FL] install'
                 working_directory: << parameters.directory >>
             - save_cache:
-                key: 3-gems-{{ arch }}-{{ checksum "<< parameters.directory >>/Gemfile.lock" }}
+                key: 4-gems-{{ arch }}-{{ checksum "<< parameters.directory >>/Gemfile.lock" }}
+                name: Save Ruby Cache
                 paths:
                     - << parameters.directory >>/vendor/bundle
     restore_yarn_cache:
@@ -701,7 +703,7 @@ jobs:
             - notify
     e2e_android:
         docker:
-            - image: cimg/node:20.12.2
+            - image: cimg/android:2024.04.1-node
         environment:
             FASTLANE_SKIP_UPDATE_CHECK: true
         resource_class: small
@@ -720,7 +722,7 @@ jobs:
             - notify
     e2e_ios:
         docker:
-            - image: cimg/node:20.12.2
+            - image: cimg/android:2024.04.1-node
         environment:
             FASTLANE_SKIP_UPDATE_CHECK: true
         resource_class: small

--- a/.circleci/src/commands/restore_ruby_cache.yml
+++ b/.circleci/src/commands/restore_ruby_cache.yml
@@ -5,14 +5,16 @@ parameters:
     default: native
 steps:
   - restore_cache:
+      name: Restore Ruby Cache
       keys:
-        - 3-gems-{{ arch }}-{{ checksum "<< parameters.directory >>/Gemfile.lock" }}
-        - 3-gems-{{ arch }}-
+        - 4-gems-{{ arch }}-{{ checksum "<< parameters.directory >>/Gemfile.lock" }}
+        - 4-gems-{{ arch }}-
   - run:
       name: '[FL] install'
       command: bundle check || bundle install
       working_directory: << parameters.directory >>
   - save_cache:
-      key: 3-gems-{{ arch }}-{{ checksum "<< parameters.directory >>/Gemfile.lock" }}
+      name: Save Ruby Cache
+      key: 4-gems-{{ arch }}-{{ checksum "<< parameters.directory >>/Gemfile.lock" }}
       paths:
         - << parameters.directory >>/vendor/bundle

--- a/.circleci/src/jobs/e2e_android.yml
+++ b/.circleci/src/jobs/e2e_android.yml
@@ -1,5 +1,7 @@
 docker:
-  - image: cimg/node:20.12.2
+  # Ruby and bundler are necessary to run e2e tests
+  # Using cimg/ruby leads to the following error: /usr/bin/env: ‘ruby3.0’: No such file or directory
+  - image: cimg/android:2024.04.1-node
 resource_class: small
 shell: /bin/bash -eo pipefail
 environment:

--- a/.circleci/src/jobs/e2e_ios.yml
+++ b/.circleci/src/jobs/e2e_ios.yml
@@ -1,5 +1,7 @@
 docker:
-  - image: cimg/node:20.12.2
+  # Ruby and bundler are necessary to run e2e tests
+  # Using cimg/ruby leads to the following error: /usr/bin/env: ‘ruby3.0’: No such file or directory
+  - image: cimg/android:2024.04.1-node
 resource_class: small
 shell: /bin/bash -eo pipefail
 environment:


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
Fix execution of e2e tests in CI by using image including ruby and ruby bundler.

### Proposed changes

<!-- Describe this PR in more detail. -->

In #2772 I upgraded/changed the used images in the e2e-android and e2e-ios jobs to just plain node ones (before it was cimg/android). Since neither are the right choice (android including unnecessary stuff and being confusing, node not including ruby and ruby bundler), I changed the used images to cimg/ruby. 

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

None.

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: None.

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
