### PR TITLE
2767: Fix cut off search results

### DIFF
--- a/native/src/components/SearchListItem.tsx
+++ b/native/src/components/SearchListItem.tsx
@@ -37,7 +37,7 @@ const SearchEntryContainer = styled.View`
 `
 
 const TitleDirectionContainer = styled.View<{ language: string }>`
-  flex-direction: ${props => contentDirection(props.language)};
+  flex-flow: ${props => contentDirection(props.language)} wrap;
   align-items: center;
 `
 
@@ -117,7 +117,7 @@ const SearchListItem = ({
       <DirectionContainer language={language}>
         <SearchEntryContainer>
           <TitleDirectionContainer language={language}>
-            <CategoryThumbnail language={language} source={thumbnail} resourceCache={resourceCache} />
+            {!!thumbnail && <CategoryThumbnail language={language} source={thumbnail} resourceCache={resourceCache} />}
             {Title}
           </TitleDirectionContainer>
           {Content}


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
I wanted to join the club and also open a PR for this.

No, seriously, none of the other fixes worked for me and I solved it very differently so I decided to go with a new branch.

### Proposed changes

<!-- Describe this PR in more detail. -->

- Only block space for the thumbnail in the search results if there is one
- Set the container to wrap around

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be none

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2767 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
