### PR TITLE
2588: Fix failing iOS delivery

### DIFF
--- a/native/Gemfile
+++ b/native/Gemfile
@@ -2,8 +2,11 @@
 
 source "https://rubygems.org"
 
-gem "fastlane", ">= 2.216.0"
+# Needed for CirleCI macos images
+# https://github.com/fastlane/fastlane/issues/21794#issuecomment-2021331335
+gem "rb-readline"
 
+gem "fastlane", ">= 2.216.0"
 gem "octokit", "~> 4.18"
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
Fix failing iOS delivery.

### Proposed changes

<!-- Describe this PR in more detail. -->

Add gem `rb-readline` to fix error during delivery on macos image.

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

None.

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: None.

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
