### PR TITLE
Add native module for reading high contrast

### DIFF
--- a/native/.idea/misc.xml
+++ b/native/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_20" project-jdk-name="11 (2)" project-jdk-type="JavaSDK" />
+</project>

--- a/native/android/app/src/main/java/tuerantuer/app/integreat/IntegreatPackage.java
+++ b/native/android/app/src/main/java/tuerantuer/app/integreat/IntegreatPackage.java
@@ -6,6 +6,7 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
 import tuerantuer.app.integreat.constants.NativeConstantsModule;
 import tuerantuer.app.integreat.fetcher.FetcherModule;
+import tuerantuer.app.integreat.fetcher.HighContrastModule;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -23,6 +24,7 @@ public class IntegreatPackage implements ReactPackage {
         List<NativeModule> modules = new ArrayList<>();
         modules.add(new FetcherModule(reactContext));
         modules.add(new NativeConstantsModule(reactContext));
+        modules.add(new HighContrastModule(reactContext));
         return modules;
     }
 }

--- a/native/android/app/src/main/java/tuerantuer/app/integreat/fetcher/HighContrastModule.java
+++ b/native/android/app/src/main/java/tuerantuer/app/integreat/fetcher/HighContrastModule.java
@@ -1,0 +1,55 @@
+package tuerantuer.app.integreat.fetcher;
+
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import android.util.Log;
+import android.content.Context;
+import android.view.accessibility.AccessibilityManager;
+import com.facebook.react.bridge.Promise;
+
+import java.lang.reflect.Method;
+
+
+public class HighContrastModule extends ReactContextBaseJavaModule {
+    public HighContrastModule(ReactApplicationContext context) {
+        super(context);
+    }
+
+    @Override
+    public String getName() {
+        return "HighContrastModule";
+    }
+
+    @ReactMethod
+    public void isHighContrastMode(final Promise promise) {
+        ReactApplicationContext reactContext = getReactApplicationContext();
+        AccessibilityManager accessibilityManager = (AccessibilityManager) reactContext.getSystemService(Context.ACCESSIBILITY_SERVICE);
+        Class<?> accessibilityManagerClass = accessibilityManager.getClass();
+
+        Method isHighTextContrastEnabledMethod = null;
+        try {
+            isHighTextContrastEnabledMethod = accessibilityManagerClass.getMethod("isHighTextContrastEnabled");
+        } catch (NoSuchMethodException e) {
+            e.printStackTrace();
+            promise.reject("Method not found");
+        }
+
+        if (isHighTextContrastEnabledMethod != null) {
+            boolean result = true;
+            try {
+                result = (boolean) isHighTextContrastEnabledMethod.invoke(accessibilityManager);
+            } catch (Exception e) {
+                e.printStackTrace();
+                promise.reject("Method call failed");
+            }
+            promise.resolve(result);
+        } else {
+            promise.reject("Method not found");
+        }
+        promise.resolve(1);
+    }
+
+}

--- a/native/src/App.tsx
+++ b/native/src/App.tsx
@@ -24,6 +24,7 @@ import buildConfig from './constants/buildConfig'
 import { userAgent } from './constants/endpoint'
 import AppContextProvider from './contexts/AppContextProvider'
 import useSendOfflineJpalSignals from './hooks/useSendOfflineJpalSignals'
+import { isHighContrastModeEnabled } from './utils/HighContrastMode'
 import { backgroundAppStatePushNotificationListener } from './utils/PushNotificationsManager'
 import sendTrackingSignal from './utils/sendTrackingSignal'
 

--- a/native/src/utils/HighContrastMode.ts
+++ b/native/src/utils/HighContrastMode.ts
@@ -1,0 +1,7 @@
+import { NativeModules } from 'react-native'
+
+export const isHighContrastModeEnabled = async (): Promise<boolean> => {
+  const { HighContrastModule } = NativeModules
+
+  return HighContrastModule.isHighContrastMode()
+}


### PR DESCRIPTION
### Short description
Introduced a native module to use the Android function to read if high contrast is set.

### Proposed changes
- Added the Native module
- Use [this](https://android.googlesource.com/platform/frameworks/base/+/a4725ef/core/java/android/view/accessibility/AccessibilityManager.java#303) Android function
- React native rejected the issue to add this function to the native modules [here](https://github.com/facebook/react-native/issues/30869)

This is just one solution, we can discuss if this PR is even what we want. Not tested for ios / No handling for ios yet. No tests or cleanup. Will do if we decide, we want to do it this way.
