### PR TITLE
2726: Refactor useUserLocation and show snackbar if permissions blocked

### DIFF
--- a/native/package.json
+++ b/native/package.json
@@ -86,7 +86,6 @@
     "react-native-safe-area-context": "^4.9.0",
     "react-native-screens": "^3.30.1",
     "react-native-svg": "^15.1.0",
-    "react-native-system-setting": "^1.7.6",
     "react-native-url-polyfill": "^2.0.0",
     "react-native-webview": "^13.8.6",
     "react-navigation-header-buttons": "^11.2.1",

--- a/native/src/components/MapView.tsx
+++ b/native/src/components/MapView.tsx
@@ -90,7 +90,7 @@ const MapView = ({
   const cameraRef = useRef<MapLibreGL.Camera>(null)
   const mapRef = useRef<MapLibreGL.MapView>(null)
   const [followUserLocation, setFollowUserLocation] = useState<boolean>(false)
-  const { requestAndDetermineLocation } = useUserLocation()
+  const { refreshPermissionAndLocation } = useUserLocation({ requestPermissionInitially: true })
   const { t } = useTranslation('pois')
   const theme = useTheme()
 
@@ -119,12 +119,12 @@ const MapView = ({
   )
 
   const onRequestLocation = useCallback(async () => {
-    await requestAndDetermineLocation()
     if (userLocation) {
       moveTo(userLocation)
       setFollowUserLocation(true)
     }
-  }, [moveTo, requestAndDetermineLocation, userLocation])
+    await refreshPermissionAndLocation()
+  }, [refreshPermissionAndLocation, moveTo, userLocation])
 
   useEffect(() => {
     if (selectedFeature) {

--- a/native/src/components/NearbyCities.tsx
+++ b/native/src/components/NearbyCities.tsx
@@ -37,8 +37,9 @@ type NearbyCitiesProps = {
 }
 
 const NearbyCities = ({ cities, navigateToDashboard, filterText }: NearbyCitiesProps): ReactElement => {
-  const locationInformation = useUserLocation()
-  const { status, coordinates, message, requestAndDetermineLocation } = locationInformation
+  const { status, coordinates, message, refreshPermissionAndLocation } = useUserLocation({
+    requestPermissionInitially: false,
+  })
   const { t } = useTranslation('landing')
 
   if (!coordinates) {
@@ -49,7 +50,7 @@ const NearbyCities = ({ cities, navigateToDashboard, filterText }: NearbyCitiesP
           {status !== 'loading' && (
             <IconButton
               icon={<StyledIcon Icon={RefreshIcon} />}
-              onPress={requestAndDetermineLocation}
+              onPress={refreshPermissionAndLocation}
               accessibilityLabel={t('refresh')}
             />
           )}

--- a/native/src/hooks/__tests__/useUserLocation.spec.tsx
+++ b/native/src/hooks/__tests__/useUserLocation.spec.tsx
@@ -1,0 +1,197 @@
+import Geolocation, { GeolocationError, GeolocationResponse } from '@react-native-community/geolocation'
+import { fireEvent, waitFor } from '@testing-library/react-native'
+import { mocked } from 'jest-mock'
+import React from 'react'
+import { Button, Text, View } from 'react-native'
+import { check, openSettings, PERMISSIONS, request, RESULTS } from 'react-native-permissions'
+
+import render from '../../testing/render'
+import useSnackbar from '../useSnackbar'
+import useUserLocation from '../useUserLocation'
+
+const augsburgCoordinates = {
+  coords: {
+    latitude: 48.369696,
+    longitude: 10.892578,
+    altitude: null,
+    accuracy: 1,
+    altitudeAccuracy: null,
+    heading: null,
+    speed: null,
+  },
+  timestamp: 1234566789,
+}
+
+jest.mock('@react-native-community/geolocation', () => ({
+  getCurrentPosition: jest.fn((setPosition: (position: GeolocationResponse) => void) =>
+    setPosition(augsburgCoordinates),
+  ),
+}))
+jest.mock('react-i18next')
+jest.mock('../../hooks/useSnackbar')
+
+const mockCheckPermission = mocked(check)
+const mockRequestPermission = mocked(request)
+const mockGetCurrentPosition = mocked(Geolocation.getCurrentPosition)
+
+describe('useUserLocation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  const showSnackbar = jest.fn()
+  mocked(useSnackbar).mockImplementation(() => showSnackbar)
+
+  const MockComponent = ({ requestPermissionInitially = false }: { requestPermissionInitially: boolean }) => {
+    const { message, coordinates, refreshPermissionAndLocation } = useUserLocation({ requestPermissionInitially })
+    return (
+      <View>
+        <Text>{message}</Text>
+        <Text>longitude: {coordinates?.[0]}</Text>
+        <Text>latitude: {coordinates?.[1]}</Text>
+        <Button title='refresh w. request and snackbar' onPress={() => refreshPermissionAndLocation()} />
+        <Button
+          title='refresh w. request'
+          onPress={() => refreshPermissionAndLocation({ showSnackbarIfBlocked: false })}
+        />
+        <Button
+          title='refresh'
+          onPress={() => {
+            refreshPermissionAndLocation({ requestPermission: false, showSnackbarIfBlocked: false })
+          }}
+        />
+      </View>
+    )
+  }
+
+  const renderMockComponent = (requestPermissionInitially = false) =>
+    render(<MockComponent requestPermissionInitially={requestPermissionInitially} />)
+
+  it('should request permissions initially and get current position', async () => {
+    mockRequestPermission.mockImplementationOnce(async () => RESULTS.GRANTED)
+    const { getByText } = renderMockComponent(true)
+    await waitFor(() => expect(getByText(`longitude: ${augsburgCoordinates.coords.longitude}`)).toBeTruthy())
+    expect(getByText(`latitude: ${augsburgCoordinates.coords.latitude}`)).toBeTruthy()
+    expect(mockRequestPermission).toHaveBeenCalledTimes(1)
+    expect(mockRequestPermission).toHaveBeenCalledWith(PERMISSIONS.IOS.LOCATION_WHEN_IN_USE)
+    expect(mockGetCurrentPosition).toHaveBeenCalledTimes(1)
+    expect(mockCheckPermission).not.toHaveBeenCalled()
+  })
+
+  it('should request permissions initially and not show snackbar if blocked', async () => {
+    mockRequestPermission.mockImplementationOnce(async () => RESULTS.BLOCKED)
+    const { getByText } = renderMockComponent(true)
+    await waitFor(() => expect(getByText('noPermission')).toBeTruthy())
+    expect(mockRequestPermission).toHaveBeenCalledTimes(1)
+    expect(mockRequestPermission).toHaveBeenCalledWith(PERMISSIONS.IOS.LOCATION_WHEN_IN_USE)
+    expect(mockGetCurrentPosition).not.toHaveBeenCalled()
+    expect(mockCheckPermission).not.toHaveBeenCalled()
+    expect(showSnackbar).not.toHaveBeenCalled()
+  })
+
+  it('should only check permissions if requestPermissionInitially is set to false', async () => {
+    mockCheckPermission.mockImplementationOnce(async () => RESULTS.BLOCKED)
+    const { getByText } = renderMockComponent(false)
+    await waitFor(() => expect(getByText('noPermission')).toBeTruthy())
+    expect(mockCheckPermission).toHaveBeenCalledTimes(1)
+    expect(mockCheckPermission).toHaveBeenCalledWith(PERMISSIONS.IOS.LOCATION_WHEN_IN_USE)
+    expect(mockGetCurrentPosition).not.toHaveBeenCalled()
+    expect(mockRequestPermission).not.toHaveBeenCalled()
+    expect(showSnackbar).not.toHaveBeenCalled()
+  })
+
+  it('should correctly handle errors during getCurrentPosition', async () => {
+    mockRequestPermission.mockImplementationOnce(async () => RESULTS.GRANTED)
+    mockGetCurrentPosition.mockImplementationOnce(
+      (_: (position: GeolocationResponse) => void, setError: ((error: GeolocationError) => void) | undefined) =>
+        setError &&
+        setError({ code: 2, message: 'timeout', POSITION_UNAVAILABLE: 0, PERMISSION_DENIED: 1, TIMEOUT: 2 }),
+    )
+    const { getByText } = renderMockComponent(true)
+    await waitFor(() => expect(getByText('timeout')).toBeTruthy())
+    expect(mockRequestPermission).toHaveBeenCalledTimes(1)
+    expect(mockRequestPermission).toHaveBeenCalledWith(PERMISSIONS.IOS.LOCATION_WHEN_IN_USE)
+    expect(mockGetCurrentPosition).toHaveBeenCalledTimes(1)
+    expect(mockCheckPermission).not.toHaveBeenCalled()
+  })
+
+  it('should refresh current location', async () => {
+    mockRequestPermission.mockImplementationOnce(async () => RESULTS.GRANTED)
+    const { getByText } = renderMockComponent(true)
+    await waitFor(() => expect(getByText(`longitude: ${augsburgCoordinates.coords.longitude}`)).toBeTruthy())
+    expect(getByText(`latitude: ${augsburgCoordinates.coords.latitude}`)).toBeTruthy()
+
+    mockGetCurrentPosition.mockImplementationOnce((setPosition: (position: GeolocationResponse) => void) =>
+      setPosition({ ...augsburgCoordinates, coords: { ...augsburgCoordinates.coords, longitude: 0, latitude: 0 } }),
+    )
+    fireEvent.press(getByText('refresh'))
+
+    await waitFor(() => expect(getByText(`longitude: 0`)).toBeTruthy())
+    expect(getByText(`latitude: 0`)).toBeTruthy()
+
+    mockGetCurrentPosition.mockImplementationOnce(
+      (_: (position: GeolocationResponse) => void, setError: ((error: GeolocationError) => void) | undefined) =>
+        setError &&
+        setError({ code: 2, message: 'timeout', POSITION_UNAVAILABLE: 0, PERMISSION_DENIED: 1, TIMEOUT: 2 }),
+    )
+    fireEvent.press(getByText('refresh'))
+
+    await waitFor(() => expect(getByText('timeout')).toBeTruthy())
+  })
+
+  it('should show snackbar if permission blocked', async () => {
+    mockRequestPermission.mockImplementationOnce(async () => RESULTS.BLOCKED)
+    const { getByText } = renderMockComponent(true)
+    await waitFor(() => expect(getByText('noPermission')).toBeTruthy())
+
+    mockRequestPermission.mockImplementationOnce(async () => RESULTS.BLOCKED)
+    fireEvent.press(getByText('refresh w. request and snackbar'))
+    expect(getByText('loading')).toBeTruthy()
+    await waitFor(() => expect(getByText('noPermission')).toBeTruthy())
+
+    expect(mockRequestPermission).toHaveBeenCalledTimes(2)
+    expect(showSnackbar).toHaveBeenCalledTimes(1)
+    expect(showSnackbar).toHaveBeenCalledWith({
+      positiveAction: {
+        label: 'layout:settings',
+        onPress: openSettings,
+      },
+      text: 'landing:noPermission',
+    })
+
+    expect(mockGetCurrentPosition).not.toHaveBeenCalled()
+    expect(mockCheckPermission).not.toHaveBeenCalled()
+  })
+
+  it('should not show snackbar if permission blocked', async () => {
+    mockRequestPermission.mockImplementationOnce(async () => RESULTS.BLOCKED)
+    const { getByText } = renderMockComponent(true)
+    await waitFor(() => expect(getByText('noPermission')).toBeTruthy())
+
+    mockRequestPermission.mockImplementationOnce(async () => RESULTS.BLOCKED)
+    fireEvent.press(getByText('refresh w. request'))
+    expect(getByText('loading')).toBeTruthy()
+    await waitFor(() => expect(getByText('noPermission')).toBeTruthy())
+
+    expect(mockRequestPermission).toHaveBeenCalledTimes(2)
+    expect(showSnackbar).not.toHaveBeenCalled()
+    expect(mockGetCurrentPosition).not.toHaveBeenCalled()
+    expect(mockCheckPermission).not.toHaveBeenCalled()
+  })
+
+  it('should request permission if initially denied', async () => {
+    mockCheckPermission.mockImplementationOnce(async () => RESULTS.DENIED)
+    const { getByText } = renderMockComponent(false)
+    await waitFor(() => expect(getByText('noPermission')).toBeTruthy())
+    expect(mockCheckPermission).toHaveBeenCalledTimes(1)
+    expect(mockRequestPermission).not.toHaveBeenCalled()
+
+    mockRequestPermission.mockImplementationOnce(async () => RESULTS.GRANTED)
+    fireEvent.press(getByText('refresh w. request'))
+
+    await waitFor(() => expect(getByText(`longitude: ${augsburgCoordinates.coords.longitude}`)).toBeTruthy())
+    expect(getByText(`latitude: ${augsburgCoordinates.coords.latitude}`)).toBeTruthy()
+    expect(mockCheckPermission).toHaveBeenCalledTimes(1)
+    expect(mockRequestPermission).toHaveBeenCalledTimes(1)
+  })
+})

--- a/native/src/utils/LocationPermissionManager.ts
+++ b/native/src/utils/LocationPermissionManager.ts
@@ -1,9 +1,0 @@
-import { Platform } from 'react-native'
-import { check, PERMISSIONS, request } from 'react-native-permissions'
-import type { PermissionStatus } from 'react-native-permissions'
-
-export const checkLocationPermission = async (): Promise<PermissionStatus> =>
-  check(Platform.OS === 'ios' ? PERMISSIONS.IOS.LOCATION_WHEN_IN_USE : PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION)
-
-export const requestLocationPermission = async (): Promise<PermissionStatus> =>
-  request(Platform.OS === 'ios' ? PERMISSIONS.IOS.LOCATION_WHEN_IN_USE : PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION)

--- a/release-notes/unreleased/2726-open-settings-geolocation.yml
+++ b/release-notes/unreleased/2726-open-settings-geolocation.yml
@@ -1,0 +1,7 @@
+issue_key: 2726
+show_in_stores: true
+platforms:
+  - android
+  - ios
+en: Open settings if location permissions are not granted.
+de: Die Einstellungen werden nun geöffnet wenn der Standort-Zugriff nicht erlaubt ist.

--- a/yarn.lock
+++ b/yarn.lock
@@ -12748,11 +12748,6 @@ react-native-svg@^15.1.0:
     css-select "^5.1.0"
     css-tree "^1.1.3"
 
-react-native-system-setting@^1.7.6:
-  version "1.7.6"
-  resolved "https://registry.yarnpkg.com/react-native-system-setting/-/react-native-system-setting-1.7.6.tgz#43633604ac1bd5fd906acdbffa627a1998d2345a"
-  integrity sha512-nBnIK5Xnyu8XRRA3BMzRI54oYlSBKc0oOTQdZOCEeOvn4ltS1nk2shj/vtMQe6khXvuhai3vIc+g7DcsOcr5+w==
-
 react-native-url-polyfill@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/react-native-url-polyfill/-/react-native-url-polyfill-2.0.0.tgz#db714520a2985cff1d50ab2e66279b9f91ffd589"


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
This PR fixes the bug that nothing is happening on pressing the geolocation button in the maps view if permissions are blocked.

### Proposed changes

<!-- Describe this PR in more detail. -->

- Open settings if permissions are blocked and user actively presses geolocation icon
- Refactor useUserLocation

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

None.

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2726.

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
