### PR TITLE
Make nginx server side includes compatible with CMS

### DIFF
--- a/web/src/index.ejs
+++ b/web/src/index.ejs
@@ -1,20 +1,20 @@
 <!doctype html>
-<html lang="">
-<head>
-    <meta charset="utf-8">
-    <meta http-equiv="x-ua-compatible" content="ie=edge">
 
-    <!-- Nginx Server Side Include template for dynamic social media previews -->
-    <!--# if expr="$render_title = yes" -->
-    <!--# include virtual="/proxy/socialmeta/$request_uri" -->
-    <!--# else -->
-    <!-- Default tags for a prettier social media preview, will be overwritten in Helmet.tsx for most pages. -->
+<!-- Nginx Server Side Include template for dynamic social media previews -->
+<!--# if expr="$render_title = yes" -->
+<!--# include virtual="/proxy/socialmeta/$request_uri" -->
+<!--# else -->
+<html lang="">
+    <head>
     <title><%= config.appName %></title>
     <meta name="apple-mobile-web-app-title" content="<%= config.appName %>">
     <meta property="og:title" content="<%= config.appName %>" data-react-helmet="true">
     <meta property="og:site_name" content="<%= config.hostName %>">
     <meta name="twitter:title" content="<%= config.appName %>">
-    <!--# endif -->
+<!--# endif -->
+
+    <meta charset="utf-8">
+    <meta http-equiv="x-ua-compatible" content="ie=edge">
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <% if (config.manifestUrl) { %>


### PR DESCRIPTION


### Short description

<!-- Describe this PR in one or two sentences. -->
In https://github.com/digitalfabrik/integreat-cms/pull/2391, I suggested to return a partial HTML response to be able to localize the `lang` attribute of the root `html`tag, e.g.:

```
<html lang="de-DE">
    <head>
        <title>Willkommen - Augsburg | Integreat</title>
        <meta name="apple-mobile-web-app-title" content="Willkommen - Augsburg | Integreat">
        <meta name="twitter:title " content="Willkommen - Augsburg | Integreat">
        <meta name="twitter:card" content="summary">
        <meta property="og:title" content="Willkommen - Augsburg | Integreat">
        
            <meta property="og:description" content="Willkommen in Augsburg">
            <meta name="twitter:description" content="Willkommen in Augsburg">
        
        <meta property="og:image" content="http://localhost:8000/static/logos/integreat/social-media-preview.png" />
        <meta property="og:image:width" content="1200" />
        <meta property="og:image:height" content="630" />
        <meta property="og:url" content="https://integreat.app/augsburg/de/willkommen/" />

```



### Proposed changes
To equalize this, we have to move these tags into the `<!--# else -->` case of the include.

### Linked issues

<!-- List all issues which should be closed when this PR is merged. -->

https://github.com/digitalfabrik/integreat-cms/issues/2084
https://openproject.tuerantuer.org/projects/infra/work_packages/222/

---
