### PR TITLE
2801: Remove shadow in header on mobile

### DIFF
--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -57,12 +57,6 @@ const Row = styled.div`
     min-height: ${dimensions.headerHeightSmall}px;
     overflow-x: auto;
     padding: 8px 0;
-    box-shadow: 0 2px 5px -3px rgb(0 0 0 / 20%);
-
-    :first-child {
-      box-shadow: 0 2px 5px -3px rgb(0 0 0 / 12%);
-      padding: 0 4px;
-    }
   }
 `
 


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
Remove the shadow in the header on mobile (web).

### Proposed changes

<!-- Describe this PR in more detail. -->

Remove shadow and padding for header and first children on mobile web.


### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
Less padding between the icons (but imo not needed).

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2801.

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
