### PR TITLE
2686: Implement dynamic padding bottom for page details

### DIFF
--- a/web/src/routes/EventsPage.tsx
+++ b/web/src/routes/EventsPage.tsx
@@ -1,3 +1,4 @@
+import { DateTime } from 'luxon'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate, useParams } from 'react-router-dom'
@@ -24,10 +25,11 @@ import { cmsApiBaseUrl } from '../constants/urls'
 import usePreviousProp from '../hooks/usePreviousProp'
 import featuredImageToSrcSet from '../utils/featuredImageToSrcSet'
 
-const Spacing = styled.div`
+const Spacing = styled.div<{ $content: string; $lastUpdate?: DateTime }>`
   display: flex;
   flex-direction: column;
   padding-top: 12px;
+  padding-bottom: ${props => (props.$content.length > 0 && props.$lastUpdate ? '0px' : '12px')};
   gap: 8px;
 `
 
@@ -118,7 +120,7 @@ const EventsPage = ({ city, pathname, languageCode, cityCode }: CityRouteProps):
           title={title}
           onInternalLinkClick={navigate}
           BeforeContent={
-            <Spacing>
+            <Spacing $content={content} $lastUpdate={lastUpdate}>
               <DatesPageDetail date={date} languageCode={languageCode} />
               {location && <PageDetail identifier={t('address')} information={location.fullAddress} />}
             </Spacing>


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->

Implemented dynamic padding for page details `Spacing` component

### Proposed changes

<!-- Describe this PR in more detail. -->

- Added `content` and `lastUpdate` props to `Spacing` component
- `Spacing` now renders padding based on props above

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

-
-

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2686 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
