### PR TITLE
2845: Fix tooltip

### DIFF
--- a/web/src/components/Tooltip.tsx
+++ b/web/src/components/Tooltip.tsx
@@ -290,7 +290,7 @@ export default ({
       trigger={trigger}
       mediumViewportFlow={fixedMediumFlow}
       smallViewportFlow={fixedSmallFlow}>
-      {children}
+      <div>{children}</div>
     </TooltipContainer>
   )
 }


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
The tooltip hover wasn't working anymore in the events list and the language switcher. The hover needs to have a parent element that is being hovered over to then show the newly visible tooltip. I added one into the `Tooltip` so that we don't need to necessarily add one around the implementations.

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2845 


