### PR TITLE
Fix annoying iOS 'progress' listener warning

### DIFF
--- a/native/ios/Integreat/fetcher/FetchResultCollector.swift
+++ b/native/ios/Integreat/fetcher/FetchResultCollector.swift
@@ -4,17 +4,19 @@ import os
 class FetchResultCollector {
   var fetchResults = [String : FetchResult]()
   var resultQueue = DispatchQueue(label: "FetchResultQueue")
-  
+
   var emitter: RCTEventEmitter
   var resolve: RCTPromiseResolveBlock
   var reject: RCTPromiseRejectBlock
   var expectedFetchCount: Int
-  
+  var hasListeners: Bool
+
   init(emitter: RCTEventEmitter, expectedFetchCount: Int, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
     self.emitter = emitter
     self.resolve = resolve
     self.reject = reject
     self.expectedFetchCount = expectedFetchCount
+    self.hasListeners = false
   }
 
   func failed(url: String, targetFile: URL, message: String) {
@@ -27,11 +29,11 @@ class FetchResultCollector {
       self.tryToResolve()
     }
   }
-  
+
   func fetched(url: String, targetFile: URL) {
     success(url: url, targetFile: targetFile, alreadyExisted: false);
   }
-  
+
   func alreadyExists(url: String, targetFile: URL) {
     success(url: url, targetFile: targetFile, alreadyExisted: true);
   }
@@ -39,47 +41,59 @@ class FetchResultCollector {
   func success(url: String, targetFile: URL, alreadyExisted: Bool) {
     resultQueue.async {
       self.fetchResults[targetFile.path] = FetchResult(url: url, lastUpdate: Date(),alreadyExisted: alreadyExisted, errorMessage: nil)
-      
+
       os_log("[%d/%d] Downloaded a file: %s", type: .info, self.currentFetchCount(), self.expectedFetchCount, url);
-      
+
       self.sendProgress();
       self.tryToResolve();
     }
   }
-  
+
   func currentFetchCount() -> Int {
     return fetchResults.count
   }
-  
+
   func tryToResolve() {
     if (currentFetchCount() != expectedFetchCount) {
       return;
     }
-    
+
     var resolveValue = [String : [String : String]]()
-    
+
     for (filePath, result) in fetchResults {
       var fetchResult = [String : String]()
       let dateTime = result.lastUpdate
-      
+
       fetchResult["url"] = result.url
-      
+
       if (result.alreadyExisted) {
         fetchResult["lastUpdate"] = dateTime.iso8601
       }
-      
+
       if (result.errorMessage != nil) {
         fetchResult["errorMessage"] = result.errorMessage
       }
-      
+
       resolveValue[filePath] = fetchResult
     }
-    
+
     os_log("Resolving promise", type: .info)
     resolve(resolveValue)
   }
-  
+
+  // Will be called when this module's first listener is added.
+  func startObserving() {
+    hasListeners = true;
+  }
+
+  // Will be called when this module's last listener is removed, or on dealloc.
+  func stopObserving() {
+    hasListeners = false;
+  }
+
   func sendProgress() {
-    emitter.sendEvent(withName: "progress", body: Double(fetchResults.count) / Double(expectedFetchCount))
+    if (hasListeners) {
+      emitter.sendEvent(withName: "progress", body: Double(fetchResults.count) / Double(expectedFetchCount))
+    }
   }
 }


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
In the iOS emulator, particularly when in Testumgebung, I keep getting lots of the console warning "Sending 'progress' with no listeners registered". This is pretty annoying when trying to use the console for debugging.

According to https://reactnative.dev/docs/native-modules-ios#sending-events-to-javascript, we shouldn't be emitting events at all if no listeners for those events are registered, so I followed that advice.

<img width="369" alt="image" src="https://github.com/user-attachments/assets/f284a4ea-b30c-4309-bb23-33745f286b76">
