### PR TITLE
2856: poi filter is too long for display and no scrolling available

### DIFF
--- a/native/src/components/Modal.tsx
+++ b/native/src/components/Modal.tsx
@@ -50,7 +50,7 @@ const Modal = ({
         <HeaderBox goBack={closeModal} text={headerTitle} />
       </Header>
       {scrollView ? (
-        <ScrollContent contentContainerStyle={{ flex: 1 }}>
+        <ScrollContent contentContainerStyle={{ flexGrow: 1 }}>
           {!!title && <Caption title={title} />}
           {children}
         </ScrollContent>

--- a/native/src/components/PoiFiltersModal.tsx
+++ b/native/src/components/PoiFiltersModal.tsx
@@ -93,9 +93,9 @@ const PoiFiltersModal = ({
 }: PoiFiltersModalProps): ReactElement => {
   const { t } = useTranslation('pois')
   const { height } = Dimensions.get('window')
-  const toggleButtonHeight = 70
-  const flatListHeight = height - (toggleButtonHeight * poiCategories.length) / 2
-
+  const toggleButtonHeight = 100
+  const numOfColumns = 3
+  const flatListHeight = Math.ceil(height - (poiCategories.length / numOfColumns) * toggleButtonHeight)
   return (
     <Modal
       modalVisible={modalVisible}
@@ -121,7 +121,7 @@ const PoiFiltersModal = ({
           </Row>
           <FlatList
             data={poiCategories}
-            numColumns={3}
+            numColumns={numOfColumns}
             style={{ marginVertical: 10, height: flatListHeight }}
             contentContainerStyle={{ gap: 16, alignItems: 'center' }}
             columnWrapperStyle={{ gap: 16 }}

--- a/native/src/components/PoiFiltersModal.tsx
+++ b/native/src/components/PoiFiltersModal.tsx
@@ -68,9 +68,7 @@ const StyledToggleButton = styled(ToggleButton)`
 const StyledTextButton = styled(TextButton)`
   margin-bottom: 16px;
 `
-const StyledScrollView = styled.ScrollView`
-  height: 100%;
-`
+
 type PoiFiltersModalProps = {
   modalVisible: boolean
   closeModal: () => void
@@ -97,35 +95,33 @@ const PoiFiltersModal = ({
   return (
     <Modal modalVisible={modalVisible} closeModal={closeModal} headerTitle='' title={t('adjustFilters')}>
       <Container>
-        <StyledScrollView>
-          <Section>
-            <SubTitle>{t('openingHours')}</SubTitle>
-            <Row>
-              <Icon Icon={ClockIcon} />
-              <StyledText>{t('onlyCurrentlyOpen')}</StyledText>
-              <FlexEnd>
-                <SettingsSwitch onPress={setCurrentlyOpenFilter} value={currentlyOpenFilter} />
-              </FlexEnd>
-            </Row>
-          </Section>
-          <Section>
-            <Row>
-              <SubTitle>{t('poiCategories')}</SubTitle>
-              <SortingHint>{t('alphabetLetters')}</SortingHint>
-            </Row>
-            <TileRow>
-              {poiCategories.map(item => (
-                <StyledToggleButton
-                  key={item.id}
-                  text={item.name}
-                  active={item.id === selectedPoiCategory?.id}
-                  onPress={() => setSelectedPoiCategory(item.id === selectedPoiCategory?.id ? null : item)}
-                  Icon={<SvgUri uri={item.icon} />}
-                />
-              ))}
-            </TileRow>
-          </Section>
-        </StyledScrollView>
+        <Section>
+          <SubTitle>{t('openingHours')}</SubTitle>
+          <Row>
+            <Icon Icon={ClockIcon} />
+            <StyledText>{t('onlyCurrentlyOpen')}</StyledText>
+            <FlexEnd>
+              <SettingsSwitch onPress={setCurrentlyOpenFilter} value={currentlyOpenFilter} />
+            </FlexEnd>
+          </Row>
+        </Section>
+        <Section>
+          <Row>
+            <SubTitle>{t('poiCategories')}</SubTitle>
+            <SortingHint>{t('alphabetLetters')}</SortingHint>
+          </Row>
+          <TileRow>
+            {poiCategories.map(item => (
+              <StyledToggleButton
+                key={item.id}
+                text={item.name}
+                active={item.id === selectedPoiCategory?.id}
+                onPress={() => setSelectedPoiCategory(item.id === selectedPoiCategory?.id ? null : item)}
+                Icon={<SvgUri uri={item.icon} />}
+              />
+            ))}
+          </TileRow>
+        </Section>
         <Section>
           <StyledTextButton
             onPress={closeModal}

--- a/native/src/components/PoiFiltersModal.tsx
+++ b/native/src/components/PoiFiltersModal.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Dimensions, FlatList } from 'react-native'
 import { SvgUri } from 'react-native-svg'
 import styled from 'styled-components/native'
 
@@ -56,20 +55,22 @@ const FlexEnd = styled.View`
   justify-content: flex-end;
 `
 
-// const TileRow = styled(Row)`
-//   place-content: space-between center;
-//   flex-wrap: wrap;
-//   gap: 16px;
-// `
+const TileRow = styled(Row)`
+  place-content: space-between center;
+  flex-wrap: wrap;
+  gap: 16px;
+`
 
 const StyledToggleButton = styled(ToggleButton)`
   margin-bottom: 8px;
 `
 
 const StyledTextButton = styled(TextButton)`
-  margin-top: 16px;
+  margin-bottom: 16px;
 `
-
+const StyledScrollView = styled.ScrollView`
+  height: 100%;
+`
 type PoiFiltersModalProps = {
   modalVisible: boolean
   closeModal: () => void
@@ -92,50 +93,39 @@ const PoiFiltersModal = ({
   poisCount,
 }: PoiFiltersModalProps): ReactElement => {
   const { t } = useTranslation('pois')
-  const { height } = Dimensions.get('window')
-  const toggleButtonHeight = 100
-  const numOfColumns = 3
-  const flatListHeight = Math.ceil(height - (poiCategories.length / numOfColumns) * toggleButtonHeight)
+
   return (
-    <Modal
-      modalVisible={modalVisible}
-      closeModal={closeModal}
-      headerTitle=''
-      title={t('adjustFilters')}
-      scrollView={false}>
+    <Modal modalVisible={modalVisible} closeModal={closeModal} headerTitle='' title={t('adjustFilters')}>
       <Container>
-        <Section>
-          <SubTitle>{t('openingHours')}</SubTitle>
-          <Row>
-            <Icon Icon={ClockIcon} />
-            <StyledText>{t('onlyCurrentlyOpen')}</StyledText>
-            <FlexEnd>
-              <SettingsSwitch onPress={setCurrentlyOpenFilter} value={currentlyOpenFilter} />
-            </FlexEnd>
-          </Row>
-        </Section>
-        <Section>
-          <Row>
-            <SubTitle>{t('poiCategories')}</SubTitle>
-            <SortingHint>{t('alphabetLetters')}</SortingHint>
-          </Row>
-          <FlatList
-            data={poiCategories}
-            numColumns={numOfColumns}
-            style={{ marginVertical: 10, height: flatListHeight }}
-            contentContainerStyle={{ gap: 16, alignItems: 'center' }}
-            columnWrapperStyle={{ gap: 16 }}
-            renderItem={({ item }) => (
-              <StyledToggleButton
-                key={item.id}
-                text={item.name}
-                active={item.id === selectedPoiCategory?.id}
-                onPress={() => setSelectedPoiCategory(item.id === selectedPoiCategory?.id ? null : item)}
-                Icon={<SvgUri uri={item.icon} />}
-              />
-            )}
-          />
-        </Section>
+        <StyledScrollView>
+          <Section>
+            <SubTitle>{t('openingHours')}</SubTitle>
+            <Row>
+              <Icon Icon={ClockIcon} />
+              <StyledText>{t('onlyCurrentlyOpen')}</StyledText>
+              <FlexEnd>
+                <SettingsSwitch onPress={setCurrentlyOpenFilter} value={currentlyOpenFilter} />
+              </FlexEnd>
+            </Row>
+          </Section>
+          <Section>
+            <Row>
+              <SubTitle>{t('poiCategories')}</SubTitle>
+              <SortingHint>{t('alphabetLetters')}</SortingHint>
+            </Row>
+            <TileRow>
+              {poiCategories.map(item => (
+                <StyledToggleButton
+                  key={item.id}
+                  text={item.name}
+                  active={item.id === selectedPoiCategory?.id}
+                  onPress={() => setSelectedPoiCategory(item.id === selectedPoiCategory?.id ? null : item)}
+                  Icon={<SvgUri uri={item.icon} />}
+                />
+              ))}
+            </TileRow>
+          </Section>
+        </StyledScrollView>
         <Section>
           <StyledTextButton
             onPress={closeModal}

--- a/native/src/components/PoiFiltersModal.tsx
+++ b/native/src/components/PoiFiltersModal.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
+import { Dimensions, FlatList } from 'react-native'
 import { SvgUri } from 'react-native-svg'
 import styled from 'styled-components/native'
 
@@ -55,11 +56,11 @@ const FlexEnd = styled.View`
   justify-content: flex-end;
 `
 
-const TileRow = styled(Row)`
-  place-content: space-between center;
-  flex-wrap: wrap;
-  gap: 16px;
-`
+// const TileRow = styled(Row)`
+//   place-content: space-between center;
+//   flex-wrap: wrap;
+//   gap: 16px;
+// `
 
 const StyledToggleButton = styled(ToggleButton)`
   margin-bottom: 8px;
@@ -91,9 +92,17 @@ const PoiFiltersModal = ({
   poisCount,
 }: PoiFiltersModalProps): ReactElement => {
   const { t } = useTranslation('pois')
+  const { height } = Dimensions.get('window')
+  const toggleButtonHeight = 70
+  const flatListHeight = height - (toggleButtonHeight * poiCategories.length) / 2
 
   return (
-    <Modal modalVisible={modalVisible} closeModal={closeModal} headerTitle='' title={t('adjustFilters')}>
+    <Modal
+      modalVisible={modalVisible}
+      closeModal={closeModal}
+      headerTitle=''
+      title={t('adjustFilters')}
+      scrollView={false}>
       <Container>
         <Section>
           <SubTitle>{t('openingHours')}</SubTitle>
@@ -110,17 +119,22 @@ const PoiFiltersModal = ({
             <SubTitle>{t('poiCategories')}</SubTitle>
             <SortingHint>{t('alphabetLetters')}</SortingHint>
           </Row>
-          <TileRow>
-            {poiCategories.map(it => (
+          <FlatList
+            data={poiCategories}
+            numColumns={3}
+            style={{ marginVertical: 10, height: flatListHeight }}
+            contentContainerStyle={{ gap: 16, alignItems: 'center' }}
+            columnWrapperStyle={{ gap: 16 }}
+            renderItem={({ item }) => (
               <StyledToggleButton
-                key={it.id}
-                text={it.name}
-                active={it.id === selectedPoiCategory?.id}
-                onPress={() => setSelectedPoiCategory(it.id === selectedPoiCategory?.id ? null : it)}
-                Icon={<SvgUri uri={it.icon} />}
+                key={item.id}
+                text={item.name}
+                active={item.id === selectedPoiCategory?.id}
+                onPress={() => setSelectedPoiCategory(item.id === selectedPoiCategory?.id ? null : item)}
+                Icon={<SvgUri uri={item.icon} />}
               />
-            ))}
-          </TileRow>
+            )}
+          />
         </Section>
         <Section>
           <StyledTextButton

--- a/native/src/components/PoiFiltersModal.tsx
+++ b/native/src/components/PoiFiltersModal.tsx
@@ -66,7 +66,8 @@ const StyledToggleButton = styled(ToggleButton)`
 `
 
 const StyledTextButton = styled(TextButton)`
-  margin-bottom: 16px;
+  margin-top: 8px;
+  margin-bottom: 8px;
 `
 
 type PoiFiltersModalProps = {
@@ -111,13 +112,13 @@ const PoiFiltersModal = ({
             <SortingHint>{t('alphabetLetters')}</SortingHint>
           </Row>
           <TileRow>
-            {poiCategories.map(item => (
+            {poiCategories.map(it => (
               <StyledToggleButton
-                key={item.id}
-                text={item.name}
-                active={item.id === selectedPoiCategory?.id}
-                onPress={() => setSelectedPoiCategory(item.id === selectedPoiCategory?.id ? null : item)}
-                Icon={<SvgUri uri={item.icon} />}
+                key={it.id}
+                text={it.name}
+                active={it.id === selectedPoiCategory?.id}
+                onPress={() => setSelectedPoiCategory(it.id === selectedPoiCategory?.id ? null : it)}
+                Icon={<SvgUri uri={it.icon} />}
               />
             ))}
           </TileRow>

--- a/release-notes/unreleased/2856-POI-filter-is-too-long-for-display.yml
+++ b/release-notes/unreleased/2856-POI-filter-is-too-long-for-display.yml
@@ -1,6 +1,7 @@
-issue_key:
+issue_key: 2856
 show_in_stores: true
-platforms: # relevant platforms, possible values: web, android and ios
+platforms:
   - ios
   - android
-en: Fixed scrolling at filter locations
+en: Fixed scrolling at filter locations.
+de: Die Filter für die Orte sind jetzt scrollbar.

--- a/release-notes/unreleased/2856-POI-filter-is-too-long-for-display.yml
+++ b/release-notes/unreleased/2856-POI-filter-is-too-long-for-display.yml
@@ -1,0 +1,6 @@
+issue_key:
+show_in_stores: true
+platforms: # relevant platforms, possible values: web, android and ios
+  - ios
+  - android
+en: Fixed scrolling at filter locations


### PR DESCRIPTION
### Short description

The POI filter on 5,5" phone leads two categories to be cut and it's not possible to scroll.

### Proposed changes

~- Used FlatList instead of .map() for build-in scrolling.~
~- Defined numbers of numColumns 3 to make it consistent on all devices~
~- Computed the flatListHeight dynamically from poiCategories length divided by numOfColumns to get number of rows multiplied by toggleButtonHeight.~
~- Used a ScrollView that wraps around opening hours section and categories section.~

- Fixed an issue with the scrollView at the modal where I replaced `{flex:1}` with `{flexGrow: 1}`

Tested on virtual devices with the following screen: 5.0, 5.5, 6.7 inches.

### Side effects

None.
~Note: I disabled scrollView from Modal (scrollView={false}) because VirtualizedLists doesn't like to be nested in ScrollViews.~

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: [#2856](https://github.com/digitalfabrik/integreat-app/issues/2856).

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
