### PR TITLE
2852:Disable PDF-Creation/-button for RTL languages

### DIFF
--- a/release-notes/unreleased/2852-Disable-PDF-Creation-button-for-RTL-languages.yml
+++ b/release-notes/unreleased/2852-Disable-PDF-Creation-button-for-RTL-languages.yml
@@ -1,0 +1,5 @@
+issue_key: 2852
+show_in_stores: false
+platforms: # relevant platforms, possible values: web, android and ios
+  - web
+en: Disabling Pdf for RTL languages due to the problem in the cms.

--- a/translations/src/config.ts
+++ b/translations/src/config.ts
@@ -1,4 +1,4 @@
-export type FontType =
+type FontType =
   | 'notoSans'
   | 'raleway'
   | 'varelaRound'

--- a/translations/src/config.ts
+++ b/translations/src/config.ts
@@ -1,4 +1,4 @@
-type FontType =
+export type FontType =
   | 'notoSans'
   | 'raleway'
   | 'varelaRound'

--- a/translations/translations.json
+++ b/translations/translations.json
@@ -46,7 +46,8 @@
       "createPdf": "Create a PDF",
       "metaDescription": "{{appName}} is your digital guide to life in Germany. Discover local information, events and advice. Always up to date and available in your own language.",
       "organizationContent": "The contents of this page are from {{organization}}.",
-      "organizationMoreInformation": "You can find more information about <1>{{organization}}</1> on <3>{{domain}}</3>."
+      "organizationMoreInformation": "You can find more information about <1>{{organization}}</1> on <3>{{domain}}</3>.",
+      "disabledPdf": "Currently the PDF-Export in this language is not available"
     },
     "es": {
       "createPdf": "Crear PDF",

--- a/web/src/components/CategoriesToolbar.tsx
+++ b/web/src/components/CategoriesToolbar.tsx
@@ -1,10 +1,9 @@
-import React, { ReactElement, useEffect, useState } from 'react'
+import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { CATEGORIES_ROUTE } from 'shared'
 import { CategoryModel } from 'shared/api'
-import { config } from 'translations'
-import { FontType } from 'translations/src/config'
+import config from 'translations/src/config'
 
 import { PdfIcon } from '../assets'
 import { cmsApiBaseUrl } from '../constants/urls'
@@ -18,35 +17,21 @@ type CategoriesToolbarProps = {
   pageTitle: string
 }
 
-type LanguageType = { code: string; rtl: boolean; additionalFont?: FontType }
-
 const CategoriesToolbar = (props: CategoriesToolbarProps): ReactElement => {
   const { category, cityCode, languageCode, pageTitle } = props
   const { t } = useTranslation('categories')
-  const [supportedRtlLanguages, setSupportedRtlLanguages] = useState([])
 
   const pdfUrl =
     !category || category.isRoot()
       ? `${cmsApiBaseUrl}/${cityCode}/${languageCode}/wp-json/ig-mpdf/v1/pdf`
       : `${cmsApiBaseUrl}/${cityCode}/${languageCode}/wp-json/ig-mpdf/v1/pdf?url=${encodeURIComponent(category.path)}`
 
-  useEffect(() => {
-    const { supportedLanguages } = config
-    const rtl = Object.keys(supportedLanguages).map(key => ({ code: key, ...supportedLanguages[key] }))
-    setSupportedRtlLanguages(rtl.filter(lang => lang.rtl === true) as [])
-  }, [languageCode])
-
   return (
     <CityContentToolbar
       route={CATEGORIES_ROUTE}
       feedbackTarget={category && !category.isRoot() ? category.slug : undefined}
       pageTitle={pageTitle}>
-      <ToolbarItem
-        icon={PdfIcon}
-        text={t('createPdf')}
-        href={pdfUrl}
-        isDisabled={supportedRtlLanguages.some((language: LanguageType) => language.code === languageCode)}
-      />
+      <ToolbarItem icon={PdfIcon} text={t('createPdf')} href={pdfUrl} isDisabled={config.hasRTLScript(languageCode)} />
     </CityContentToolbar>
   )
 }

--- a/web/src/components/CategoriesToolbar.tsx
+++ b/web/src/components/CategoriesToolbar.tsx
@@ -1,8 +1,10 @@
-import React, { ReactElement } from 'react'
+import React, { ReactElement, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { CATEGORIES_ROUTE } from 'shared'
 import { CategoryModel } from 'shared/api'
+import { config } from 'translations'
+import { FontType } from 'translations/src/config'
 
 import { PdfIcon } from '../assets'
 import { cmsApiBaseUrl } from '../constants/urls'
@@ -16,21 +18,35 @@ type CategoriesToolbarProps = {
   pageTitle: string
 }
 
+type LanguageType = { code: string; rtl: boolean; additionalFont?: FontType }
+
 const CategoriesToolbar = (props: CategoriesToolbarProps): ReactElement => {
   const { category, cityCode, languageCode, pageTitle } = props
   const { t } = useTranslation('categories')
+  const [supportedRtlLanguages, setSupportedRtlLanguages] = useState([])
 
   const pdfUrl =
     !category || category.isRoot()
       ? `${cmsApiBaseUrl}/${cityCode}/${languageCode}/wp-json/ig-mpdf/v1/pdf`
       : `${cmsApiBaseUrl}/${cityCode}/${languageCode}/wp-json/ig-mpdf/v1/pdf?url=${encodeURIComponent(category.path)}`
 
+  useEffect(() => {
+    const { supportedLanguages } = config
+    const rtl = Object.keys(supportedLanguages).map(key => ({ code: key, ...supportedLanguages[key] }))
+    setSupportedRtlLanguages(rtl.filter(lang => lang.rtl === true) as [])
+  }, [languageCode])
+
   return (
     <CityContentToolbar
       route={CATEGORIES_ROUTE}
       feedbackTarget={category && !category.isRoot() ? category.slug : undefined}
       pageTitle={pageTitle}>
-      <ToolbarItem icon={PdfIcon} text={t('createPdf')} href={pdfUrl} />
+      <ToolbarItem
+        icon={PdfIcon}
+        text={t('createPdf')}
+        href={pdfUrl}
+        isDisabled={supportedRtlLanguages.some((language: LanguageType) => language.code === languageCode)}
+      />
     </CityContentToolbar>
   )
 }

--- a/web/src/components/StyledToolbarItem.tsx
+++ b/web/src/components/StyledToolbarItem.tsx
@@ -3,12 +3,13 @@ import styled from 'styled-components'
 import dimensions from '../constants/dimensions'
 import CleanAnchor from './CleanAnchor'
 
-const StyledToolbarItem = styled(CleanAnchor)`
+const StyledToolbarItem = styled(CleanAnchor)<{ disabled?: boolean }>`
   display: inline-block;
   padding: 8px;
   cursor: pointer;
+  /* pointer-events: ${props => (props.disabled ? 'none' : null)}; */
   border: none;
-  color: ${props => props.theme.colors.textColor};
+  color: ${props => (props.disabled ? props.theme.colors.textDisabledColor : props.theme.colors.textColor)};
   background-color: transparent;
   text-align: center;
 

--- a/web/src/components/StyledToolbarItem.tsx
+++ b/web/src/components/StyledToolbarItem.tsx
@@ -7,7 +7,6 @@ const StyledToolbarItem = styled(CleanAnchor)<{ disabled?: boolean }>`
   display: inline-block;
   padding: 8px;
   cursor: pointer;
-  /* pointer-events: ${props => (props.disabled ? 'none' : null)}; */
   border: none;
   color: ${props => (props.disabled ? props.theme.colors.textDisabledColor : props.theme.colors.textColor)};
   background-color: transparent;

--- a/web/src/components/ToolbarItem.tsx
+++ b/web/src/components/ToolbarItem.tsx
@@ -31,7 +31,7 @@ type ToolbarItemProps = {
 const ToolbarItem = ({ href, text, icon, isDisabled = false, onClick }: ToolbarItemProps): ReactElement => {
   const { t } = useTranslation('categories')
   return isDisabled ? (
-    <Tooltip text={t('createPdf')} flow='up'>
+    <Tooltip text={t('disabledPdf')} flow='up'>
       <StyledToolbarItem
         as={onClick ? Button : undefined}
         // @ts-expect-error wrong types from polymorphic 'as', see https://github.com/styled-components/styled-components/issues/4112

--- a/web/src/components/ToolbarItem.tsx
+++ b/web/src/components/ToolbarItem.tsx
@@ -1,13 +1,15 @@
 import React, { ReactElement } from 'react'
+import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
 import StyledSmallViewTip from './StyledSmallViewTip'
 import StyledToolbarItem from './StyledToolbarItem'
+import Tooltip from './Tooltip'
 import Button from './base/Button'
 import Icon from './base/Icon'
 
-const StyledIcon = styled(Icon)`
-  color: ${props => props.theme.colors.textSecondaryColor};
+const StyledIcon = styled(Icon)<{ disabled?: boolean }>`
+  color: ${props => (props.disabled ? props.theme.colors.textDisabledColor : props.theme.colors.textSecondaryColor)};
 `
 
 type ItemProps =
@@ -23,14 +25,36 @@ type ItemProps =
 type ToolbarItemProps = {
   icon: string
   text: string
+  isDisabled?: boolean
 } & ItemProps
 
-const ToolbarItem = ({ href, text, icon, onClick }: ToolbarItemProps): ReactElement => (
-  // @ts-expect-error wrong types from polymorphic 'as', see https://github.com/styled-components/styled-components/issues/4112
-  <StyledToolbarItem as={onClick ? Button : undefined} href={href} onClick={onClick} label={text}>
-    <StyledIcon src={icon} />
-    <StyledSmallViewTip>{text}</StyledSmallViewTip>
-  </StyledToolbarItem>
-)
+const ToolbarItem = ({ href, text, icon, isDisabled = false, onClick }: ToolbarItemProps): ReactElement => {
+  const { t } = useTranslation('categories')
+  return isDisabled ? (
+    <Tooltip text={t('createPdf')} flow='up'>
+      <StyledToolbarItem
+        as={onClick ? Button : undefined}
+        // @ts-expect-error wrong types from polymorphic 'as', see https://github.com/styled-components/styled-components/issues/4112
+        href={null}
+        onClick={onClick}
+        label={text}
+        disabled={isDisabled}>
+        <StyledIcon src={icon} disabled={isDisabled} />
+        <StyledSmallViewTip>{text}</StyledSmallViewTip>
+      </StyledToolbarItem>
+    </Tooltip>
+  ) : (
+    <StyledToolbarItem
+      as={onClick ? Button : undefined}
+      // @ts-expect-error wrong types from polymorphic 'as', see https://github.com/styled-components/styled-components/issues/4112
+      href={href}
+      onClick={onClick}
+      label={text}
+      disabled={isDisabled}>
+      <StyledIcon src={icon} disabled={isDisabled} />
+      <StyledSmallViewTip>{text}</StyledSmallViewTip>
+    </StyledToolbarItem>
+  )
+}
 
 export default ToolbarItem

--- a/web/src/components/__tests__/CategoriesToolbar.spec.tsx
+++ b/web/src/components/__tests__/CategoriesToolbar.spec.tsx
@@ -68,4 +68,15 @@ describe('CategoriesToolbar', () => {
       )}`,
     )
   })
+
+  it('should prevent PDF URL for RTL Languages', () => {
+    const cityCode = 'augsburg'
+    const languageCode = 'ar'
+    const { getByText } = renderWithTheme(
+      <CategoriesToolbar category={rootCategory} cityCode={cityCode} languageCode={languageCode} pageTitle='Test' />,
+    )
+    const pdfUrlLink = getByText('categories:createPdf').closest('a')
+
+    expect(pdfUrlLink?.href).toBeFalsy()
+  })
 })


### PR DESCRIPTION
### Short description

Disabling PDF-Creation for RTL languages

### Proposed changes

<!-- Describe this PR in more detail. -->

- Modified ToolbarItem and StyledToolbarItem to accept disabled props to change colors.
- Used config.hasRTLScript to check it it's RTL.
- Added disabledPdf  line to translation.json in english (Translation to other languages needed especially RTL languages ).

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
None

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2852 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
