### PR TITLE
2880: Fix repeating dates. Again.

### DIFF
--- a/release-notes/unreleased/2880-Repeating-dates.yml
+++ b/release-notes/unreleased/2880-Repeating-dates.yml
@@ -1,0 +1,8 @@
+issue_key: 2880
+show_in_stores: true
+platforms:
+  - web
+  - android
+  - ios
+en: Fix the dates on recurring all-day events
+de: Fehlerbehebung beim Datum von wiederholenden ganztägigen Veranstaltungen

--- a/shared/api/models/DateModel.ts
+++ b/shared/api/models/DateModel.ts
@@ -83,9 +83,6 @@ class DateModel {
     // bigger than the distance from midnight (e.g. 1 am with a 2h offset during CET summer time)
     // https://github.com/jkbrzt/rrule#important-use-utc-dates
     const localRecurrenceRule = this.getRecurrenceRuleInLocalTime(this.recurrenceRule)
-    if (!localRecurrenceRule) {
-      return [this]
-    }
 
     return localRecurrenceRule
       .between(minDate, maxDate, true, (_, index) => index < count)
@@ -138,7 +135,7 @@ class DateModel {
     return null
   }
 
-  private getRecurrenceRuleInLocalTime(recurrenceRule: RRuleType): RRuleType | undefined {
+  private getRecurrenceRuleInLocalTime(recurrenceRule: RRuleType): RRuleType {
     const startDate = recurrenceRule.options.dtstart
     const offsetStartDate = DateTime.fromJSDate(startDate).minus({ minutes: startDate.getTimezoneOffset() }).toJSDate()
     return new RRuleType({

--- a/shared/api/models/__tests__/DateModel.spec.ts
+++ b/shared/api/models/__tests__/DateModel.spec.ts
@@ -338,7 +338,7 @@ describe('DateModel', () => {
       ])
     })
 
-    it('should correctly handle allDay events', () => {
+    it('should correctly handle allDay events in summer time', () => {
       jest.useFakeTimers({ now: new Date('2024-08-13T15:23:57.443+02:00') })
       const recurrenceRule = rrulestr('DTSTART:20240813T220000\nRRULE:FREQ=WEEKLY;BYDAY=SA')
       const date = new DateModel({
@@ -354,6 +354,27 @@ describe('DateModel', () => {
           recurrenceRule,
           startDate: DateTime.fromISO('2024-08-17T00:00:00.000+02:00'),
           endDate: DateTime.fromISO('2024-08-17T23:59:00.000+02:00'),
+          offset: 120,
+        }),
+      ])
+    })
+
+    it('should correctly handle allDay events in winter time', () => {
+      jest.useFakeTimers({ now: new Date('2024-01-13T15:23:57.443+01:00') })
+      const recurrenceRule = rrulestr('DTSTART:20230813T220000\nRRULE:FREQ=WEEKLY;BYDAY=MO')
+      const date = new DateModel({
+        startDate: DateTime.fromISO('2023-08-14T00:00:00.000+01:00'),
+        endDate: DateTime.fromISO('2023-08-14T23:59:00.000+01:00'),
+        allDay: true,
+        recurrenceRule,
+      })
+
+      expect(date.recurrences(1)).toEqual([
+        new DateModel({
+          allDay: true,
+          recurrenceRule,
+          startDate: DateTime.fromISO('2024-01-15T00:00:00.000+01:00'),
+          endDate: DateTime.fromISO('2024-01-15T23:59:00.000+01:00'),
           offset: 120,
         }),
       ])

--- a/shared/api/models/__tests__/DateModel.spec.ts
+++ b/shared/api/models/__tests__/DateModel.spec.ts
@@ -291,7 +291,7 @@ describe('DateModel', () => {
           recurrenceRule,
           startDate: DateTime.fromISO('2024-01-17T14:00:00.000+01:00'),
           endDate: DateTime.fromISO('2024-01-17T15:00:00.000+01:00'),
-          offset: 120, // TODO: check if this shouldn't be 60 minutes because it is winter time after all
+          offset: 120,
         }),
       ])
     })
@@ -312,7 +312,7 @@ describe('DateModel', () => {
           recurrenceRule,
           startDate: DateTime.fromISO('2024-08-13T16:00:00.000+02:00'),
           endDate: DateTime.fromISO('2024-08-13T18:00:00.000+02:00'),
-          offset: 60, // TODO: same as above
+          offset: 60,
         }),
       ])
     })
@@ -340,7 +340,7 @@ describe('DateModel', () => {
 
     it('should correctly handle allDay events', () => {
       jest.useFakeTimers({ now: new Date('2024-08-13T15:23:57.443+02:00') })
-      const recurrenceRule = rrulestr('DTSTART:20240813T220000\nRRULE:FREQ=WEEKLY;BYDAY=SA', { tzid: 'UTC' })
+      const recurrenceRule = rrulestr('DTSTART:20240813T220000\nRRULE:FREQ=WEEKLY;BYDAY=SA')
       const date = new DateModel({
         startDate: DateTime.fromISO('2024-08-14T00:00:00.000+02:00'),
         endDate: DateTime.fromISO('2024-08-14T23:59:00.000+02:00'),
@@ -354,6 +354,27 @@ describe('DateModel', () => {
           recurrenceRule,
           startDate: DateTime.fromISO('2024-08-17T00:00:00.000+02:00'),
           endDate: DateTime.fromISO('2024-08-17T23:59:00.000+02:00'),
+          offset: 120,
+        }),
+      ])
+    })
+
+    it('should also return events that are happening right now', () => {
+      jest.useFakeTimers({ now: new Date('2024-08-15T15:23:57.443+02:00') })
+      const recurrenceRule = rrulestr('DTSTART:20240815T120000\nRRULE:FREQ=WEEKLY;BYDAY=TH')
+      const date = new DateModel({
+        startDate: DateTime.fromISO('2024-08-15T14:00:00.000+02:00'),
+        endDate: DateTime.fromISO('2024-08-15T16:00:00.000+02:00'),
+        allDay: false,
+        recurrenceRule,
+      })
+
+      expect(date.recurrences(1)).toEqual([
+        new DateModel({
+          allDay: false,
+          recurrenceRule,
+          startDate: DateTime.fromISO('2024-08-15T14:00:00.000+02:00'),
+          endDate: DateTime.fromISO('2024-08-15T16:00:00.000+02:00'),
           offset: 120,
         }),
       ])

--- a/shared/api/models/__tests__/DateModel.spec.ts
+++ b/shared/api/models/__tests__/DateModel.spec.ts
@@ -337,5 +337,26 @@ describe('DateModel', () => {
         }),
       ])
     })
+
+    it('should correctly handle allDay events', () => {
+      jest.useFakeTimers({ now: new Date('2024-08-13T15:23:57.443+02:00') })
+      const recurrenceRule = rrulestr('DTSTART:20240813T220000\nRRULE:FREQ=WEEKLY;BYDAY=SA', { tzid: 'UTC' })
+      const date = new DateModel({
+        startDate: DateTime.fromISO('2024-08-14T00:00:00.000+02:00'),
+        endDate: DateTime.fromISO('2024-08-14T23:59:00.000+02:00'),
+        allDay: true,
+        recurrenceRule,
+      })
+
+      expect(date.recurrences(1)).toEqual([
+        new DateModel({
+          allDay: true,
+          recurrenceRule,
+          startDate: DateTime.fromISO('2024-08-17T00:00:00.000+02:00'),
+          endDate: DateTime.fromISO('2024-08-17T23:59:00.000+02:00'),
+          offset: 120,
+        }),
+      ])
+    })
   })
 })

--- a/shared/api/models/__tests__/DateModel.spec.ts
+++ b/shared/api/models/__tests__/DateModel.spec.ts
@@ -253,5 +253,89 @@ describe('DateModel', () => {
       expect(recurrence.toFormattedString('de', false)).toBe('7. Mai 2024 10:00 - 12:00')
       expect(recurrence.recurrences(1)[0]!.toFormattedString('de', false)).toBe('7. Mai 2024 10:00 - 12:00')
     })
+
+    it('should correctly handle dates if it is winter time and the event starts during winter time', () => {
+      jest.useFakeTimers({ now: new Date('2024-01-13T15:23:57.443+01:00') })
+      const recurrenceRule = rrulestr('DTSTART:20231223T070000Z\nRRULE:FREQ=WEEKLY;BYDAY=MO')
+      const date = new DateModel({
+        startDate: DateTime.fromISO('2023-12-25T08:00:00.000+01:00'),
+        endDate: DateTime.fromISO('2023-12-25T10:00:00.000+01:00'),
+        allDay: false,
+        recurrenceRule,
+      })
+
+      expect(date.recurrences(1)).toEqual([
+        new DateModel({
+          allDay: false,
+          recurrenceRule,
+          startDate: DateTime.fromISO('2024-01-15T08:00:00.000+01:00'),
+          endDate: DateTime.fromISO('2024-01-15T10:00:00.000+01:00'),
+          offset: 60,
+        }),
+      ])
+    })
+
+    it('should correctly handle dates if it is winter time and the event starts during summer time', () => {
+      jest.useFakeTimers({ now: new Date('2024-01-13T15:23:57.443+01:00') })
+      const recurrenceRule = rrulestr('DTSTART:20230831T120000Z\nRRULE:FREQ=WEEKLY;BYDAY=WE')
+      const date = new DateModel({
+        startDate: DateTime.fromISO('2023-09-06T14:00:00.000+02:00'),
+        endDate: DateTime.fromISO('2023-09-06T15:00:00.000+02:00'),
+        allDay: false,
+        recurrenceRule,
+      })
+
+      expect(date.recurrences(1)).toEqual([
+        new DateModel({
+          allDay: false,
+          recurrenceRule,
+          startDate: DateTime.fromISO('2024-01-17T14:00:00.000+01:00'),
+          endDate: DateTime.fromISO('2024-01-17T15:00:00.000+01:00'),
+          offset: 120, // TODO: check if this shouldn't be 60 minutes because it is winter time after all
+        }),
+      ])
+    })
+
+    it('should correctly handle dates if it is summer time and the event starts during winter time', () => {
+      jest.useFakeTimers({ now: new Date('2024-08-13T15:23:57.443+02:00') })
+      const recurrenceRule = rrulestr('DTSTART:20231223T150000Z\nRRULE:FREQ=WEEKLY;BYDAY=TU')
+      const date = new DateModel({
+        startDate: DateTime.fromISO('2023-12-26T16:00:00.000+01:00'),
+        endDate: DateTime.fromISO('2023-12-26T18:00:00.000+01:00'),
+        allDay: false,
+        recurrenceRule,
+      })
+
+      expect(date.recurrences(1)).toEqual([
+        new DateModel({
+          allDay: false,
+          recurrenceRule,
+          startDate: DateTime.fromISO('2024-08-13T16:00:00.000+02:00'),
+          endDate: DateTime.fromISO('2024-08-13T18:00:00.000+02:00'),
+          offset: 60, // TODO: same as above
+        }),
+      ])
+    })
+
+    it('should correctly handle dates if it is summer time and the event starts during summer time', () => {
+      jest.useFakeTimers({ now: new Date('2024-08-13T15:23:57.443+02:00') })
+      const recurrenceRule = rrulestr('DTSTART:20240331T230000Z\nRRULE:FREQ=WEEKLY;BYDAY=TH')
+      const date = new DateModel({
+        startDate: DateTime.fromISO('2024-04-01T01:00:00.000+02:00'),
+        endDate: DateTime.fromISO('2024-04-01T23:59:00.000+02:00'),
+        allDay: false,
+        recurrenceRule,
+      })
+
+      expect(date.recurrences(1)).toEqual([
+        new DateModel({
+          allDay: false,
+          recurrenceRule,
+          startDate: DateTime.fromISO('2024-08-15T01:00:00.000+02:00'),
+          endDate: DateTime.fromISO('2024-08-15T23:59:00.000+02:00'),
+          offset: 120,
+        }),
+      ])
+    })
   })
 })


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
The repeating dates were off again. Reminder, the underlying problem is that the package `rrule` handles time zones by ignoring them and pretending that everything is in UTC. This time, we had the problem that e.g. all-day events arrive with a starting time of 0:00+2 which translates to 22:00 on the previous day in UTC. If we then go and get for example the next Saturday from that, we get Saturday at 22:00 in UTC, which translates to midnight on Sunday in local time.

Links for testing: http://localhost:9000/testumgebung/de/events/jeden-donnerstag and https://cms-test.integreat-app.de/testumgebung/events/de/4596/edit/

Note: I haven't found a well-supported alternative package, but man, would I be happy to switch.

### Proposed changes

<!-- Describe this PR in more detail. -->

- Move the start date in the recurrence rule to local time, then get the next recurrences, then set those back to UTC time
- Added a couple of more tests for different situations I could think of

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- It should be none. I decided against keeping the offset on the recurrences to keep them in the existing (and frankly, correct) date format.

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2880 