### PR TITLE
2223: Add link to POI from events

### DIFF
--- a/native/src/components/PageDetail.tsx
+++ b/native/src/components/PageDetail.tsx
@@ -1,32 +1,66 @@
 import React, { ReactElement } from 'react'
+import { Pressable, Text } from 'react-native'
 import styled from 'styled-components/native'
 
+import { InternalPathnameParser } from 'shared'
+
+import buildConfig from '../constants/buildConfig'
 import { contentDirection } from '../constants/contentDirection'
+import useNavigate from '../hooks/useNavigate'
+
+const DetailContainer = styled.View<{ language: string }>`
+  flex-direction: ${props => contentDirection(props.language)};
+  font-family: ${props => props.theme.fonts.native.contentFontRegular};
+  color: ${props => props.theme.colors.textColor};
+`
 
 const Identifier = styled.Text`
   font-family: ${props => props.theme.fonts.native.contentFontBold};
   color: ${props => props.theme.colors.textColor};
 `
-const DetailContainer = styled.Text<{ language: string }>`
-  display: flex;
-  flex-direction: ${props => contentDirection(props.language)};
-  font-family: ${props => props.theme.fonts.native.contentFontRegular};
-  color: ${props => props.theme.colors.textColor};
+
+const StyledButton = styled.Pressable`
+  /* Offset for bold sibling + underline */
+  margin-top: 1px;
+`
+
+const ButtonText = styled.Text`
+  color: ${props => props.theme.colors.linkColor};
+  text-decoration: underline;
+  text-decoration-color: ${props => props.theme.colors.linkColor};
+`
+
+const StyledText = styled.Text`
+  /* Offset for bold sibling */
+  margin-top: 2px;
 `
 
 type PageDetailProps = {
   identifier: string
   information: string
   language: string
+  locationPath?: string | null
 }
 
-const PageDetail = (props: PageDetailProps): ReactElement => {
-  const { identifier, information, language } = props
+const PageDetail = ({ identifier, information, language, locationPath }: PageDetailProps): ReactElement => {
+  const { navigateTo } = useNavigate()
+
+  if (locationPath) {
+    const parsedRoute = new InternalPathnameParser(locationPath, language, buildConfig().featureFlags.fixedCity).route()
+    return (
+      <DetailContainer language={language}>
+        <Identifier>{identifier}: </Identifier>
+        <StyledButton onPress={() => navigateTo(parsedRoute)}>
+          <ButtonText>{information}</ButtonText>
+        </StyledButton>
+      </DetailContainer>
+    )
+  }
 
   return (
     <DetailContainer language={language}>
       <Identifier>{identifier}: </Identifier>
-      {information}
+      <StyledText>{information}</StyledText>
     </DetailContainer>
   )
 }

--- a/native/src/components/PageDetail.tsx
+++ b/native/src/components/PageDetail.tsx
@@ -1,5 +1,4 @@
 import React, { ReactElement } from 'react'
-import { Pressable, Text } from 'react-native'
 import styled from 'styled-components/native'
 
 import { InternalPathnameParser } from 'shared'
@@ -8,7 +7,7 @@ import buildConfig from '../constants/buildConfig'
 import { contentDirection } from '../constants/contentDirection'
 import useNavigate from '../hooks/useNavigate'
 
-const DetailContainer = styled.View<{ language: string }>`
+const DetailContainer = styled.Text<{ language: string }>`
   flex-direction: ${props => contentDirection(props.language)};
   font-family: ${props => props.theme.fonts.native.contentFontRegular};
   color: ${props => props.theme.colors.textColor};
@@ -21,18 +20,13 @@ const Identifier = styled.Text`
 
 const StyledButton = styled.Pressable`
   /* Offset for bold sibling + underline */
-  margin-top: 1px;
+  margin-top: -2px;
 `
 
 const ButtonText = styled.Text`
   color: ${props => props.theme.colors.linkColor};
   text-decoration: underline;
   text-decoration-color: ${props => props.theme.colors.linkColor};
-`
-
-const StyledText = styled.Text`
-  /* Offset for bold sibling */
-  margin-top: 2px;
 `
 
 type PageDetailProps = {
@@ -60,7 +54,7 @@ const PageDetail = ({ identifier, information, language, locationPath }: PageDet
   return (
     <DetailContainer language={language}>
       <Identifier>{identifier}: </Identifier>
-      <StyledText>{information}</StyledText>
+      {information}
     </DetailContainer>
   )
 }

--- a/native/src/components/__tests__/DatesPageDetail.spec.tsx
+++ b/native/src/components/__tests__/DatesPageDetail.spec.tsx
@@ -1,3 +1,4 @@
+import { NavigationContainer } from '@react-navigation/native'
 import { fireEvent } from '@testing-library/react-native'
 import { DateTime } from 'luxon'
 import React from 'react'
@@ -12,7 +13,12 @@ jest.mock('react-i18next')
 
 jest.useFakeTimers({ now: new Date('2023-10-09T15:23:57.443+02:00') })
 describe('DatesPageDetail', () => {
-  const renderDatesPageDetail = (date: DateModel) => render(<DatesPageDetail date={date} languageCode='de' />)
+  const renderDatesPageDetail = (date: DateModel) =>
+    render(
+      <NavigationContainer>
+        <DatesPageDetail date={date} languageCode='de' />
+      </NavigationContainer>,
+    )
   const date = (rrule?: string) =>
     new DateModel({
       startDate: DateTime.fromISO('2023-10-09T07:00:00.000+02:00'),

--- a/native/src/components/__tests__/PageDetail.spec.tsx
+++ b/native/src/components/__tests__/PageDetail.spec.tsx
@@ -1,3 +1,4 @@
+import { NavigationContainer } from '@react-navigation/native'
 import React from 'react'
 import { I18nManager } from 'react-native'
 
@@ -7,16 +8,21 @@ import PageDetail from '../PageDetail'
 describe('PageDetail', () => {
   it('should display the given identifier followed by a colon', () => {
     const { queryAllByText, queryByText } = render(
-      <PageDetail identifier='Test Identifier' information='Some important information' language='de' />,
+      <NavigationContainer>
+        <PageDetail identifier='Test Identifier' information='Some important information' language='de' />
+      </NavigationContainer>,
     )
     expect(queryAllByText(/Test Identifier/)).toBeTruthy()
     expect(queryByText(/Some important information/)).toBeTruthy()
   })
+
   describe('should manually reverse if content language doesnt have the same direction as system language', () => {
     it('if system language is not rtl', () => {
       I18nManager.forceRTL(false)
       const { queryAllByText } = render(
-        <PageDetail identifier='Test Identifier' information='Some important information' language='de' />,
+        <NavigationContainer>
+          <PageDetail identifier='Test Identifier' information='Some important information' language='de' />
+        </NavigationContainer>,
       )
       queryAllByText(/Some important information/).forEach(element => {
         expect(element).toHaveStyle({
@@ -24,7 +30,9 @@ describe('PageDetail', () => {
         })
       })
       const { queryAllByText: queryAllByTextReverse } = render(
-        <PageDetail identifier='Test Identifier' information='Some important information' language='ar' />,
+        <NavigationContainer>
+          <PageDetail identifier='Test Identifier' information='Some important information' language='ar' />
+        </NavigationContainer>,
       )
       queryAllByTextReverse(/Some important information/).forEach(element => {
         expect(element).toHaveStyle({
@@ -32,10 +40,13 @@ describe('PageDetail', () => {
         })
       })
     })
+
     it('if system language is rtl', () => {
       I18nManager.forceRTL(true)
       const { queryAllByText: queryAllByTextReverse } = render(
-        <PageDetail identifier='Test Identifier' information='Some important information' language='de' />,
+        <NavigationContainer>
+          <PageDetail identifier='Test Identifier' information='Some important information' language='de' />
+        </NavigationContainer>,
       )
       queryAllByTextReverse(/Some important information/).forEach(element => {
         expect(element).toHaveStyle({
@@ -43,7 +54,9 @@ describe('PageDetail', () => {
         })
       })
       const { queryAllByText } = render(
-        <PageDetail identifier='Test Identifier' information='Some important information' language='ar' />,
+        <NavigationContainer>
+          <PageDetail identifier='Test Identifier' information='Some important information' language='ar' />
+        </NavigationContainer>,
       )
       queryAllByText(/Some important information/).forEach(element => {
         expect(element).toHaveStyle({

--- a/native/src/routes/Events.tsx
+++ b/native/src/routes/Events.tsx
@@ -72,7 +72,12 @@ const Events = ({ cityModel, language, navigateTo, events, slug, refresh }: Even
               <PageDetailsContainer>
                 <DatesPageDetail date={event.date} languageCode={language} />
                 {event.location && (
-                  <PageDetail identifier={t('address')} information={event.location.fullAddress} language={language} />
+                  <PageDetail
+                    identifier={t('address')}
+                    information={event.location.fullAddress}
+                    language={language}
+                    locationPath={event.locationPath}
+                  />
                 )}
               </PageDetailsContainer>
             }

--- a/native/src/utils/DatabaseConnector.ts
+++ b/native/src/utils/DatabaseConnector.ts
@@ -109,6 +109,7 @@ type ContentEventJsonType = {
   }
   location: LocationJsonType<number | null> | null
   featured_image: FeaturedImageJsonType | null | undefined
+  location_path: string | null
 }
 type ContentLanguageJsonType = {
   code: string
@@ -656,6 +657,7 @@ class DatabaseConnector {
               full: event.featuredImage.full,
             }
           : null,
+        location_path: event.locationPath,
       }),
     )
     await this.writeFile(this.getContentPath('events', context), JSON.stringify(jsonModels))
@@ -702,6 +704,7 @@ class DatabaseConnector {
                 town: jsonObject.location.town,
               })
             : null,
+          locationPath: jsonObject.location_path,
         })
       })
 

--- a/native/src/utils/__tests__/DatabaseConnector.spec.ts
+++ b/native/src/utils/__tests__/DatabaseConnector.spec.ts
@@ -265,6 +265,7 @@ describe('DatabaseConnector', () => {
         location: null,
         lastUpdate: DateTime.fromISO('2022-06-29T09:19:57.443+02:00'),
         featuredImage: null,
+        locationPath: '/testumgebung/de/locations/testort/',
       })
 
       expect(event.date.toFormattedString('de', false)).toBe('7. Mai 2024 10:00 - 12:00')

--- a/shared/api/endpoints/__tests__/createEventsEndpoint.spec.ts
+++ b/shared/api/endpoints/__tests__/createEventsEndpoint.spec.ts
@@ -71,6 +71,7 @@ describe('events', () => {
       ],
     },
     recurrence_rule: rrule,
+    location_path: '/testumgebung/de/locations/testort/',
   })
 
   const createEventModel = (allDay: boolean, startDate: DateTime, endDate: DateTime, rrule?: string): EventModel =>
@@ -121,6 +122,7 @@ describe('events', () => {
           height: 500,
         },
       }),
+      locationPath: '/testumgebung/de/locations/testort/',
     })
 
   const event1 = createEvent(false, '2016-01-31T10:00:00+01:00', '2016-01-31T13:00:00+01:00')

--- a/shared/api/endpoints/createEventsEndpoint.ts
+++ b/shared/api/endpoints/createEventsEndpoint.ts
@@ -86,6 +86,7 @@ export default (baseUrl: string): Endpoint<ParamsType, Array<EventModel>> =>
                     full: event.featured_image.full[0],
                   })
                 : null,
+              locationPath: event.location_path,
             })
           })
           .sort(eventCompare),

--- a/shared/api/endpoints/testing/EventModelBuilder.ts
+++ b/shared/api/endpoints/testing/EventModelBuilder.ts
@@ -118,6 +118,7 @@ class EventModelBuilder {
                     <img src='${resourceUrl2}'/>`,
             thumbnail,
             featuredImage: null,
+            locationPath: '/testumgebung/de/locations/testort/',
           }),
           resources: {
             [resourceUrl1]: this.createResource(resourceUrl1, index, lastUpdate),

--- a/shared/api/models/EventModel.ts
+++ b/shared/api/models/EventModel.ts
@@ -14,6 +14,7 @@ class EventModel extends ExtendedPageModel {
   _location: LocationModel<number | null> | null
   _excerpt: string
   _featuredImage: FeaturedImageModel | null
+  _locationPath: string | null
 
   constructor(params: {
     path: string
@@ -26,14 +27,16 @@ class EventModel extends ExtendedPageModel {
     availableLanguages: Record<string, string>
     lastUpdate: DateTime
     featuredImage: FeaturedImageModel | null
+    locationPath: string | null
   }) {
-    const { date, location, excerpt, featuredImage, ...other } = params
+    const { date, location, excerpt, featuredImage, locationPath, ...other } = params
     super(other)
     this._date = date
     this._location = location
     // Remove carriage returns that break e.g. ical
     this._excerpt = decodeHTML(excerpt).replace(/\r/g, '').trim()
     this._featuredImage = featuredImage
+    this._locationPath = locationPath
   }
 
   get date(): DateModel {
@@ -50,6 +53,10 @@ class EventModel extends ExtendedPageModel {
 
   get featuredImage(): FeaturedImageModel | null {
     return this._featuredImage
+  }
+
+  get locationPath(): string | null {
+    return this._locationPath
   }
 
   toICal(baseUrl: string, appName: string, recurring: boolean): string {

--- a/shared/api/models/__tests__/EventModel.spec.ts
+++ b/shared/api/models/__tests__/EventModel.spec.ts
@@ -32,6 +32,7 @@ describe('EventModel', () => {
     availableLanguages: {},
     lastUpdate: DateTime.fromISO('2022-06-05T17:50:00+02:00'),
     featuredImage: null,
+    locationPath: '/testumgebung/de/locations/testort/',
   }
   const event = new EventModel(params)
   const baseUrl = 'https://example.com'
@@ -100,5 +101,9 @@ describe('EventModel', () => {
     expect(encodeURI(description)).toBe(
       'DESCRIPTION:Wer%20darf%20teilnehmen?%5Cn%20%20%20%20%20%20Alle%20Frauen%20sind%20herzlich%20willkommen.%5Cn%20%20%20%20%20%20Was%20machen%20wir%20genau?%5Cn%5Cn%20%20%20%20%20%20Yoga%5Cn%20%20%20%20%20%20Stretching%5Cn%20%20%20%20Dancing%5Cn%5Cn%20%20%20%20Das%20Angebot%20ist%20kostenlos%5Cn%20%20%20%20Bitte%20melden%20Sie%20sich:%5Cn%20%20%20%20%20%20%C2%A0%5Cn%20%20%20%20anmeldung@invia-augbsurg.de%5Cn%20%20%20%2008214494625%5Cn%20%20%20%20Informationen%20bez%C3%BCglich%20des%20Orts%20erhalten%20Sie%20nach%20der%20Anmeldung%5Cn%5Cnhttps://example.com/augsburg/de/events/event0',
     )
+  })
+
+  it('should have a location path', () => {
+    expect(event.locationPath).toBe('/testumgebung/de/locations/testort/')
   })
 })

--- a/shared/api/types.ts
+++ b/shared/api/types.ts
@@ -117,6 +117,7 @@ export type JsonEventType = {
   location: JsonLocationType<number | null>
   featured_image: JsonFeaturedImageType | null | undefined
   recurrence_rule?: string | null
+  location_path: string | null
 }
 export type JsonTunewsType = {
   id: number

--- a/web/src/components/PageDetail.tsx
+++ b/web/src/components/PageDetail.tsx
@@ -1,19 +1,27 @@
 import React, { ReactElement } from 'react'
 import styled from 'styled-components'
 
+import Link from './base/Link'
+
 const Identifier = styled.span`
   font-weight: 700;
+`
+
+const StyledLink = styled(Link)`
+  color: ${props => props.theme.colors.linkColor};
+  text-decoration: underline;
 `
 
 type PageDetailProps = {
   identifier: string
   information: string
+  pathToInformation?: string | null
 }
 
-const PageDetail = ({ identifier, information }: PageDetailProps): ReactElement => (
+const PageDetail = ({ identifier, information, pathToInformation }: PageDetailProps): ReactElement => (
   <div>
     <Identifier>{identifier}: </Identifier>
-    <span>{information}</span>
+    {pathToInformation ? <StyledLink to={pathToInformation}>{information}</StyledLink> : <span>{information}</span>}
   </div>
 )
 

--- a/web/src/components/__tests__/JsonLdEvent.spec.tsx
+++ b/web/src/components/__tests__/JsonLdEvent.spec.tsx
@@ -55,6 +55,7 @@ describe('JsonLdEvent', () => {
           height: 40,
         },
       }),
+      locationPath: '/testumgebung/de/locations/testort/',
     })
     expect(createJsonLd(eventModel)).toEqual({
       '@context': 'https://schema.org',

--- a/web/src/components/__tests__/PageDetail.spec.tsx
+++ b/web/src/components/__tests__/PageDetail.spec.tsx
@@ -6,10 +6,20 @@ import PageDetail from '../PageDetail'
 describe('PageDetail', () => {
   const identifier = 'Date'
   const information = 'May 22, 2020 1:00 AM'
+  const path = '/testumgebung/de/location1'
 
-  it('should render correctly', () => {
+  it('should render correctly without a path', () => {
     const { getByText } = renderWithRouterAndTheme(<PageDetail identifier={identifier} information={information} />)
     expect(getByText(`${identifier}:`)).toBeDefined()
     expect(getByText(information)).toBeDefined()
+  })
+
+  it('should render correctly with a path', () => {
+    const { getByText, getByRole, debug } = renderWithRouterAndTheme(
+      <PageDetail identifier={identifier} information={information} pathToInformation={path} />,
+    )
+    expect(getByText(`${identifier}:`)).toBeDefined()
+    expect(getByText(information)).toBeDefined()
+    expect(getByRole('link', { name: information })).toHaveAttribute('href', path)
   })
 })

--- a/web/src/components/__tests__/PageDetail.spec.tsx
+++ b/web/src/components/__tests__/PageDetail.spec.tsx
@@ -15,7 +15,7 @@ describe('PageDetail', () => {
   })
 
   it('should render correctly with a path', () => {
-    const { getByText, getByRole, debug } = renderWithRouterAndTheme(
+    const { getByText, getByRole } = renderWithRouterAndTheme(
       <PageDetail identifier={identifier} information={information} pathToInformation={path} />,
     )
     expect(getByText(`${identifier}:`)).toBeDefined()

--- a/web/src/routes/EventsPage.tsx
+++ b/web/src/routes/EventsPage.tsx
@@ -126,7 +126,13 @@ const EventsPage = ({ city, pathname, languageCode, cityCode }: CityRouteProps):
           BeforeContent={
             <Spacing $content={content} $lastUpdate={lastUpdate}>
               <DatesPageDetail date={date} languageCode={languageCode} />
-              {location && <PageDetail identifier={t('address')} information={location.fullAddress} />}
+              {location && (
+                <PageDetail
+                  identifier={t('address')}
+                  information={location.fullAddress}
+                  pathToInformation={event.locationPath}
+                />
+              )}
             </Spacing>
           }
           Footer={<ExportEventButton event={event} />}


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
When creating an event in the CMS, you can choose a POI as a possible location. These now get displayed as links to the POI when you look at the event in the app too.

One weird thing: after a rebuild in the native app on my machine, the `locationPath` only shows up after a pull-to-refresh. Any ideas why? Anybody else have the same problem?

### Proposed changes

<!-- Describe this PR in more detail. -->

- Add the `locationPath` to the `EventModel`
- Turn the address in the event page / route into a link to the POI if we get a `locationPath`

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- If no `locationPath` is present, nothing should change, not even with RTL but please double-check :)

### Testing

I would recommend using http://localhost:9000/testumgebung/de/events/test-veranstaltung-mit-link-zu-ort for testing.

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2223 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
