### PR TITLE
2886: Not working Link in Aschaffenburg

### DIFF
--- a/native/src/components/RemoteContent.tsx
+++ b/native/src/components/RemoteContent.tsx
@@ -133,9 +133,37 @@ const RemoteContent = (props: RemoteContentProps): ReactElement | null => {
   if (error) {
     return <Failure code={ErrorCode.UnknownError} />
   }
+  const injectedJavaScript = `
+  (function() {
+    document.addEventListener('touchend', function(e) {
+      var target = e.target || e.srcElement;
+      
+      function findClosestAnchor(element) {
+        while (element) {
+          if (element.tagName.toLowerCase() === 'a') {
+            return element;
+          }
+          element = element.parentElement;
+        }
+        return null;
+      }
+      if (['a', 'li', 'span', 'strong'].includes(target.tagName.toLowerCase())) {
+        var anchor = findClosestAnchor(target);
+        if (anchor) {
+          e.preventDefault();
+          window.location.href = anchor.getAttribute('href');
+        }
+      } else {
+        e.stopPropagation();
+      }
+    }, false);
+  })();
+  true;
+`
 
   return (
     <WebView
+      injectedJavaScript={injectedJavaScript}
       source={{
         baseUrl: resourceCacheUrl,
         html: renderHtml(

--- a/release-notes/unreleased/ReleaseNoteTemplate.yml
+++ b/release-notes/unreleased/ReleaseNoteTemplate.yml
@@ -1,0 +1,6 @@
+issue_key: 2886
+show_in_stores: false
+platforms: # relevant platforms, possible values: web, android and ios
+  - android
+  - ios
+en: Improved touch response for better navigation


### PR DESCRIPTION
### Short description

When pressing an anchor tag inside the WebView , the scroll position jumps down.

### Proposed changes

<!-- Describe this PR in more detail. -->

- Injecting JavaScript to webView to prevent <a> tag from scrolling.
- The code should listen to presses and go through nested elements to find <a> tag and forward the href to the window. 

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

None.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

1. Open 'Hallo Aschaffenburg' - tile 'Hallo!'
2. Swipe up and tap 'Aschaffenburg in Zahlen'
3. Swipe all the way up
4. Tap at 'Broschüre zum Familienleben' -> page opens; all fine now tap at back
5. Again tap at 'Broschüre zum Familienleben' -> page jumps by about 250 pixel down;

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2886

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
