### PR TITLE
2922: Prevent app from crashing for invalid urls

### DIFF
--- a/shared/utils/normalizePath.ts
+++ b/shared/utils/normalizePath.ts
@@ -1,5 +1,13 @@
 import normalizePath from 'normalize-path'
 
-const normalize = (value: string): string => decodeURIComponent(normalizePath(value)).toLowerCase()
+import { NOT_FOUND_ROUTE } from '../routes'
+
+const normalize = (value: string): string => {
+  try {
+    return decodeURIComponent(normalizePath(value)).toLowerCase()
+  } catch (_) {
+    return NOT_FOUND_ROUTE
+  }
+}
 
 export default normalize


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
Prevent app from crashing for invalid urls.

### Proposed changes

<!-- Describe this PR in more detail. -->
- Catch errors in `normalizePath` and return the NOT_FOUND route to show an error (which will lead to a not found error being displayed)
- Do nothing if the server already returns an error (the second case in the issue)

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

None.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
This can't be tested with webpack-dev-server. We have to release this to webnext and then test there.
To simulate the behavior, you can change [L53 in `CityContentSwitcher`](https://github.com/digitalfabrik/integreat-app/blob/34857b4c87f3d07e764fd05fd4c05fb6188a8ddc/web/src/CityContentSwitcher.tsx#L53) to
``` ts
  const pathname = normalizePath('/lkmuenchen/ru/%D0%BF%D1%80%D0%B8%D0%B1%D1%8B%D1%82%D0%B8%D0%B5-%D0%B8-%D0%B6%D0%B8%D0%B7%D0%BD%D1%8C-%D0%B2-%D0%B3%D0%B5%D1%80%D0%BC%D0%B0%D0%BD%D0%B8%D0%B8/%D0%BC%D0%BE%D0%B1%D0%B8%D0%BB%D1%8C%D0%BD%D0%BE%D1%81%D1%82%D1%8C/%D0')
```

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2922.

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
