### PR TITLE
2160: Fix jumping webview issue by switching libraries

### DIFF
--- a/native/package.json
+++ b/native/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "@dr.pogodin/react-native-static-server": "^0.5.5",
+    "@dr.pogodin/react-native-webview": "^13.13.0",
     "@gorhom/bottom-sheet": "^4.6.4",
     "@maplibre/maplibre-react-native": "^9.1.0",
     "@notifee/react-native": "^7.8.2",
@@ -87,7 +88,6 @@
     "react-native-screens": "^3.34.0",
     "react-native-svg": "^15.6.0",
     "react-native-url-polyfill": "^2.0.0",
-    "react-native-webview": "^13.12.1",
     "react-navigation-header-buttons": "^11.2.1",
     "rrule": "^2.8.1",
     "shared": "0.0.1",

--- a/native/src/__tests__/Navigator.spec.tsx
+++ b/native/src/__tests__/Navigator.spec.tsx
@@ -23,7 +23,7 @@ jest.mock('../utils/sentry')
 jest.mock('react-native/Libraries/Utilities/useWindowDimensions')
 jest.mock('react-i18next')
 jest.mock('react-native/Libraries/EventEmitter/NativeEventEmitter')
-jest.mock('react-native-webview', () => ({
+jest.mock('@dr.pogodin/react-native-webview', () => ({
   default: () => jest.fn(),
 }))
 jest.mock('../routes/Intro', () => {

--- a/native/src/components/Page.tsx
+++ b/native/src/components/Page.tsx
@@ -83,6 +83,7 @@ const Page = ({
         cacheDictionary={cacheDictionary}
         onLinkPress={onLinkPress}
         onLoad={onLoad}
+        loading={loading}
         language={language}
         resourceCacheUrl={resourceCacheUrl}
       />

--- a/native/src/components/RemoteContent.tsx
+++ b/native/src/components/RemoteContent.tsx
@@ -1,7 +1,7 @@
+import WebView, { WebViewMessageEvent, WebViewNavigation } from '@dr.pogodin/react-native-webview'
 import React, { ReactElement, useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Text, Platform, useWindowDimensions } from 'react-native'
-import WebView, { WebViewMessageEvent, WebViewNavigation } from 'react-native-webview'
 import { useTheme } from 'styled-components/native'
 
 import { CONSENT_ROUTE } from 'shared'
@@ -23,6 +23,13 @@ import { log, reportError } from '../utils/sentry'
 import Failure from './Failure'
 import { ParsedCacheDictionaryType } from './Page'
 
+// Fixes crashing in Android
+// https://github.com/react-native-webview/react-native-webview/issues/811
+const DEFAULT_OPACITY = 0.99
+
+// Fix title being displayed only after content is visible
+const LOADING_OPACITY = 0
+
 export const renderWebviewError = (
   errorDomain: string | null | undefined,
   errorCode: number,
@@ -40,11 +47,19 @@ type RemoteContentProps = {
   resourceCacheUrl: string
   onLinkPress: (url: string) => void
   onLoad: () => void
+  loading: boolean
 }
 
 // If the app crashes without an error message while using RemoteContent, consider wrapping it in a ScrollView or setting a manual height
-const RemoteContent = (props: RemoteContentProps): ReactElement | null => {
-  const { onLoad, content, cacheDictionary, resourceCacheUrl, language, onLinkPress } = props
+const RemoteContent = ({
+  onLoad,
+  content,
+  cacheDictionary,
+  resourceCacheUrl,
+  language,
+  onLinkPress,
+  loading,
+}: RemoteContentProps): ReactElement | null => {
   const [error, setError] = useState<string | null>(null)
   const [pressedUrl, setPressedUrl] = useState<string | null>(null)
   const { settings, updateSettings } = useAppContext()
@@ -167,7 +182,7 @@ const RemoteContent = (props: RemoteContentProps): ReactElement | null => {
       setSupportMultipleWindows={false}
       style={{
         height: webViewHeight,
-        opacity: 0.99, // fixes crashing in Android https://github.com/react-native-webview/react-native-webview/issues/811
+        opacity: loading ? LOADING_OPACITY : DEFAULT_OPACITY,
       }}
     />
   )

--- a/native/src/components/__tests__/CategoryListItem.spec.tsx
+++ b/native/src/components/__tests__/CategoryListItem.spec.tsx
@@ -6,7 +6,7 @@ import render from '../../testing/render'
 import CategoryListItem from '../CategoryListItem'
 
 jest.mock('styled-components')
-jest.mock('react-native-webview', () => ({
+jest.mock('@dr.pogodin/react-native-webview', () => ({
   default: () => jest.fn(),
 }))
 

--- a/native/src/components/__tests__/SearchListItem.spec.tsx
+++ b/native/src/components/__tests__/SearchListItem.spec.tsx
@@ -10,7 +10,7 @@ import SearchListItem from '../SearchListItem'
 
 jest.mock('react-i18next')
 jest.mock('styled-components')
-jest.mock('react-native-webview', () => ({
+jest.mock('@dr.pogodin/react-native-webview', () => ({
   default: () => jest.fn(),
 }))
 

--- a/native/src/constants/webview.ts
+++ b/native/src/constants/webview.ts
@@ -1,5 +1,5 @@
+import { WebViewSource } from '@dr.pogodin/react-native-webview/lib/WebViewTypes'
 import { Platform } from 'react-native'
-import { WebViewSource } from 'react-native-webview/lib/WebViewTypes'
 
 export const ERROR_MESSAGE_TYPE = 'error'
 export const WARNING_MESSAGE_TYPE = 'warning'

--- a/native/src/routes/__tests__/SearchModal.spec.tsx
+++ b/native/src/routes/__tests__/SearchModal.spec.tsx
@@ -21,7 +21,7 @@ import SearchModal, { SearchModalProps } from '../SearchModal'
 jest.mock('../../utils/sendTrackingSignal')
 jest.mock('../../hooks/useResourceCache', () => () => ({}))
 jest.mock('react-i18next')
-jest.mock('react-native-webview', () => ({
+jest.mock('@dr.pogodin/react-native-webview', () => ({
   default: jest.fn,
 }))
 jest.mock('react-native-inappbrowser-reborn', () => ({

--- a/release-notes/unreleased/2160-jumping-webview.yml
+++ b/release-notes/unreleased/2160-jumping-webview.yml
@@ -1,0 +1,6 @@
+issue_key: 2160
+show_in_stores: true
+platforms:
+  - android
+en: Fixed a bug causing the content to jump if pressed.
+de: Unerwartete Sprünge des Inhalts werden nun verhindert.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1643,6 +1643,14 @@
   resolved "https://registry.yarnpkg.com/@dr.pogodin/react-native-static-server/-/react-native-static-server-0.5.5.tgz#f7695c0b3f9b039bbbfb4fd7d3d9d875ee90daba"
   integrity sha512-EwstRdTIfUcKOyyf8PYJFkz9XMRGCuCru1wmlyllrItyCvykAAum6HK4koUjzEemY+A3twY2V7tr7pa9qslpmw==
 
+"@dr.pogodin/react-native-webview@^13.13.0":
+  version "13.13.0"
+  resolved "https://registry.yarnpkg.com/@dr.pogodin/react-native-webview/-/react-native-webview-13.13.0.tgz#7105cc4918152b9272cc287dfe89b34d5de90c61"
+  integrity sha512-QKARvM6hbd89OA3KIUjRIZy5ccaDR8PRoIAyznAHVxWR/lC6FDSXXVVm3LS33tiQt4SbLvifYK/k89CeOgjK6w==
+  dependencies:
+    escape-string-regexp "^4.0.0"
+    invariant "2.2.4"
+
 "@dual-bundle/import-meta-resolve@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.0.0.tgz#df79b7ea62c55094dc129880387864cdf41eca7c"
@@ -13604,14 +13612,6 @@ react-native-url-polyfill@^2.0.0:
   integrity sha512-My330Do7/DvKnEvwQc0WdcBnFPploYKp9CYlefDXzIdEaA+PAhDYllkvGeEroEzvc4Kzzj2O4yVdz8v6fjRvhA==
   dependencies:
     whatwg-url-without-unicode "8.0.0-3"
-
-react-native-webview@^13.12.1:
-  version "13.12.2"
-  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-13.12.2.tgz#b379b28c725632efabb42a2cf8387bd03cf34f33"
-  integrity sha512-OpRcEhf1IEushREax6rrKTeqGrHZ9OmryhZLBLQQU4PwjqVsq55iC8OdYSD61/F628f9rURn9THyxEZjrknpQQ==
-  dependencies:
-    escape-string-regexp "^4.0.0"
-    invariant "2.2.4"
 
 react-native@*:
   version "0.73.6"


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
This PR fixes both #2160 and #2886 caused by the webview jumping on simple press on Android.

### Proposed changes

<!-- Describe this PR in more detail. -->

- Switch to https://github.com/birdofpreyru/react-native-webview (a well-maintained fork of https://github.com/react-native-webview/react-native-webview) that fixes the upstream issue https://github.com/react-native-webview/react-native-webview/issues/3014
- We might switch back to the original library once the issue is fixed upstream

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
None.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Test if this PR resolves the two linked issues and try clicking various elements in our content.

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2160, #2886.

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
