### PR TITLE
2948: Start a new chat for each region

### DIFF
--- a/release-notes/unreleased/2948-unique-chat-id.yml
+++ b/release-notes/unreleased/2948-unique-chat-id.yml
@@ -1,0 +1,5 @@
+issue_key: 2948
+show_in_stores: false
+platforms:
+  - web
+en: Chats are not shared across regions.

--- a/web/src/components/ChatController.tsx
+++ b/web/src/components/ChatController.tsx
@@ -24,7 +24,7 @@ const POLLING_INTERVAL = 16000
 const ChatController = ({ city, language }: ChatControllerProps): ReactElement => {
   const [sendingStatus, setSendingStatus] = useState<SendingStatusType>('idle')
   const { value: deviceId } = useLocalStorage({
-    key: LOCAL_STORAGE_ITEM_CHAT_MESSAGES,
+    key: `${LOCAL_STORAGE_ITEM_CHAT_MESSAGES}-${city}`,
     initialValue: window.crypto.randomUUID(),
   })
   const {


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
Start a new chat for each region instead of sharing the chat instance.
This would break the chat in the backend.

### Proposed changes

<!-- Describe this PR in more detail. -->

Store the id of the chat in the local storage related to the city.

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

:warning: Previous chats won't work anymore (unless the chat id is copied manually to the new local storage entry).

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Open the chat in testumgebung and send a message.
Then go to muenchen and open the chat and confirm that there is no chat yet.

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2948, https://github.com/digitalfabrik/integreat-chat/issues/54.

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
