### PR TITLE
2961: Fix app crash for scaleX on svg

### DIFF
--- a/native/package.json
+++ b/native/package.json
@@ -86,7 +86,7 @@
     "react-native-reanimated": "^3.15.1",
     "react-native-safe-area-context": "^4.10.9",
     "react-native-screens": "^3.34.0",
-    "react-native-svg": "^15.6.0",
+    "react-native-svg": "^15.7.1",
     "react-native-url-polyfill": "^2.0.0",
     "react-navigation-header-buttons": "^11.2.1",
     "rrule": "^2.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13597,10 +13597,10 @@ react-native-svg-transformer@^1.3.0:
     "@svgr/plugin-svgo" "^8.1.0"
     path-dirname "^1.0.2"
 
-react-native-svg@^15.6.0:
-  version "15.6.0"
-  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-15.6.0.tgz#13b2af53b1701597df301122b869b61918e1e9a5"
-  integrity sha512-TUtR+h+yi1ODsd8FHdom1TpjfWOmnaK5pri5rnSBXnMqpzq8o2zZfonHTjPX+nS3wb/Pu2XsoARgYaHNjVWXhQ==
+react-native-svg@^15.7.1:
+  version "15.7.1"
+  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-15.7.1.tgz#299bf5ff21fb355a0f4bedd4cb8f9f520725c4fe"
+  integrity sha512-Xc11L4t6/DtmUwrQqHR7S45Qy3cIWpcfGlmEatVeZ9c1N8eAK79heJmGRgCOVrXESrrLEHfP/AYGf0BGyrvV6A==
   dependencies:
     css-select "^5.1.0"
     css-tree "^1.1.3"


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
Fix app crash for scaleX on svg.

### Proposed changes

<!-- Describe this PR in more detail. -->

Upgrade react-native-svg.

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

None.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
See issue.

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2961.

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
