### PR TITLE
Speed up local development android builds

### DIFF
--- a/native/run
+++ b/native/run
@@ -21,7 +21,7 @@ program
   .option('--production', 'whether a production (release) build should be made')
   .action((buildConfigName, options) => {
     const { production } = options
-    const productionFlag = production ? '--mode=release' : ''
+    const buildFlag = production ? '--mode=release' : '--active-arch-only'
 
     const jsonBuildConfig = execSync(
       `yarn workspace --silent build-configs --silent manage to-json ${buildConfigName} android`,
@@ -34,7 +34,7 @@ program
       .toString()
       .replaceAll('\n', ' ')
     execSync(
-      `yarn cross-env ${buildConfig} yarn react-native run-android --no-packager --appId ${applicationId} ${productionFlag}`,
+      `yarn cross-env ${buildConfig} yarn react-native run-android --no-packager --appId ${applicationId} ${buildFlag}`,
       { stdio: 'inherit' },
     )
   })


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
Speed up local development android builds using `--active-arch-only` flag.
See https://reactnative.dev/docs/build-speed#build-only-one-abi-during-development-android-only.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Android build  still works.

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: None.

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
