### PR TITLE
2924: Rename e2e testumgebung

### DIFF
--- a/e2e-tests/shared/constants.ts
+++ b/e2e-tests/shared/constants.ts
@@ -1,6 +1,6 @@
 export const filter = 'wirschaffendas'
 export const contentSearch = 'language'
-export const defaultCity = 'Testumgebung Ende-zu-Ende-Testing'
+export const defaultCity = 'E2E-Testumgebung'
 export const augsburgCity = 'Stadt Augsburg'
 export const language = 'en'
 

--- a/shared/api/models/__tests__/EventModel.spec.ts
+++ b/shared/api/models/__tests__/EventModel.spec.ts
@@ -6,6 +6,8 @@ import DateModel from '../DateModel'
 import EventModel from '../EventModel'
 import LocationModel from '../LocationModel'
 
+jest.useFakeTimers({ now: new Date('2023-10-02T15:23:57.443+02:00') })
+
 describe('EventModel', () => {
   const params = {
     path: '/augsburg/de/events/event0',


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
- Rename e2e testumgebung
- Fix failing unit test by mocking time

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
None.

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2924.

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
