### PR TITLE
2953: Switch to android app bundles (.aab)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -326,6 +326,16 @@ jobs:
                 paths:
                     - << parameters.build_config_name >>.apk
                 root: native/android
+            - run:
+                command: mv app/build/outputs/bundle/release/app-release.aab << parameters.build_config_name >>.aab
+                name: Rename aab
+                working_directory: native/android
+            - store_artifacts:
+                path: native/android/<< parameters.build_config_name >>.aab
+            - persist_to_workspace:
+                paths:
+                    - << parameters.build_config_name >>.aab
+                root: native/android
             - unless:
                 condition:
                     or:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -579,7 +579,7 @@ jobs:
                 name: '[FL] Browserstack Upload Live'
                 working_directory: native
             - run:
-                command: bundle exec fastlane android playstore_upload build_config_name:<< parameters.build_config_name >> apk_path:attached_workspace/<< parameters.build_config_name >>.apk production_delivery:"<< parameters.production_delivery >>" version_name:${NEW_VERSION_NAME} version_code:${NEW_VERSION_CODE}
+                command: bundle exec fastlane android playstore_upload build_config_name:<< parameters.build_config_name >> aab_path:attached_workspace/<< parameters.build_config_name >>.aab production_delivery:"<< parameters.production_delivery >>" version_name:${NEW_VERSION_NAME} version_code:${NEW_VERSION_CODE}
                 name: '[FL] Play Store Upload'
                 working_directory: native
             - notify

--- a/.circleci/src/jobs/build_android.yml
+++ b/.circleci/src/jobs/build_android.yml
@@ -70,6 +70,16 @@ steps:
       root: native/android
       paths:
         - << parameters.build_config_name >>.apk
+  - run:
+      name: Rename aab
+      command: mv app/build/outputs/bundle/release/app-release.aab << parameters.build_config_name >>.aab
+      working_directory: native/android
+  - store_artifacts:
+      path: native/android/<< parameters.build_config_name >>.aab
+  - persist_to_workspace:
+      root: native/android
+      paths:
+        - << parameters.build_config_name >>.aab
   - unless:
       condition:
         or:

--- a/.circleci/src/jobs/deliver_android.yml
+++ b/.circleci/src/jobs/deliver_android.yml
@@ -32,6 +32,6 @@ steps:
       working_directory: native
   - run:
       name: '[FL] Play Store Upload'
-      command: bundle exec fastlane android playstore_upload build_config_name:<< parameters.build_config_name >> apk_path:attached_workspace/<< parameters.build_config_name >>.apk production_delivery:"<< parameters.production_delivery >>" version_name:${NEW_VERSION_NAME} version_code:${NEW_VERSION_CODE}
+      command: bundle exec fastlane android playstore_upload build_config_name:<< parameters.build_config_name >> aab_path:attached_workspace/<< parameters.build_config_name >>.aab production_delivery:"<< parameters.production_delivery >>" version_name:${NEW_VERSION_NAME} version_code:${NEW_VERSION_CODE}
       working_directory: native
   - notify

--- a/native/android/fastlane/Fastfile
+++ b/native/android/fastlane/Fastfile
@@ -68,7 +68,7 @@ lane :build do |options|
   end
 
   gradle(
-      task: "assembleRelease",
+      tasks: ["assembleRelease", "bundleRelease"],
       properties: {
           :BUILD_CONFIG_NAME => build_config_name,
           :VERSION_CODE => version_code,

--- a/native/fastlane/Fastfile
+++ b/native/fastlane/Fastfile
@@ -66,8 +66,8 @@ platform :android do
   # version_code: The version code of the app
   # version_name: The version name of the app
   # build_config_name: The name of the build config
-  # apk_path: The path of the apk to upload (relative to home dir)
-  # production_delivery: Whether the apk should be uploaded to the production track
+  # aab_path: The path of the aab to upload (relative to home dir)
+  # production_delivery: Whether the aab should be uploaded to the production track
   desc "Deliver the app to Play Store. Depending on the option `production_delivery` the update is released to the general public."
   lane :playstore_upload do |options|
     ensure_env_vars(
@@ -77,10 +77,10 @@ platform :android do
     version_code = options[:version_code]
     version_name = options[:version_name]
     build_config_name = options[:build_config_name]
-    apk_path = options[:apk_path]
+    aab_path = options[:aab_path]
     production_delivery = options[:production_delivery]
 
-    if [version_name, version_code, build_config_name, apk_path, production_delivery].include?(nil)
+    if [version_name, version_code, build_config_name, aab_path, production_delivery].include?(nil)
       raise "'nil' passed as parameter! Aborting..."
     end
 
@@ -102,7 +102,7 @@ platform :android do
         skip_upload_screenshots: skip_images,
         skip_upload_metadata: false,
         release_status: "completed",
-        apk: "#{ENV['HOME']}/#{apk_path}",
+        aab: "#{ENV['HOME']}/#{aab_path}",
         json_key_data: ENV["GOOGLE_SERVICE_ACCOUNT_JSON"]
     )
   end
@@ -153,6 +153,7 @@ platform :android do
       skip_upload_screenshots: true,
       skip_upload_metadata: true,
       skip_upload_apk: true,
+      skip_upload_aab: true,
       release_status: "completed",
       json_key_data: ENV["GOOGLE_SERVICE_ACCOUNT_JSON"]
     )

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{"versionName":"2024.10.3","versionCode":100042400}
+{"versionName":"2024.10.4","versionCode":100042401}

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{"versionName":"2024.10.4","versionCode":100042401}
+{"versionName":"2024.10.5","versionCode":100042402}

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{"versionName":"2024.10.5","versionCode":100042402}
+{"versionName":"2024.10.6","versionCode":100042403}


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
Switch to android app bundles (.aab) to reduce download size.

### Proposed changes

<!-- Describe this PR in more detail. -->

- Build and upload .aabs
- Continue to include .apks to the release notes

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
None.

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2953

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
