### PR TITLE
2818: Remove codeclimate from CI to fix builds of forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,22 +229,8 @@ commands:
         description: Runs the test task and stores coverage and junit data
         steps:
             - run:
-                command: |
-                    # download test reporter as a static binary
-                    curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-                    chmod +x ./cc-test-reporter
-                name: Setup Code Climate test-reporter
-            - run:
-                command: ./cc-test-reporter before-build
-                name: Code Climate before build
-            - run:
                 command: yarn test:ci --maxWorkers ${TOTAL_CPUS}
                 name: Unit Tests with Coverage
-            - run:
-                command: |
-                    ./cc-test-reporter format-coverage -t lcov -o reports/coverage/codeclimate.json reports/coverage/lcov.info
-                    ./cc-test-reporter upload-coverage -i reports/coverage/codeclimate.json
-                name: Code Climate after build
             - store_test_results:
                 path: reports/unit-test
             - store_artifacts:
@@ -1095,7 +1081,6 @@ workflows:
                 prepare_delivery: false
             - check:
                 context:
-                    - codeclimate-integreat-app
                     - mattermost
             - build_web:
                 build_config_name: integreat-test-cms
@@ -1210,7 +1195,6 @@ workflows:
                 prepare_delivery: true
             - check:
                 context:
-                    - codeclimate-integreat-app
                     - mattermost
             - e2e_web:
                 context:
@@ -1543,7 +1527,6 @@ workflows:
                 prepare_delivery: true
             - check:
                 context:
-                    - codeclimate-integreat-app
                     - mattermost
             - build_android:
                 build_config_name: integreat-e2e
@@ -1751,7 +1734,6 @@ workflows:
                 prepare_delivery: true
             - check:
                 context:
-                    - codeclimate-integreat-app
                     - mattermost
             - build_android:
                 build_config_name: integreat-e2e
@@ -2009,7 +1991,6 @@ workflows:
                 prepare_delivery: true
             - check:
                 context:
-                    - codeclimate-integreat-app
                     - mattermost
             - e2e_web:
                 context:
@@ -2086,7 +2067,6 @@ workflows:
                 prepare_delivery: true
             - check:
                 context:
-                    - codeclimate-integreat-app
                     - mattermost
             - e2e_web:
                 context:

--- a/.circleci/src/commands/unit_test.yml
+++ b/.circleci/src/commands/unit_test.yml
@@ -1,22 +1,8 @@
 description: Runs the test task and stores coverage and junit data
 steps:
   - run:
-      name: Setup Code Climate test-reporter
-      command: |
-        # download test reporter as a static binary
-        curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-        chmod +x ./cc-test-reporter
-  - run:
-      name: Code Climate before build
-      command: ./cc-test-reporter before-build
-  - run:
       name: Unit Tests with Coverage
       command: yarn test:ci --maxWorkers ${TOTAL_CPUS}
-  - run:
-      name: Code Climate after build
-      command: |
-        ./cc-test-reporter format-coverage -t lcov -o reports/coverage/codeclimate.json reports/coverage/lcov.info
-        ./cc-test-reporter upload-coverage -i reports/coverage/codeclimate.json
   - store_test_results:
       path: reports/unit-test
   - store_artifacts:

--- a/.circleci/src/workflows/commit.yml
+++ b/.circleci/src/workflows/commit.yml
@@ -10,7 +10,6 @@ jobs:
 
   - check:
       context:
-        - codeclimate-integreat-app
         - mattermost
 
   - build_web:

--- a/.circleci/src/workflows/delivery.yml
+++ b/.circleci/src/workflows/delivery.yml
@@ -11,7 +11,6 @@ jobs:
 
   - check:
       context:
-        - codeclimate-integreat-app
         - mattermost
 
   - e2e_web:

--- a/.circleci/src/workflows/native_beta_delivery.yml
+++ b/.circleci/src/workflows/native_beta_delivery.yml
@@ -10,7 +10,6 @@ jobs:
       prepare_delivery: true
   - check:
       context:
-        - codeclimate-integreat-app
         - mattermost
 
   - build_android:

--- a/.circleci/src/workflows/native_production_delivery.yml
+++ b/.circleci/src/workflows/native_production_delivery.yml
@@ -11,7 +11,6 @@ jobs:
 
   - check:
       context:
-        - codeclimate-integreat-app
         - mattermost
 
   - build_android:

--- a/.circleci/src/workflows/web_beta_delivery.yml
+++ b/.circleci/src/workflows/web_beta_delivery.yml
@@ -10,7 +10,6 @@ jobs:
       prepare_delivery: true
   - check:
       context:
-        - codeclimate-integreat-app
         - mattermost
   - e2e_web:
       context:

--- a/.circleci/src/workflows/web_production_delivery.yml
+++ b/.circleci/src/workflows/web_production_delivery.yml
@@ -10,7 +10,6 @@ jobs:
       prepare_delivery: true
   - check:
       context:
-        - codeclimate-integreat-app
         - mattermost
   - e2e_web:
       context:

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/facebook/react/blob/master/LICENSE)
 [![versioning](https://img.shields.io/badge/calver-YYYY.MM.PATCH-22bfda.svg)](version.json)
 [![CircleCI Status](https://circleci.com/gh/digitalfabrik/integreat-app.svg?style=shield)](https://circleci.com/gh/digitalfabrik/integreat-app)
-[![Maintainability](https://api.codeclimate.com/v1/badges/5be95233a83e181d8a42/maintainability)](https://codeclimate.com/github/digitalfabrik/integreat-app/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/5be95233a83e181d8a42/test_coverage)](https://codeclimate.com/github/digitalfabrik/integreat-app/test_coverage)
 [![CodeScene Code Health](https://codescene.io/projects/53058/status-badges/code-health)](https://codescene.io/projects/53058)
 
 # integreat-app


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
Remove codeclimate from CI to fix builds of forks. Codeclimate was not actively used by us anymore.

### Proposed changes

<!-- Describe this PR in more detail. -->

- Remove codeclimate

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- The corresponding context in circleci can only be removed after this is merged to avoid failing builds

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Just have a look at the builds and see that they succeed.

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2818

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
