### PR TITLE
2548: Split up web feedback at the first level into two smileys again

### DIFF
--- a/web/src/components/CityContentToolbar.tsx
+++ b/web/src/components/CityContentToolbar.tsx
@@ -73,9 +73,7 @@ const CityContentToolbar = (props: CityContentToolbarProps) => {
           id='copy-icon'
         />
       </Tooltip>
-      {hasFeedbackOption && (
-        <FeedbackToolbarItem route={route} slug={feedbackTarget} isInBottomActionSheet={isInBottomActionSheet} />
-      )}
+      {hasFeedbackOption && <FeedbackToolbarItem route={route} slug={feedbackTarget} />}
     </Toolbar>
   )
 }

--- a/web/src/components/Feedback.tsx
+++ b/web/src/components/Feedback.tsx
@@ -46,7 +46,7 @@ type FeedbackProps = {
   contactMail: string
   onCommentChanged: (comment: string) => void
   onContactMailChanged: (contactMail: string) => void
-  onFeedbackChanged: (isPositiveFeedback: boolean | null) => void
+  onFeedbackChanged?: (isPositiveFeedback: boolean | null) => void
   onSubmit: () => void
   sendingStatus: SendingStatusType
   noResults: boolean | undefined
@@ -94,7 +94,7 @@ const Feedback = ({
           </InputSection>
         </>
       ) : (
-        <FeedbackButtons isPositive={isPositiveFeedback} onRatingChange={onFeedbackChanged} />
+        onFeedbackChanged && <FeedbackButtons isPositive={isPositiveFeedback} onRatingChange={onFeedbackChanged} />
       )}
 
       <InputSection

--- a/web/src/components/FeedbackContainer.tsx
+++ b/web/src/components/FeedbackContainer.tsx
@@ -15,6 +15,7 @@ type FeedbackContainerProps = {
   noResults?: boolean
   slug?: string
   onSubmit?: () => void
+  isPositive: boolean | null
 }
 
 export type SendingStatusType = 'idle' | 'sending' | 'failed' | 'successful'
@@ -28,8 +29,9 @@ export const FeedbackContainer = ({
   slug,
   onClose,
   onSubmit,
+  isPositive,
 }: FeedbackContainerProps): ReactElement => {
-  const [isPositiveRating, setIsPositiveRating] = useState<boolean | null>(null)
+  const [isPositiveRating, setIsPositiveRating] = useState<boolean | null>(isPositive)
   const [comment, setComment] = useState<string>('')
   const [contactMail, setContactMail] = useState<string>('')
   const [sendingStatus, setSendingStatus] = useState<SendingStatusType>('idle')

--- a/web/src/components/FeedbackContainer.tsx
+++ b/web/src/components/FeedbackContainer.tsx
@@ -15,7 +15,8 @@ type FeedbackContainerProps = {
   noResults?: boolean
   slug?: string
   onSubmit?: () => void
-  isPositive: boolean | null
+  isPositiveRating: boolean | null
+  setIsPositiveRating?: (isPositiveFeedback: boolean | null) => void
 }
 
 export type SendingStatusType = 'idle' | 'sending' | 'failed' | 'successful'
@@ -29,9 +30,9 @@ export const FeedbackContainer = ({
   slug,
   onClose,
   onSubmit,
-  isPositive,
+  isPositiveRating,
+  setIsPositiveRating,
 }: FeedbackContainerProps): ReactElement => {
-  const [isPositiveRating, setIsPositiveRating] = useState<boolean | null>(isPositive)
   const [comment, setComment] = useState<string>('')
   const [contactMail, setContactMail] = useState<string>('')
   const [sendingStatus, setSendingStatus] = useState<SendingStatusType>('idle')

--- a/web/src/components/FeedbackToolbarItem.tsx
+++ b/web/src/components/FeedbackToolbarItem.tsx
@@ -13,10 +13,9 @@ import ToolbarItem from './ToolbarItem'
 type FeedbackToolbarItemProps = {
   route: RouteType
   slug?: string
-  isInBottomActionSheet: boolean
 }
 
-const FeedbackToolbarItem = ({ route, slug, isInBottomActionSheet }: FeedbackToolbarItemProps): ReactElement => {
+const FeedbackToolbarItem = ({ route, slug }: FeedbackToolbarItemProps): ReactElement => {
   const { cityCode, languageCode } = useCityContentParams()
   const [isFeedbackOpen, setIsFeedbackOpen] = useState(false)
   const [isSubmitted, setIsSubmitted] = useState(false)
@@ -27,7 +26,7 @@ const FeedbackToolbarItem = ({ route, slug, isInBottomActionSheet }: FeedbackToo
   return (
     <>
       {isFeedbackOpen && (
-        <Modal title={title} closeModal={() => setIsFeedbackOpen(false)} wrapInPortal={isInBottomActionSheet}>
+        <Modal title={title} closeModal={() => setIsFeedbackOpen(false)} wrapInPortal>
           <FeedbackContainer
             onClose={() => setIsFeedbackOpen(false)}
             onSubmit={() => setIsSubmitted(true)}

--- a/web/src/components/FeedbackToolbarItem.tsx
+++ b/web/src/components/FeedbackToolbarItem.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 
 import { FeedbackRouteType } from 'shared/api'
 
-import { FeedbackIcon } from '../assets'
+import { HappySmileyIcon, SadSmileyIcon } from '../assets'
 import useCityContentParams from '../hooks/useCityContentParams'
 import { RouteType } from '../routes'
 import FeedbackContainer from './FeedbackContainer'
@@ -20,6 +20,7 @@ const FeedbackToolbarItem = ({ route, slug, isInBottomActionSheet }: FeedbackToo
   const { cityCode, languageCode } = useCityContentParams()
   const [isFeedbackOpen, setIsFeedbackOpen] = useState(false)
   const [isSubmitted, setIsSubmitted] = useState(false)
+  const [isPositive, setIsPositive] = useState<boolean | null>(null)
   const { t } = useTranslation('feedback')
   const title = isSubmitted ? t('thanksHeadline') : t('headline')
 
@@ -34,10 +35,26 @@ const FeedbackToolbarItem = ({ route, slug, isInBottomActionSheet }: FeedbackToo
             cityCode={cityCode}
             language={languageCode}
             slug={slug}
+            isPositive={isPositive}
           />
         </Modal>
       )}
-      <ToolbarItem icon={FeedbackIcon} text={t('feedback')} onClick={() => setIsFeedbackOpen(true)} />
+      <ToolbarItem
+        icon={HappySmileyIcon}
+        text={t('useful')}
+        onClick={() => {
+          setIsFeedbackOpen(true)
+          setIsPositive(true)
+        }}
+      />
+      <ToolbarItem
+        icon={SadSmileyIcon}
+        text={t('notUseful')}
+        onClick={() => {
+          setIsFeedbackOpen(true)
+          setIsPositive(false)
+        }}
+      />
     </>
   )
 }

--- a/web/src/components/FeedbackToolbarItem.tsx
+++ b/web/src/components/FeedbackToolbarItem.tsx
@@ -19,7 +19,7 @@ const FeedbackToolbarItem = ({ route, slug }: FeedbackToolbarItemProps): ReactEl
   const { cityCode, languageCode } = useCityContentParams()
   const [isFeedbackOpen, setIsFeedbackOpen] = useState(false)
   const [isSubmitted, setIsSubmitted] = useState(false)
-  const [isPositive, setIsPositive] = useState<boolean | null>(null)
+  const [isPositiveRating, setIsPositiveRating] = useState<boolean | null>(null)
   const { t } = useTranslation('feedback')
   const title = isSubmitted ? t('thanksHeadline') : t('headline')
 
@@ -34,7 +34,8 @@ const FeedbackToolbarItem = ({ route, slug }: FeedbackToolbarItemProps): ReactEl
             cityCode={cityCode}
             language={languageCode}
             slug={slug}
-            isPositive={isPositive}
+            isPositiveRating={isPositiveRating}
+            setIsPositiveRating={setIsPositiveRating}
           />
         </Modal>
       )}
@@ -43,7 +44,7 @@ const FeedbackToolbarItem = ({ route, slug }: FeedbackToolbarItemProps): ReactEl
         text={t('useful')}
         onClick={() => {
           setIsFeedbackOpen(true)
-          setIsPositive(true)
+          setIsPositiveRating(true)
         }}
       />
       <ToolbarItem
@@ -51,7 +52,7 @@ const FeedbackToolbarItem = ({ route, slug }: FeedbackToolbarItemProps): ReactEl
         text={t('notUseful')}
         onClick={() => {
           setIsFeedbackOpen(true)
-          setIsPositive(false)
+          setIsPositiveRating(false)
         }}
       />
     </>

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -1,11 +1,11 @@
-import React, { ReactNode, useLayoutEffect, useState } from 'react'
+import React, { ReactNode } from 'react'
 import styled, { css } from 'styled-components'
 
 import dimensions from '../constants/dimensions'
 import useWindowDimensions from '../hooks/useWindowDimensions'
+import '../styles/Aside.css'
 import { MobileBanner } from './MobileBanner'
-
-const additionalToolbarTopSpacing = 32
+import Portal from './Portal'
 
 export const RichLayout = styled.div`
   position: relative;
@@ -49,6 +49,7 @@ const Body = styled.div<{ $fullWidth: boolean; $disableScrollingSafari: boolean 
   background-color: ${props => props.theme.colors.backgroundColor};
   word-wrap: break-word;
   min-height: 100%;
+  display: flex;
 
   /* Fix jumping iOS Safari Toolbar by prevent scrolling on body */
 
@@ -93,25 +94,6 @@ const Main = styled.main<{ $fullWidth: boolean }>`
   }
 `
 
-const Aside = styled.aside<{ $languageSelectorHeight: number }>`
-  top: ${props => props.$languageSelectorHeight + dimensions.headerHeightLarge + additionalToolbarTopSpacing}px;
-  margin-top: ${props => props.$languageSelectorHeight - dimensions.navigationMenuHeight}px;
-  display: inline-block;
-  position: sticky;
-  width: ${dimensions.toolbarWidth}px;
-  vertical-align: top;
-  z-index: 10;
-
-  &:empty {
-    display: none;
-  }
-
-  &:empty + * {
-    display: block;
-    max-width: 100%;
-  }
-`
-
 export const LAYOUT_ELEMENT_ID = 'layout'
 
 type LayoutProps = {
@@ -133,20 +115,18 @@ const Layout = ({
   fullWidth = false,
   disableScrollingSafari = false,
 }: LayoutProps): JSX.Element => {
-  const { width, viewportSmall } = useWindowDimensions()
-  const [languageSelectorHeight, setLanguageSelectorHeight] = useState<number>(0)
-
-  useLayoutEffect(() => {
-    const panelHeight = document.getElementById('languageSelector')?.clientHeight
-    setLanguageSelectorHeight(panelHeight ?? 0)
-  }, [width])
+  const { viewportSmall } = useWindowDimensions()
 
   return (
     <RichLayout id={LAYOUT_ELEMENT_ID}>
       <MobileBanner />
       {header}
       <Body $fullWidth={fullWidth} $disableScrollingSafari={disableScrollingSafari}>
-        {!viewportSmall && <Aside $languageSelectorHeight={languageSelectorHeight}>{toolbar}</Aside>}
+        {!viewportSmall && (
+          <Portal className='aside' show>
+            {toolbar}
+          </Portal>
+        )}
         <Main $fullWidth={fullWidth}>{children}</Main>
       </Body>
       {viewportSmall && toolbar}

--- a/web/src/components/SearchFeedback.tsx
+++ b/web/src/components/SearchFeedback.tsx
@@ -35,7 +35,7 @@ const SearchFeedback = ({ cityCode, languageCode, query, noResults }: SearchFeed
           routeType={SEARCH_ROUTE}
           query={query}
           noResults={noResults}
-          isPositive={null}
+          isPositiveRating={null}
         />
       </Container>
     )

--- a/web/src/components/SearchFeedback.tsx
+++ b/web/src/components/SearchFeedback.tsx
@@ -35,6 +35,7 @@ const SearchFeedback = ({ cityCode, languageCode, query, noResults }: SearchFeed
           routeType={SEARCH_ROUTE}
           query={query}
           noResults={noResults}
+          isPositive={null}
         />
       </Container>
     )

--- a/web/src/components/__tests__/FeedbackContainer.spec.tsx
+++ b/web/src/components/__tests__/FeedbackContainer.spec.tsx
@@ -34,6 +34,7 @@ describe('FeedbackContainer', () => {
     language,
     onClose: closeModal,
     query,
+    isPositive: null,
   })
 
   it('should display thanks message for modal', async () => {

--- a/web/src/components/__tests__/FeedbackContainer.spec.tsx
+++ b/web/src/components/__tests__/FeedbackContainer.spec.tsx
@@ -34,15 +34,13 @@ describe('FeedbackContainer', () => {
     language,
     onClose: closeModal,
     query,
-    isPositive: null,
+    isPositiveRating: null,
   })
 
   it('should display thanks message for modal', async () => {
-    const { getByRole, findByText } = renderWithTheme(<FeedbackContainer {...buildDefaultProps(CATEGORIES_ROUTE)} />)
-    const buttonRating = getByRole('button', {
-      name: 'feedback:useful',
-    })
-    fireEvent.click(buttonRating)
+    const { getByRole, findByText } = renderWithTheme(
+      <FeedbackContainer {...buildDefaultProps(CATEGORIES_ROUTE)} isPositiveRating />,
+    )
     const button = getByRole('button', {
       name: 'feedback:send',
     })

--- a/web/src/components/__tests__/FeedbackToolbarItem.spec.tsx
+++ b/web/src/components/__tests__/FeedbackToolbarItem.spec.tsx
@@ -24,12 +24,11 @@ describe('FeedbackToolbarItem', () => {
     expect(queryByText('feedback:headline')).toBeFalsy()
     expect(queryByText('feedback:thanksHeadline')).toBeFalsy()
 
-    fireEvent.click(getByText('feedback:feedback'))
+    fireEvent.click(getByText('feedback:useful'))
 
     expect(getByText('feedback:headline')).toBeTruthy()
     expect(queryByText('feedback:thanksHeadline')).toBeFalsy()
 
-    fireEvent.click(getByText('feedback:useful'))
     fireEvent.click(getByText('feedback:send'))
 
     expect(await findByText('feedback:thanksMessage')).toBeTruthy()

--- a/web/src/components/__tests__/FeedbackToolbarItem.spec.tsx
+++ b/web/src/components/__tests__/FeedbackToolbarItem.spec.tsx
@@ -18,7 +18,7 @@ jest.mock('focus-trap-react', () => ({ children }: { children: ReactElement }) =
 describe('FeedbackToolbarItem', () => {
   it('should open and update title on submit feedback', async () => {
     const { queryByText, findByText, getByText } = renderWithRouterAndTheme(
-      <FeedbackToolbarItem route={CATEGORIES_ROUTE} slug='my-slug' isInBottomActionSheet={false} />,
+      <FeedbackToolbarItem route={CATEGORIES_ROUTE} slug='my-slug' />,
     )
 
     expect(queryByText('feedback:headline')).toBeFalsy()

--- a/web/src/styles/Aside.css
+++ b/web/src/styles/Aside.css
@@ -1,0 +1,18 @@
+.aside {
+  position: fixed;
+  top: 35%;
+  width: 100px;
+  left: 3%;
+
+  @media (min-width: 1100px) {
+    left: 10%;
+  }
+
+  &:empty {
+    display: none;
+  }
+
+  &:empty + * {
+    max-width: 100%;
+  }
+}

--- a/web/src/styles/Aside.css
+++ b/web/src/styles/Aside.css
@@ -2,7 +2,7 @@
   position: fixed;
   top: 35%;
   width: 100px;
-  left: 3%;
+  left: 1%;
 
   @media (min-width: 1100px) {
     left: 10%;
@@ -10,9 +10,5 @@
 
   &:empty {
     display: none;
-  }
-
-  &:empty + * {
-    max-width: 100%;
   }
 }


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
The municipalities have been receiving way less feedback since we made some changes there about half a year ago. In this PR, I changed the sidebar in web desktop / the footer in web mobile to show the two smileys instead of the button saying Feedback.

### Proposed changes

<!-- Describe this PR in more detail. -->

- Instead of showing the FeedbackIcon in the sidebar / footer, this shows the HappySmileyIcon and the SadSmileyIcon
- A click on either of those icons opens the feedback overlay with the clicked icon selected
- I added a Portal around the sidebar in web desktop to avoid the sidebar poking through when the language selection screen is open

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- If the device is narrower than 408px, the sad smiley jumps to a new row. Do we have a minimum width that we support?

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
- Check that sending feedback still works
- Check that the sidebar isn't hidden behind things it shouldn't be
- Check that the sidebar isn't hiding other things that it shouldn't be hiding

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2548 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
