### PR TITLE
3008: Hide the loader when first opening the search page

### DIFF
--- a/web/src/routes/SearchPage.tsx
+++ b/web/src/routes/SearchPage.tsx
@@ -82,6 +82,15 @@ const SearchPage = ({ city, cityCode, languageCode, pathname }: CityRouteProps):
     />
   )
 
+  if (query.length === 0) {
+    return (
+      <CityContentLayout isLoading {...locationLayoutParams}>
+        <Helmet pageTitle={pageTitle} languageChangePaths={languageChangePaths} cityModel={city} />
+        {SearchBar}
+      </CityContentLayout>
+    )
+  }
+
   if (loading || !results) {
     return (
       <CityContentLayout isLoading {...locationLayoutParams}>

--- a/web/src/routes/SearchPage.tsx
+++ b/web/src/routes/SearchPage.tsx
@@ -58,11 +58,19 @@ const SearchPage = ({ city, cityCode, languageCode, pathname }: CityRouteProps):
     code,
   }))
 
-  const locationLayoutParams: Omit<CityContentLayoutProps, 'isLoading'> = {
+  const layoutParams: Omit<CityContentLayoutProps, 'isLoading'> = {
     city,
     languageChangePaths,
     route: SEARCH_ROUTE,
     languageCode,
+  }
+
+  if (error) {
+    return (
+      <CityContentLayout isLoading={false} {...layoutParams}>
+        <FailureSwitcher error={error} />
+      </CityContentLayout>
+    )
   }
 
   const handleFilterTextChanged = (filterText: string): void => {
@@ -71,71 +79,52 @@ const SearchPage = ({ city, cityCode, languageCode, pathname }: CityRouteProps):
     navigate(`${pathname}/${appendToUrl}`, { replace: true })
   }
 
-  const pageTitle = `${t('pageTitle')} - ${city.name}`
-
-  const SearchBar = (
-    <SearchInput
-      filterText={filterText}
-      placeholderText={t('searchPlaceholder')}
-      onFilterTextChange={handleFilterTextChanged}
-      spaceSearch
-    />
-  )
-
-  if (query.length === 0) {
+  const getPageContent = () => {
+    if (query.length === 0) {
+      return null
+    }
+    if (loading || allPossibleResults.length === 0) {
+      return <LoadingSpinner />
+    }
     return (
-      <CityContentLayout isLoading {...locationLayoutParams}>
-        <Helmet pageTitle={pageTitle} languageChangePaths={languageChangePaths} cityModel={city} />
-        {SearchBar}
-      </CityContentLayout>
-    )
-  }
-
-  if (loading) {
-    return (
-      <CityContentLayout isLoading {...locationLayoutParams}>
-        <Helmet pageTitle={pageTitle} languageChangePaths={languageChangePaths} cityModel={city} />
-        {SearchBar}
-        <LoadingSpinner />
-      </CityContentLayout>
-    )
-  }
-
-  if (error) {
-    return (
-      <CityContentLayout isLoading={false} {...locationLayoutParams}>
-        <FailureSwitcher error={error} />
-      </CityContentLayout>
+      <>
+        <List>
+          <SearchCounter>{t('searchResultsCount', { count: results?.length ?? 0 })}</SearchCounter>
+          {results?.map(({ title, content, path, thumbnail }) => (
+            <SearchListItem
+              title={title}
+              contentWithoutHtml={parseHTML(content)}
+              key={path}
+              query={query}
+              path={path}
+              thumbnail={thumbnail}
+            />
+          ))}
+        </List>
+        <SearchFeedback
+          cityCode={cityCode}
+          languageCode={languageCode}
+          noResults={results?.length === 0}
+          query={filterText}
+        />
+      </>
     )
   }
 
   return (
-    <CityContentLayout isLoading={false} {...locationLayoutParams}>
-      <Helmet pageTitle={pageTitle} languageChangePaths={languageChangePaths} cityModel={city} />
-      {SearchBar}
-      {query.length > 0 && (
-        <>
-          <List>
-            <SearchCounter>{t('searchResultsCount', { count: results?.length })}</SearchCounter>
-            {results?.map(({ title, content, path, thumbnail }) => (
-              <SearchListItem
-                title={title}
-                contentWithoutHtml={parseHTML(content)}
-                key={path}
-                query={query}
-                path={path}
-                thumbnail={thumbnail}
-              />
-            ))}
-          </List>
-          <SearchFeedback
-            cityCode={cityCode}
-            languageCode={languageCode}
-            noResults={results?.length === 0}
-            query={filterText}
-          />
-        </>
-      )}
+    <CityContentLayout isLoading={false} {...layoutParams}>
+      <Helmet
+        pageTitle={`${t('pageTitle')} - ${city.name}`}
+        languageChangePaths={languageChangePaths}
+        cityModel={city}
+      />
+      <SearchInput
+        filterText={filterText}
+        placeholderText={t('searchPlaceholder')}
+        onFilterTextChange={handleFilterTextChanged}
+        spaceSearch
+      />
+      {getPageContent()}
     </CityContentLayout>
   )
 }

--- a/web/src/routes/SearchPage.tsx
+++ b/web/src/routes/SearchPage.tsx
@@ -83,14 +83,14 @@ const SearchPage = ({ city, cityCode, languageCode, pathname }: CityRouteProps):
     if (query.length === 0) {
       return null
     }
-    if (loading || allPossibleResults.length === 0) {
+    if (loading || !results) {
       return <LoadingSpinner />
     }
     return (
       <>
         <List>
-          <SearchCounter>{t('searchResultsCount', { count: results?.length ?? 0 })}</SearchCounter>
-          {results?.map(({ title, content, path, thumbnail }) => (
+          <SearchCounter>{t('searchResultsCount', { count: results.length })}</SearchCounter>
+          {results.map(({ title, content, path, thumbnail }) => (
             <SearchListItem
               title={title}
               contentWithoutHtml={parseHTML(content)}
@@ -104,7 +104,7 @@ const SearchPage = ({ city, cityCode, languageCode, pathname }: CityRouteProps):
         <SearchFeedback
           cityCode={cityCode}
           languageCode={languageCode}
-          noResults={results?.length === 0}
+          noResults={results.length === 0}
           query={filterText}
         />
       </>

--- a/web/src/routes/SearchPage.tsx
+++ b/web/src/routes/SearchPage.tsx
@@ -91,7 +91,7 @@ const SearchPage = ({ city, cityCode, languageCode, pathname }: CityRouteProps):
     )
   }
 
-  if (loading || !results) {
+  if (loading) {
     return (
       <CityContentLayout isLoading {...locationLayoutParams}>
         <Helmet pageTitle={pageTitle} languageChangePaths={languageChangePaths} cityModel={city} />
@@ -116,8 +116,8 @@ const SearchPage = ({ city, cityCode, languageCode, pathname }: CityRouteProps):
       {query.length > 0 && (
         <>
           <List>
-            <SearchCounter>{t('searchResultsCount', { count: results.length })}</SearchCounter>
-            {results.map(({ title, content, path, thumbnail }) => (
+            <SearchCounter>{t('searchResultsCount', { count: results?.length })}</SearchCounter>
+            {results?.map(({ title, content, path, thumbnail }) => (
               <SearchListItem
                 title={title}
                 contentWithoutHtml={parseHTML(content)}
@@ -131,7 +131,7 @@ const SearchPage = ({ city, cityCode, languageCode, pathname }: CityRouteProps):
           <SearchFeedback
             cityCode={cityCode}
             languageCode={languageCode}
-            noResults={results.length === 0}
+            noResults={results?.length === 0}
             query={filterText}
           />
         </>


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
When the search page opens, it shouldn't show a loader while we're loading stuff that the user can't see.

### Proposed changes

<!-- Describe this PR in more detail. -->

- Show only the search bar when the query is empty.

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Compare the loading of https://integreat.app/testumgebung/de/search and http://localhost:9000/testumgebung/de/search

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3008 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
