### PR TITLE
2548: Refactoring

### DIFF
--- a/web/src/components/CategoriesToolbar.tsx
+++ b/web/src/components/CategoriesToolbar.tsx
@@ -8,7 +8,7 @@ import config from 'translations/src/config'
 import { PdfIcon } from '../assets'
 import { cmsApiBaseUrl } from '../constants/urls'
 import CityContentToolbar from './CityContentToolbar'
-import ToolbarItem from './ToolbarItem'
+import ToolbarIcon from './ToolbarIcon'
 
 type CategoriesToolbarProps = {
   category?: CategoryModel
@@ -31,7 +31,7 @@ const CategoriesToolbar = (props: CategoriesToolbarProps): ReactElement => {
       route={CATEGORIES_ROUTE}
       feedbackTarget={category && !category.isRoot() ? category.slug : undefined}
       pageTitle={pageTitle}>
-      <ToolbarItem icon={PdfIcon} text={t('createPdf')} to={pdfUrl} isDisabled={config.hasRTLScript(languageCode)} />
+      <ToolbarIcon icon={PdfIcon} text={t('createPdf')} to={pdfUrl} isDisabled={config.hasRTLScript(languageCode)} />
     </CityContentToolbar>
   )
 }

--- a/web/src/components/CityContentToolbar.tsx
+++ b/web/src/components/CityContentToolbar.tsx
@@ -9,7 +9,7 @@ import { RouteType } from '../routes'
 import FeedbackToolbarIcons from './FeedbackToolbarIcons'
 import SharingPopup from './SharingPopup'
 import Toolbar from './Toolbar'
-import ToolbarItem from './ToolbarItem'
+import ToolbarIcon from './ToolbarIcon'
 import Tooltip from './base/Tooltip'
 
 type CityContentToolbarProps = {
@@ -66,7 +66,7 @@ const CityContentToolbar = (props: CityContentToolbarProps) => {
         isOpen={linkCopied}
         place={tooltipDirection}
         tooltipContent={t('common:copied')}>
-        <ToolbarItem
+        <ToolbarIcon
           icon={linkCopied ? DoneIcon : CopyIcon}
           text={t('copyUrl')}
           onClick={copyToClipboard}

--- a/web/src/components/CityContentToolbar.tsx
+++ b/web/src/components/CityContentToolbar.tsx
@@ -6,7 +6,7 @@ import { useTheme } from 'styled-components'
 import { CopyIcon, DoneIcon } from '../assets'
 import useWindowDimensions from '../hooks/useWindowDimensions'
 import { RouteType } from '../routes'
-import FeedbackToolbarItem from './FeedbackToolbarItem'
+import FeedbackToolbarIcons from './FeedbackToolbarIcons'
 import SharingPopup from './SharingPopup'
 import Toolbar from './Toolbar'
 import ToolbarItem from './ToolbarItem'
@@ -73,7 +73,7 @@ const CityContentToolbar = (props: CityContentToolbarProps) => {
           id='copy-icon'
         />
       </Tooltip>
-      {hasFeedbackOption && <FeedbackToolbarItem route={route} slug={feedbackTarget} />}
+      {hasFeedbackOption && <FeedbackToolbarIcons route={route} slug={feedbackTarget} />}
     </Toolbar>
   )
 }

--- a/web/src/components/FeedbackToolbarIcons.tsx
+++ b/web/src/components/FeedbackToolbarIcons.tsx
@@ -10,12 +10,12 @@ import FeedbackContainer from './FeedbackContainer'
 import Modal from './Modal'
 import ToolbarItem from './ToolbarItem'
 
-type FeedbackToolbarItemProps = {
+type FeedbackToolbarIconsProps = {
   route: RouteType
   slug?: string
 }
 
-const FeedbackToolbarItem = ({ route, slug }: FeedbackToolbarItemProps): ReactElement => {
+const FeedbackToolbarIcons = ({ route, slug }: FeedbackToolbarIconsProps): ReactElement => {
   const { cityCode, languageCode } = useCityContentParams()
   const [isFeedbackOpen, setIsFeedbackOpen] = useState(false)
   const [isSubmitted, setIsSubmitted] = useState(false)
@@ -59,4 +59,4 @@ const FeedbackToolbarItem = ({ route, slug }: FeedbackToolbarItemProps): ReactEl
   )
 }
 
-export default FeedbackToolbarItem
+export default FeedbackToolbarIcons

--- a/web/src/components/FeedbackToolbarIcons.tsx
+++ b/web/src/components/FeedbackToolbarIcons.tsx
@@ -8,7 +8,7 @@ import useCityContentParams from '../hooks/useCityContentParams'
 import { RouteType } from '../routes'
 import FeedbackContainer from './FeedbackContainer'
 import Modal from './Modal'
-import ToolbarItem from './ToolbarItem'
+import ToolbarIcon from './ToolbarIcon'
 
 type FeedbackToolbarIconsProps = {
   route: RouteType
@@ -39,7 +39,7 @@ const FeedbackToolbarIcons = ({ route, slug }: FeedbackToolbarIconsProps): React
           />
         </Modal>
       )}
-      <ToolbarItem
+      <ToolbarIcon
         icon={HappySmileyIcon}
         text={t('useful')}
         onClick={() => {
@@ -47,7 +47,7 @@ const FeedbackToolbarIcons = ({ route, slug }: FeedbackToolbarIconsProps): React
           setIsPositiveRating(true)
         }}
       />
-      <ToolbarItem
+      <ToolbarIcon
         icon={SadSmileyIcon}
         text={t('notUseful')}
         onClick={() => {

--- a/web/src/components/SharingPopup.tsx
+++ b/web/src/components/SharingPopup.tsx
@@ -6,7 +6,7 @@ import styled, { css, useTheme } from 'styled-components'
 import { CloseIcon, FacebookIcon, MailIcon, ShareIcon, WhatsappIcon } from '../assets'
 import useWindowDimensions from '../hooks/useWindowDimensions'
 import Portal from './Portal'
-import ToolbarItem from './ToolbarItem'
+import ToolbarIcon from './ToolbarIcon'
 import Button from './base/Button'
 import Icon from './base/Icon'
 import Link from './base/Link'
@@ -249,7 +249,7 @@ const SharingPopup = ({ shareUrl, title, flow, portalNeeded }: SharingPopupProps
           </TooltipContainer>
         </>
       )}
-      <ToolbarItem icon={ShareIcon} text={t('layout:share')} onClick={() => setShareOptionsVisible(true)} />
+      <ToolbarIcon icon={ShareIcon} text={t('layout:share')} onClick={() => setShareOptionsVisible(true)} />
     </SharingPopupContainer>
   )
 }

--- a/web/src/components/ToolbarIcon.tsx
+++ b/web/src/components/ToolbarIcon.tsx
@@ -10,7 +10,7 @@ import Icon from './base/Icon'
 import Link from './base/Link'
 import Tooltip from './base/Tooltip'
 
-const StyledToolbarItem = styled(Link)<{ disabled?: boolean }>`
+const StyledToolbarIcon = styled(Link)<{ disabled?: boolean }>`
   display: inline-block;
   padding: 8px;
   border: none;
@@ -31,7 +31,7 @@ const StyledTooltip = styled(Tooltip)`
   max-width: 250px;
 `
 
-type ItemProps =
+type IconProps =
   | {
       onClick: () => void
       to?: undefined
@@ -41,29 +41,29 @@ type ItemProps =
       to: string
     }
 
-type ToolbarItemProps = {
+type ToolbarIconProps = {
   icon: string
   text: string
   id?: string
   isDisabled?: boolean
-} & ItemProps
+} & IconProps
 
-const ToolbarItem = ({ to, text, icon, isDisabled = false, onClick, id }: ToolbarItemProps): ReactElement => {
+const ToolbarIcon = ({ to, text, icon, isDisabled = false, onClick, id }: ToolbarIconProps): ReactElement => {
   const { t } = useTranslation('categories')
   const toolTipId = spacesToDashes(text)
   if (isDisabled) {
     return (
       <StyledTooltip id={toolTipId} tooltipContent={t('disabledPdf')}>
         {/* @ts-expect-error wrong types from polymorphic 'as', see https://github.com/styled-components/styled-components/issues/4112 */}
-        <StyledToolbarItem as='div' id={id} label={text} disabled>
+        <StyledToolbarIcon as='div' id={id} label={text} disabled>
           <StyledIcon src={icon} disabled />
           <StyledSmallViewTip>{text}</StyledSmallViewTip>
-        </StyledToolbarItem>
+        </StyledToolbarIcon>
       </StyledTooltip>
     )
   }
   return (
-    <StyledToolbarItem
+    <StyledToolbarIcon
       as={onClick ? Button : undefined}
       id={id}
       // @ts-expect-error wrong types from polymorphic 'as', see https://github.com/styled-components/styled-components/issues/4112
@@ -73,8 +73,8 @@ const ToolbarItem = ({ to, text, icon, isDisabled = false, onClick, id }: Toolba
       disabled={false}>
       <StyledIcon src={icon} disabled={false} />
       <StyledSmallViewTip>{text}</StyledSmallViewTip>
-    </StyledToolbarItem>
+    </StyledToolbarIcon>
   )
 }
 
-export default ToolbarItem
+export default ToolbarIcon

--- a/web/src/components/__tests__/FeedbackToolbarItem.spec.tsx
+++ b/web/src/components/__tests__/FeedbackToolbarItem.spec.tsx
@@ -4,7 +4,7 @@ import React, { ReactElement } from 'react'
 import { CATEGORIES_ROUTE } from 'shared'
 
 import { renderWithRouterAndTheme } from '../../testing/render'
-import FeedbackToolbarItem from '../FeedbackToolbarItem'
+import FeedbackToolbarIcons from '../FeedbackToolbarIcons'
 
 jest.mock('react-i18next')
 jest.mock('shared/api', () => ({
@@ -15,10 +15,10 @@ jest.mock('shared/api', () => ({
 }))
 jest.mock('focus-trap-react', () => ({ children }: { children: ReactElement }) => <div>{children}</div>)
 
-describe('FeedbackToolbarItem', () => {
+describe('FeedbackToolbarIcons', () => {
   it('should open and update title on submit feedback', async () => {
     const { queryByText, findByText, getByText } = renderWithRouterAndTheme(
-      <FeedbackToolbarItem route={CATEGORIES_ROUTE} slug='my-slug' />,
+      <FeedbackToolbarIcons route={CATEGORIES_ROUTE} slug='my-slug' />,
     )
 
     expect(queryByText('feedback:headline')).toBeFalsy()


### PR DESCRIPTION
### Short description

As discussed in https://github.com/digitalfabrik/integreat-app/pull/3004#discussion_r1865704311, this just renames the component `FeedbackToolbarItem` to `FeedbackToolbarIcons` because -- as @steffenkleinle correctly pointed out -- it is confusing to have a component named `FeedbackToolbarItem` returning two `Items`.

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2548 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
