### PR TITLE
Hotfix: Fix map layout

### DIFF
--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -74,8 +74,8 @@ const Body = styled.div<{ $fullWidth: boolean; $disableScrollingSafari: boolean 
 
 const Main = styled.main<{ $fullWidth: boolean }>`
   display: inline-block;
-  width: ${props => (props.$fullWidth ? '100%' : dimensions.maxWidth - 2 * dimensions.toolbarWidth)}px;
-  max-width: calc(100% - ${dimensions.toolbarWidth}px);
+  width: ${props => (props.$fullWidth ? '100%' : `${dimensions.maxWidth - 2 * dimensions.toolbarWidth}px`)};
+  max-width: ${props => (props.$fullWidth ? '100%' : `calc(100% - ${dimensions.toolbarWidth}px)`)};
   box-sizing: border-box;
   margin: 0 auto;
   padding: ${props => (props.$fullWidth ? '0' : `0 ${dimensions.mainContainerHorizontalPadding}px 30px`)};


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
We currently have the beautiful line `width: ${props => (props.$fullWidth ? '100%' : dimensions.maxWidth - 2 * dimensions.toolbarWidth)}px;` in our code which leads to the `width: 100%px;` when `$fullWidth` is `true`. Until merging #3004, that was not a problem (I assume it was overwritten somewhere but I honestly don't see it). After merging #3004, we have a slight layout issue here: https://webnext.integreat.app/augsburg/en/locations This PR fixes that.

### Proposed changes

<!-- Describe this PR in more detail. -->

- Puts the `px` where it belongs
- Updates the `max-width` to account for the `$fullWidth` prop

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- I hope no new ones!

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Look at http://localhost:9000/testumgebung/de/locations in a desktop browser, compare it to https://webnext.integreat.app/augsburg/en/locations.
