### PR TITLE
3020: Fixing the unexpected scrolling behavior at mobile

### DIFF
--- a/web/src/index.ejs
+++ b/web/src/index.ejs
@@ -110,7 +110,12 @@
                 opacity: 1;
             }
         }
-
+        @media (max-width: 768px) {
+            html, body {
+                height: 100%;
+                overflow-x: hidden; 
+            }
+        }
         #splash {
             position: fixed;
             top: 0;


### PR DESCRIPTION
### Short description

If I scroll down on a longer page and follow a link to a shorter page, there is a lot of extra space at the bottom of the shorter page. The browser maintains the height from the previous page as a minimum.

### Proposed changes

<!-- Describe this PR in more detail. -->

- I just added added a `height: 100% ` and `overflow-x: hidden` for mobile screen only to prevent any unexpected issues that could occur for desktop.

### Side effects

I hope none despite this applied on body/html across the app.

### Testing
You can test this also on web.
- on Chrome go to `Landkreis Aichach-Friedberg`
- Select law and finance and scroll to the end (you can notice the space is gone).


Fixes: #3020 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
