### PR TITLE
2909: Fix copy text being cut off in the suggest your region page

### DIFF
--- a/native/src/routes/CityNotCooperating.tsx
+++ b/native/src/routes/CityNotCooperating.tsx
@@ -8,7 +8,7 @@ import TextButton from '../components/base/TextButton'
 import buildConfig, { buildConfigAssets } from '../constants/buildConfig'
 
 const Container = styled.ScrollView`
-  display: flex;
+  flex: 1;
   padding: 30px;
 `
 
@@ -59,10 +59,10 @@ const StyledButton = styled(TextButton)`
 `
 
 const TemplateText = styled.Text`
-  top: -20px;
+  margin-top: -20px;
   border: 1px solid ${props => props.theme.colors.themeColor};
-  padding: 50px 30px 30px;
-  margin-bottom: 40px;
+  padding: 30px 20px 20px;
+  margin-bottom: 250px;
 `
 
 const StyledIcon = styled(Icon)`


### PR DESCRIPTION
### Short description

Currently the copy text is not shown fully, half of it is cut off. The text should be fully shown.

### Proposed changes

<!-- Describe this PR in more detail. -->

Fix the scroll view and the template text's style

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

none

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2909 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
