### PR TITLE
Fix autocorrected typo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in the repo.
 
--       @steffenkleinle @f1sh1918 @LeandraH @bahaaTuffaha @lunars97
+*       @steffenkleinle @f1sh1918 @LeandraH @bahaaTuffaha @lunars97


### PR DESCRIPTION
### Short description

Sorry, I'm not sure why my editor autocorrected the `*` to a `-` in the last PR for the codeowners but this fixes it.