### PR TITLE
3048: Calendar button position fix

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -27,7 +27,7 @@ LuxonSettings.throwOnInvalid = true
 LuxonSettings.defaultLocale = config.defaultFallback
 
 const App = (): ReactElement => {
-  const [contentLanguage, setContentLanguage] = useState<string>(safeLocalStorage.getItem('i18nextLng') || '')
+  const [contentLanguage, setContentLanguage] = useState<string>(config.defaultFallback)
   const { t } = useTranslation('landing')
 
   const contentDirection = contentLanguage

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -27,7 +27,7 @@ LuxonSettings.throwOnInvalid = true
 LuxonSettings.defaultLocale = config.defaultFallback
 
 const App = (): ReactElement => {
-  const [contentLanguage, setContentLanguage] = useState<string>()
+  const [contentLanguage, setContentLanguage] = useState<string>(safeLocalStorage.getItem('i18nextLng') || '')
   const { t } = useTranslation('landing')
 
   const contentDirection = contentLanguage

--- a/web/src/components/DatePicker.tsx
+++ b/web/src/components/DatePicker.tsx
@@ -29,7 +29,7 @@ const StyledIconButton = styled(Button)<{ $isCalendarOpen: boolean }>`
   justify-content: center;
   align-items: center;
   position: absolute;
-  right: 16px;
+  ${props => (props.theme.contentDirection === 'rtl' ? 'left: 16px;' : 'right: 16px;')};
   align-self: center;
   background-color: ${props =>
     props.$isCalendarOpen ? props.theme.colors.themeColorLight : props.theme.colors.textDisabledColor};


### PR DESCRIPTION
### Short description

Calendar button for Event's date filter has a position problem when switching to RTL language.

### Proposed changes

<!-- Describe this PR in more detail. -->

- Switching sides depending language direction. 
- I had to fix the language direction by getting the i18nextLng from localStorage and setting the initial value for contentLanguage state at app.tsx (becouse when refreshing the page contentLanguage gets undefined to it defaults to ltr language)

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- App.tsx (web)
- DatePicker.tsx (web)

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3048 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
