### PR TITLE
3020: Fix unexpected scrolling behaviour in mobile desktop

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -16,6 +16,8 @@ import { initSentry } from './utils/sentry'
 
 const GlobalStyle = createGlobalStyle`
   body {
+    position: relative;
+  
     /* Styling for react-tooltip: https://react-tooltip.com/docs/getting-started#styling */
     --rt-color-dark: ${props => props.theme.colors.textSecondaryColor};
     --rt-color-white: ${props => props.theme.colors.backgroundColor};

--- a/web/src/components/KebabMenu.tsx
+++ b/web/src/components/KebabMenu.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, ReactNode } from 'react'
+import React, { ReactElement, ReactNode, useLayoutEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
@@ -77,6 +77,13 @@ const StyledIcon = styled(Icon)`
 const KebabMenu = ({ items, show, setShow, Footer }: KebabMenuProps): ReactElement | null => {
   useLockedBody(show)
   const { t } = useTranslation('layout')
+  const [scrollY, setScrollY] = useState<number>(0)
+
+  useLayoutEffect(() => {
+    if (show) {
+      setScrollY(window.scrollY)
+    }
+  }, [show])
 
   const onClick = () => {
     setShow(!show)
@@ -95,8 +102,8 @@ const KebabMenu = ({ items, show, setShow, Footer }: KebabMenuProps): ReactEleme
         className='kebab-menu'
         show={show}
         style={{
-          visibility: show ? 'visible' : 'hidden',
-          top: window.scrollY > 0 ? `${window.scrollY}px` : undefined,
+          display: show ? 'block' : 'none',
+          top: scrollY > 0 ? `${scrollY}px` : undefined,
         }}>
         {/* disabled because this is an overlay for backdrop close */}
         {/* eslint-disable-next-line styled-components-a11y/no-static-element-interactions,styled-components-a11y/click-events-have-key-events */}

--- a/web/src/styles/KebabMenu.css
+++ b/web/src/styles/KebabMenu.css
@@ -5,4 +5,5 @@
   width: 100%;
   height: 100%;
   overflow: hidden;
+  z-index: 10;
 }


### PR DESCRIPTION
### Short description

Currently the category pages are having additional scrollable blank height after the toolbar footer on the small screens if the side kebab-menu is activated. This might be happening because of the `visibility: hidden` attribute of the `Portal` potentially taking up unintended space due to it being a part of the DOM, therefore it could still occupy space.

### Proposed changes

<!-- Describe this PR in more detail. -->

- use display instead of visibility
- add relative position to the parent element (body), because of the child `Portal` element having the absolute position
- add z-index to be placed above the category elements
- refactor `window.scrollY`  to calculate and memoize the value and to make sure the side menu starts at the top of the screen

### Testing

- Open the side-menu on the small screen and check the category and its children to see if there is additional height after the toolbar footer and try to open the side-menu as well as inside category children

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

-should be none?

### Resolved issues

Fixes: #3020 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
