### PR TITLE
2356: Show nearby cities for web

### DIFF
--- a/web/src/__tests__/RootSwitcher.spec.tsx
+++ b/web/src/__tests__/RootSwitcher.spec.tsx
@@ -16,6 +16,7 @@ import { renderWithRouterAndTheme } from '../testing/render'
 jest.mock('shared/api', () => ({
   ...jest.requireActual('shared/api'),
   useLoadFromEndpoint: jest.fn(),
+  useLoadAsync: jest.fn(() => ({ data: null, error: null })),
 }))
 jest.mock('../CityContentSwitcher')
 

--- a/web/src/components/CitySelector.tsx
+++ b/web/src/components/CitySelector.tsx
@@ -1,11 +1,12 @@
-import React, { ReactElement, useState } from 'react'
+import React, { ReactElement, useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
-import { filterSortCities } from 'shared'
-import { CityModel } from 'shared/api'
+import { filterSortCities, getNearbyCities, LocationType } from 'shared'
+import { CityModel, useLoadAsync } from 'shared/api'
 
 import buildConfig from '../constants/buildConfig'
+import getUserLocation from '../utils/getUserLocation'
 import CityEntry from './CityEntry'
 import CrashTestingIcon from './CrashTestingIcon'
 import Failure from './Failure'
@@ -25,9 +26,36 @@ const CityListParent = styled.div<{ $stickyTop: number }>`
   background-color: ${props => props.theme.colors.backgroundColor};
   border-bottom: 1px solid ${props => props.theme.colors.themeColor};
 `
+
 const SearchCounter = styled.p`
   color: ${props => props.theme.colors.textSecondaryColor};
 `
+
+type NearbyCitiesProps = {
+  userLocation: LocationType | null
+  cities: CityModel[]
+  language: string
+  filterText: string
+}
+
+const NearbyCities = ({ userLocation, cities, language, filterText }: NearbyCitiesProps) => {
+  const { t } = useTranslation('landing')
+  const nearCities = userLocation
+    ? getNearbyCities(
+        userLocation,
+        cities.filter(city => city.live),
+      )
+    : []
+
+  return nearCities.length > 0 ? (
+    <div key='nearbyCities'>
+      <CityListParent $stickyTop={0}>{t('nearbyCities')}</CityListParent>
+      {nearCities.map(city => (
+        <CityEntry key={city.code} city={city} language={language} filterText={filterText} />
+      ))}
+    </div>
+  ) : null
+}
 
 type CitySelectorProps = {
   cities: CityModel[]
@@ -38,6 +66,13 @@ const CitySelector = ({ cities, language }: CitySelectorProps): ReactElement => 
   const [filterText, setFilterText] = useState<string>('')
   const [stickyTop, setStickyTop] = useState<number>(0)
   const { t } = useTranslation('landing')
+
+  const { data: userLocation } = useLoadAsync(
+    useCallback(async () => {
+      const userLocation = await getUserLocation()
+      return userLocation.status === 'ready' ? userLocation.coordinates : null
+    }, []),
+  )
 
   const resultCities = filterSortCities(cities, filterText, buildConfig().featureFlags.developerFriendly)
 
@@ -62,6 +97,7 @@ const CitySelector = ({ cities, language }: CitySelectorProps): ReactElement => 
         spaceSearch={false}
         onStickyTopChanged={setStickyTop}>
         <SearchCounter>{t('search:searchResultsCount', { count: resultCities.length })}</SearchCounter>
+        <NearbyCities userLocation={userLocation} cities={cities} language={language} filterText={filterText} />
         {resultCities.length === 0 ? <Failure errorMessage='search:nothingFound' /> : groups}
       </ScrollingSearchBox>
     </Container>

--- a/web/src/components/__tests__/CitySelector.spec.tsx
+++ b/web/src/components/__tests__/CitySelector.spec.tsx
@@ -9,6 +9,10 @@ import CitySelector from '../CitySelector'
 
 jest.mock('react-inlinesvg')
 jest.mock('react-i18next')
+jest.mock('shared/api', () => ({
+  ...jest.requireActual('shared/api'),
+  useLoadAsync: jest.fn(() => ({ data: null, error: null })),
+}))
 
 describe('CitySelector', () => {
   const previousConfig = buildConfig()


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
Showing nearby cities for web.

### Proposed changes

<!-- Describe this PR in more detail. -->

- Created a small component just to show nearby cities similar to `groups`.
- Used the `getUserLocation()` the same way it's been used at `PoisPage.tsx`.
- Added some mocks.

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- `CitySelector.tsx`

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

- Change location or http://localhost:9000/landing/en
- Enable location and refresh the page.
- If you are not located in Germany you can override you location from F12 -> 3 dots menu -> more tools -> sensors -> change it to Berlin.

Fixes: #2356 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
