### PR TITLE
3054: Fix rtl display events

### DIFF
--- a/release-notes/unreleased/3054-fix-rtl-display-events.yml
+++ b/release-notes/unreleased/3054-fix-rtl-display-events.yml
@@ -1,0 +1,5 @@
+issue_key: 3054
+show_in_stores: false
+platforms:
+  - web
+en: Not recurring events will now be displayed correct for rtl languages.

--- a/web/src/components/ListItem.tsx
+++ b/web/src/components/ListItem.tsx
@@ -58,7 +58,7 @@ const ListItem = ({ path, title, thumbnail, thumbnailSize, children, Icon }: Lis
       {!!thumbnail && <Thumbnail alt='' src={thumbnail} $thumbnailSize={thumbnailSize} />}
       <Description>
         <TitleRow>
-          <Title dir='auto'>{title}</Title>
+          <Title>{title}</Title>
           {Icon}
         </TitleRow>
         {children}


### PR DESCRIPTION
### Short description

It looks like due to not needed direction tags, the rtl events are not displayed correctly,

### Proposed changes

<!-- Describe this PR in more detail. -->

- removed not needed direction tags for title row, since they will be inherited from `ListItemContainer`

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- may affect other components that use ListItems (Licenses, Pois, Breadcrumbs)

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Open: http://localhost:9000/testumgebung/ar/events

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3054

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
