### PR TITLE
Include ios and android for native and allow use of root project in IntelliJ

### DIFF
--- a/.idea/integreat-app.iml
+++ b/.idea/integreat-app.iml
@@ -5,14 +5,20 @@
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/locales" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/release-notes" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/tools" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/.idea" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/.github" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/.circleci" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/docs" isTestSource="false" />
-      <excludeFolder url="file://$MODULE_DIR$/native" />
-      <excludeFolder url="file://$MODULE_DIR$/web" />
+      <sourceFolder url="file://$MODULE_DIR$/release-notes" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/assets" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/build-configs" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/e2e-tests" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/shared" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/translations" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/native/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/web/src" isTestSource="false" />
+      <excludeFolder url="file://$MODULE_DIR$/native/android/.gradle" />
+      <excludeFolder url="file://$MODULE_DIR$/native/android/app/build" />
+      <excludeFolder url="file://$MODULE_DIR$/native/android/build" />
+      <excludeFolder url="file://$MODULE_DIR$/native/android/vendor" />
+      <excludeFolder url="file://$MODULE_DIR$/native/ios/vendor" />
+      <excludeFolder url="file://$MODULE_DIR$/native/vendor" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/native/.idea/integreat-app-native.iml
+++ b/native/.idea/integreat-app-native.iml
@@ -3,11 +3,18 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$/..">
+      <sourceFolder url="file://$MODULE_DIR$/../assets" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/../build-configs" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/../e2e-tests" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/../release-notes" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/../shared" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/../translations/override-translations" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/../translations/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/../translations/store-translations" type="java-resource" />
       <excludeFolder url="file://$MODULE_DIR$/../api-client/node_modules" />
       <excludeFolder url="file://$MODULE_DIR$/../api-client/reports" />
-      <excludeFolder url="file://$MODULE_DIR$/android" />
       <excludeFolder url="file://$MODULE_DIR$/flow-typed" />
-      <excludeFolder url="file://$MODULE_DIR$/ios" />
       <excludeFolder url="file://$MODULE_DIR$/node_modules" />
       <excludeFolder url="file://$MODULE_DIR$/reports" />
       <excludeFolder url="file://$MODULE_DIR$/../translations/external-jobs" />
@@ -23,6 +30,11 @@
       <excludeFolder url="file://$MODULE_DIR$/../.yarn" />
       <excludeFolder url="file://$MODULE_DIR$/.bundle" />
       <excludeFolder url="file://$MODULE_DIR$/vendor" />
+      <excludeFolder url="file://$MODULE_DIR$/android/.gradle" />
+      <excludeFolder url="file://$MODULE_DIR$/android/app/build" />
+      <excludeFolder url="file://$MODULE_DIR$/android/build" />
+      <excludeFolder url="file://$MODULE_DIR$/android/vendor" />
+      <excludeFolder url="file://$MODULE_DIR$/ios/vendor" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/web/.idea/integreat-app-web.iml
+++ b/web/.idea/integreat-app-web.iml
@@ -3,6 +3,15 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$/..">
+      <sourceFolder url="file://$MODULE_DIR$/../assets" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/../build-configs" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/../e2e-tests" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/../release-notes" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/../shared" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/../translations/override-translations" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/../translations/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/../translations/store-translations" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/../api-client/node_modules" />
       <excludeFolder url="file://$MODULE_DIR$/../api-client/reports" />
       <excludeFolder url="file://$MODULE_DIR$/../translations/external-jobs" />


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
Include ios and android for native and allow use of root project in IntelliJ.
This allows searching these files as well.

### Proposed changes

<!-- Describe this PR in more detail. -->

- Remove exclusion of ios and android on native
- Remove exclusion of native and web in the root project
- Mark directories correctly

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

The docs saying "open web or native" separately is kinda outdated/not the only option anymore. However, I would first try to work with the root project only for a bit before changing that recommendation.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Open the root or native project and play around. Let me know if you find this annoying.

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: N/A

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
- -->
