### PR TITLE
2926: Redesign search feedback native

### DIFF
--- a/native/src/components/Feedback.tsx
+++ b/native/src/components/Feedback.tsx
@@ -9,15 +9,12 @@ import useNavigate from '../hooks/useNavigate'
 import Caption from './Caption'
 import FeedbackButtons from './FeedbackButtons'
 import { SendingStatusType } from './FeedbackContainer'
-import HorizontalLine from './HorizontalLine'
 import LoadingSpinner from './LoadingSpinner'
 import Note from './Note'
-import NothingFound from './NothingFound'
 import InputSection from './base/InputSection'
 import TextButton from './base/TextButton'
 
 const Wrapper = styled.View`
-  padding: 20px;
   gap: 8px;
 `
 
@@ -79,11 +76,7 @@ const Feedback = ({
     <KeyboardAwareScrollView>
       <Wrapper>
         {isSearchFeedback ? (
-          <>
-            <NothingFound />
-            <HorizontalLine />
-            <InputSection title={t('searchTermDescription')} value={searchTerm} onChange={setSearchTerm} />
-          </>
+          <InputSection title={t('searchTermDescription')} value={searchTerm} onChange={setSearchTerm} />
         ) : (
           <>
             <Caption title={t('headline')} />

--- a/native/src/components/FeedbackContainer.tsx
+++ b/native/src/components/FeedbackContainer.tsx
@@ -21,11 +21,11 @@ const Container = styled.View`
   gap: 8px;
 `
 
-const BoldText = styled(Text)`
+const Title = styled(Text)`
   font-weight: 600;
 `
 
-const TextBeforeButton = styled(BoldText)`
+const Hint = styled(Title)`
   margin-top: 8px;
   text-align: center;
 `
@@ -88,11 +88,9 @@ const FeedbackContainer = ({ query, language, routeType, cityCode, slug }: Feedb
     })
   }
 
-  const fallbackLanguage = config.sourceLanguage
-
-  return (
-    <Container>
-      {showFeedback ? (
+  if (showFeedback) {
+    return (
+      <Container>
         <Feedback
           comment={comment}
           contactMail={contactMail}
@@ -105,16 +103,22 @@ const FeedbackContainer = ({ query, language, routeType, cityCode, slug }: Feedb
           searchTerm={searchTerm}
           setSearchTerm={setSearchTerm}
         />
-      ) : (
-        <>
-          <BoldText>
-            {language === fallbackLanguage ? t('noResultsInOneLanguage') : t('noResultsInTwoLanguages')}
-          </BoldText>
-          <Text>{t('checkQuery', { appName: buildConfig().appName })}</Text>
-          <TextBeforeButton>{t('informationMissing')}</TextBeforeButton>
-          <TextButton text={t('giveFeedback')} onPress={() => setShowFeedback(true)} />
-        </>
-      )}
+      </Container>
+    )
+  }
+
+  const fallbackLanguage = config.sourceLanguage
+
+  return (
+    <Container>
+      <>
+        <Title>
+          {language === fallbackLanguage ? t('noResultsInUserLanguage') : t('noResultsInUserAndSourceLanguage')}
+        </Title>
+        <Text>{t('checkQuery', { appName: buildConfig().appName })}</Text>
+        <Hint>{t('informationMissing')}</Hint>
+        <TextButton text={t('giveFeedback')} onPress={() => setShowFeedback(true)} />
+      </>
     </Container>
   )
 }

--- a/native/src/components/FeedbackContainer.tsx
+++ b/native/src/components/FeedbackContainer.tsx
@@ -1,17 +1,33 @@
 import React, { ReactElement, useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import styled from 'styled-components/native'
 
 import { SEND_FEEDBACK_SIGNAL_NAME } from 'shared'
 import { createFeedbackEndpoint, FeedbackRouteType } from 'shared/api'
+import { config } from 'translations'
 
+import buildConfig from '../constants/buildConfig'
 import { determineApiUrl } from '../utils/helpers'
 import sendTrackingSignal from '../utils/sendTrackingSignal'
 import { reportError } from '../utils/sentry'
 import Feedback from './Feedback'
+import Text from './base/Text'
+import TextButton from './base/TextButton'
 
 const Container = styled.View`
   flex: 1;
   background-color: ${props => props.theme.colors.backgroundColor};
+  padding: 8px 20px;
+  gap: 8px;
+`
+
+const BoldText = styled(Text)`
+  font-weight: 600;
+`
+
+const TextBeforeButton = styled(BoldText)`
+  margin-top: 8px;
+  text-align: center;
 `
 
 export type SendingStatusType = 'idle' | 'sending' | 'failed' | 'successful'
@@ -30,6 +46,8 @@ const FeedbackContainer = ({ query, language, routeType, cityCode, slug }: Feedb
   const [isPositiveRating, setIsPositiveRating] = useState<boolean | null>(null)
   const [sendingStatus, setSendingStatus] = useState<SendingStatusType>('idle')
   const [searchTerm, setSearchTerm] = useState<string | undefined>(query)
+  const [showFeedback, setShowFeedback] = useState<boolean>(query === undefined)
+  const { t } = useTranslation('feedback')
 
   useEffect(() => {
     setSearchTerm(query)
@@ -70,20 +88,33 @@ const FeedbackContainer = ({ query, language, routeType, cityCode, slug }: Feedb
     })
   }
 
+  const fallbackLanguage = config.sourceLanguage
+
   return (
     <Container>
-      <Feedback
-        comment={comment}
-        contactMail={contactMail}
-        sendingStatus={sendingStatus}
-        onCommentChanged={setComment}
-        onFeedbackContactMailChanged={setContactMail}
-        isPositiveFeedback={isPositiveRating}
-        setIsPositiveFeedback={setIsPositiveRating}
-        onSubmit={handleSubmit}
-        searchTerm={searchTerm}
-        setSearchTerm={setSearchTerm}
-      />
+      {showFeedback ? (
+        <Feedback
+          comment={comment}
+          contactMail={contactMail}
+          sendingStatus={sendingStatus}
+          onCommentChanged={setComment}
+          onFeedbackContactMailChanged={setContactMail}
+          isPositiveFeedback={isPositiveRating}
+          setIsPositiveFeedback={setIsPositiveRating}
+          onSubmit={handleSubmit}
+          searchTerm={searchTerm}
+          setSearchTerm={setSearchTerm}
+        />
+      ) : (
+        <>
+          <BoldText>
+            {language === fallbackLanguage ? t('noResultsInOneLanguage') : t('noResultsInTwoLanguages')}
+          </BoldText>
+          <Text>{t('checkQuery', { appName: buildConfig().appName })}</Text>
+          <TextBeforeButton>{t('informationMissing')}</TextBeforeButton>
+          <TextButton text={t('giveFeedback')} onPress={() => setShowFeedback(true)} />
+        </>
+      )}
     </Container>
   )
 }

--- a/native/src/components/__tests__/Feedback.spec.tsx
+++ b/native/src/components/__tests__/Feedback.spec.tsx
@@ -82,7 +82,6 @@ describe('Feedback', () => {
         <Feedback {...buildProps(false, 'comment', 'query')} />
       </NavigationContainer>,
     )
-    expect(getByText('search:nothingFound')).toBeDefined()
     expect(getByText('searchTermDescription')).toBeDefined()
   })
 

--- a/native/src/components/__tests__/FeedbackContainer.spec.tsx
+++ b/native/src/components/__tests__/FeedbackContainer.spec.tsx
@@ -123,6 +123,8 @@ describe('FeedbackContainer', () => {
         <FeedbackContainer routeType={SEARCH_ROUTE} language={language} cityCode={city} query={query} />
       </NavigationContainer>,
     )
+    const buttonToOpenFeedback = getByText('giveFeedback')
+    fireEvent.press(buttonToOpenFeedback)
     const button = getByText('send')
     fireEvent.press(button)
     expect(await findByText('thanksMessage')).toBeDefined()
@@ -148,6 +150,8 @@ describe('FeedbackContainer', () => {
         <FeedbackContainer routeType={SEARCH_ROUTE} language={language} cityCode={city} query={query} />
       </NavigationContainer>,
     )
+    const buttonToOpenFeedback = getByText('giveFeedback')
+    fireEvent.press(buttonToOpenFeedback)
     const input = getByDisplayValue(query)
     fireEvent.changeText(input, fullSearchTerm)
     const button = getByText('send')
@@ -168,11 +172,13 @@ describe('FeedbackContainer', () => {
   })
 
   it('should disable send button if query term is removed', async () => {
-    const { findByText, getByDisplayValue } = render(
+    const { findByText, getByDisplayValue, getByText } = render(
       <NavigationContainer>
         <FeedbackContainer routeType={SEARCH_ROUTE} language={language} cityCode={city} query='query' />
       </NavigationContainer>,
     )
+    const buttonToOpenFeedback = getByText('giveFeedback')
+    fireEvent.press(buttonToOpenFeedback)
     expect(await findByText('send')).not.toBeDisabled()
     const input = getByDisplayValue('query')
     fireEvent.changeText(input, '')

--- a/native/src/routes/__tests__/SearchModal.spec.tsx
+++ b/native/src/routes/__tests__/SearchModal.spec.tsx
@@ -125,7 +125,7 @@ describe('SearchModal', () => {
 
     fireEvent.changeText(getByPlaceholderText('searchPlaceholder'), 'no results, please')
 
-    expect(getByText('search:nothingFound')).toBeTruthy()
+    expect(getByText('noResultsInOneLanguage')).toBeTruthy()
   })
 
   it('should open with an initial search text if one is supplied', () => {

--- a/native/src/routes/__tests__/SearchModal.spec.tsx
+++ b/native/src/routes/__tests__/SearchModal.spec.tsx
@@ -125,7 +125,7 @@ describe('SearchModal', () => {
 
     fireEvent.changeText(getByPlaceholderText('searchPlaceholder'), 'no results, please')
 
-    expect(getByText('noResultsInOneLanguage')).toBeTruthy()
+    expect(getByText('noResultsInUserLanguage')).toBeTruthy()
   })
 
   it('should open with an initial search text if one is supplied', () => {

--- a/translations/translations.json
+++ b/translations/translations.json
@@ -4767,8 +4767,8 @@
       "giveFeedback": "Feedback geben",
       "checkQuery": "Überprüfen Sie Ihren Suchbegriff oder ändern Sie die eingestellte Sprache der {{appName}}-App.",
       "informationMissing": "Hier fehlen Informationen?",
-      "noResultsInOneLanguage": "Es wurden leider keine passenden Ergebnisse in Deiner Sprache gefunden.",
-      "noResultsInTwoLanguages": "Es wurden leider keine passenden Ergebnisse in Deiner Sprache oder auf Deutsch gefunden."
+      "noResultsInUserLanguage": "Es wurden leider keine passenden Ergebnisse in Deiner Sprache gefunden.",
+      "noResultsInUserAndSourceLanguage": "Es wurden leider keine passenden Ergebnisse in Deiner Sprache oder auf Deutsch gefunden."
     },
     "am": {
       "disclaimer": "የግንኙነት መረጃና ዕትም",
@@ -4954,10 +4954,10 @@
       "contactMailAddress": "E-Mail for further questions",
       "note": "Please select a reaction or write a comment in order to send feedback.",
       "giveFeedback": "Give feedback",
-      "checkQuery": "Check your search term or select a different language in the {{appName}} app",
+      "checkQuery": "Check your search term or select a different language in the {{appName}} app.",
       "informationMissing": "Is information missing?",
-      "noResultsInOneLanguage": "Sorry, we could not find any matching results in your language.",
-      "noResultsInTwoLanguages": "Sorry, we could not find any matching results in your language or in German."
+      "noResultsInUserLanguage": "Sorry, we could not find any matching results in your language.",
+      "noResultsInUserAndSourceLanguage": "Sorry, we could not find any matching results in your language or in German."
     },
     "es": {
       "disclaimer": "Contacto y aviso legal",

--- a/web/src/components/SearchFeedback.tsx
+++ b/web/src/components/SearchFeedback.tsx
@@ -19,16 +19,16 @@ const CenteredContainer = styled.div`
   text-align: center;
 `
 
-const SemiBoldText = styled.p`
+const SmallTitle = styled.p`
   font-weight: 600;
 `
 
-const MiddleText = styled.p`
-  padding-bottom: 1rem;
+const Hint = styled.p`
+  padding-bottom: 16px;
 `
 
 const StyledButton = styled(TextButton)`
-  margin-top: 0.5rem;
+  margin-top: 8px;
 `
 
 type SearchFeedbackProps = {
@@ -63,11 +63,11 @@ const SearchFeedback = ({ cityCode, languageCode, query, noResults }: SearchFeed
 
     return (
       <CenteredContainer>
-        <SemiBoldText>
-          {languageCode === fallbackLanguage ? t('noResultsInOneLanguage') : t('noResultsInTwoLanguages')}
-        </SemiBoldText>
-        <MiddleText>{t('checkQuery', { appName: buildConfig().appName })}</MiddleText>
-        <SemiBoldText>{t('informationMissing')}</SemiBoldText>
+        <SmallTitle>
+          {languageCode === fallbackLanguage ? t('noResultsInUserLanguage') : t('noResultsInUserAndSourceLanguage')}
+        </SmallTitle>
+        <Hint>{t('checkQuery', { appName: buildConfig().appName })}</Hint>
+        <SmallTitle>{t('informationMissing')}</SmallTitle>
         <StyledButton type='button' text={t('giveFeedback')} onClick={() => setShowFeedback(true)} />
       </CenteredContainer>
     )

--- a/web/src/routes/__tests__/SearchPage.spec.tsx
+++ b/web/src/routes/__tests__/SearchPage.spec.tsx
@@ -87,7 +87,7 @@ describe('SearchPage', () => {
       },
     })
 
-    expect(getByText('feedback:noResultsInTwoLanguages')).toBeTruthy()
+    expect(getByText('feedback:noResultsInUserAndSourceLanguage')).toBeTruthy()
   })
 
   describe('url query', () => {


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
This is the implementation of the redesign of the search feedback in native.

### Proposed changes

<!-- Describe this PR in more detail. -->

- When there are no search results, the text makes it clearer that we also searched in the fallback language, and a suggestion to try a different language.
- When there are no search results, there is a very clear CTA to open the feedback form if the user thinks there is information missing anyway.
- The design also calls for the number of search results to disappear if there aren't any but I decided against that so that a screen reader can still yell at someone to stop typing if they already have no results (#2352)

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- The sad smiley in the search feedback disappears (though I'm not sure that qualifies as a side effect since that's the design)
- I used German as the hard-coded fallback language in the translations. Should we ever have the app with a different fallback language by going international, we'll have to fix that. I decided to kick that problem down the road because it's not that likely a scenario, and we would probably have to check through the entire app anyway in that case.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
You can switch the app to English and search for "alleinerziehend".

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Partially fixes: #2926 
