### PR TITLE
3060: KebabMenu - Aligned CloseButton based on Position of Expand Button

### DIFF
--- a/web/src/components/KebabMenu.tsx
+++ b/web/src/components/KebabMenu.tsx
@@ -61,8 +61,21 @@ const Heading = styled.div`
   justify-content: ${props => (props.theme.contentDirection === 'rtl' ? `flex-start` : `flex-end`)};
   background-color: ${props => props.theme.colors.backgroundAccentColor};
   box-shadow: -3px 3px 3px 0 rgb(0 0 0 / 13%);
-  height: ${dimensions.headerHeightSmall}px;
-  padding: 0 8px;
+  min-height: ${dimensions.headerHeightSmall}px;
+  padding: 8px 8px;
+`
+
+const ActionBar = styled.nav`
+  order: 3;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+  padding: 0 16px;
+
+  @media ${dimensions.smallViewport} {
+    order: 2;
+  }
 `
 
 const Content = styled.div`
@@ -103,9 +116,11 @@ const KebabMenu = ({ items, show, setShow, Footer }: KebabMenuProps): ReactEleme
         <Overlay onClick={onClick} $show={show} />
         <List $show={show}>
           <Heading>
-            <Button onClick={onClick} label={t('sideBarCloseAriaLabel')}>
-              <Icon src={CloseIcon} />
-            </Button>
+            <ActionBar>
+              <Button onClick={onClick} label={t('sideBarCloseAriaLabel')}>
+                <Icon src={CloseIcon} />
+              </Button>
+            </ActionBar>
           </Heading>
           <Content>{items}</Content>
           {Footer}


### PR DESCRIPTION
### Short description

I aligned the close button with the expand button and changed the height of the header, so that now the KebapMenu Header has the same height as the main header

### Proposed changes

- I have added the container ActionBar container (analoguos to the Header structure in Header.tsx) 
-  changed height to min-height,so that now the header of the KebapMenu has the same height as the main header
-  adjusted the paddings

### Side effects

- none that I am aware of

### Testing

- Is the close button correctly positioned under all circumstances?

### Resolved issues

Fixes: #3060 