### PR TITLE
3058: Fix truncated path links in push notifications

### DIFF
--- a/release-notes/unreleased/3058-fix-truncated-links-in-push-notifications.yml
+++ b/release-notes/unreleased/3058-fix-truncated-links-in-push-notifications.yml
@@ -1,0 +1,8 @@
+issue_key: 3058
+show_in_stores: true
+platforms:
+  - ios
+  - android
+  - web
+en: Fixed an issue with truncated links in local news
+de: Ein Problem mit abgeschnittenen Links in lokalen Nachrichten wurde behoben

--- a/shared/utils/__tests__/replaceLinks.spec.ts
+++ b/shared/utils/__tests__/replaceLinks.spec.ts
@@ -31,6 +31,11 @@ describe('replaceLinks', () => {
     expect(replace).toHaveBeenCalledTimes(1)
     expect(replace).toHaveReturnedWith('https://integreat.app/asdf')
   })
+  it('should match "_2025.pdf"', () => {
+    replaceLinks('some content https://bildung-test.de/fileadmin/media/pdf/test_2024.pdf', replace)
+    expect(replace).toHaveBeenCalledTimes(1)
+    expect(replace).toHaveReturnedWith('https://bildung-test.de/fileadmin/media/pdf/test_2024.pdf')
+  })
 
   it('should match arabic non-ASCII chars in pathname, query and hash', () => {
     replaceLinks(

--- a/shared/utils/replaceLinks.ts
+++ b/shared/utils/replaceLinks.ts
@@ -7,7 +7,7 @@ const unicode = 'a-zA-Z0-9\\u00A0-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFEF'
 const protocol = /([A-Za-z]{3,9}:(?:\/\/)?)/
 const hostname = /(?:[-;:&=+$,\w]+@)?([A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*)/
 // language=RegExp
-const path = `(?:\\/(?:[+~%/.${unicode}-]*[+~%/${unicode}-]+)?)?`
+const path = `(?:\\/(?:[+~%/_.${unicode}-]*[+~%/${unicode}-]+)?)?`
 // language=RegExp
 const query = `(?:\\?([-+=&;%@.${unicode}]*[-+=&;%@${unicode}]+)?)?`
 // language=RegExp


### PR DESCRIPTION
### Short Description
The underscore does not exist in regex for path which is leading for. ex. this path to pdf file `https://bildung-fuerth.de/fileadmin/media/pdf/Sprachwegweiser_2024.pdf ` being truncated in push notifications. 
### Proposed Changes

<!-- Describe this PR in more detail. -->

- add `_` to path in regex

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

- Go to Testumgebung http://localhost:9000/testumgebung/de/news/local/11356
- Click on the link and see that the page is not found

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3058 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
