### PR TITLE
Fix iOS build scripts

### DIFF
--- a/native/ios/Integreat.xcodeproj/xcshareddata/xcschemes/aschaffenburg.xcscheme
+++ b/native/ios/Integreat.xcodeproj/xcshareddata/xcschemes/aschaffenburg.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Setup build config"
-               scriptText = "exec &gt; ${PROJECT_DIR}/prebuild_build_config.log 2&gt;&amp;1&#10;cd ${PROJECT_DIR} &amp;&amp; yarn workspace build-configs manage write-xcconfig aschaffenburg ios --directory ${PROJECT_DIR}&#10;">
+               scriptText = "export PATH=&quot;$PATH:/opt/homebrew/bin&quot;&#10;&#10;exec &gt; ${PROJECT_DIR}/prebuild_build_config.log 2&gt;&amp;1&#10;cd ${PROJECT_DIR} &amp;&amp; yarn workspace build-configs manage write-xcconfig aschaffenburg ios --directory ${PROJECT_DIR}&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
@@ -26,7 +26,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Setup native translations"
-               scriptText = "exec &gt; ${PROJECT_DIR}/prebuild_native_translations.log 2&gt;&amp;1&#10;cd ${PROJECT_DIR} &amp;&amp; yarn workspace translations manage write-plist Aschaffenburg --translations &quot;../translations/translations.json&quot; --destination ${PROJECT_DIR}/Integreat&#10;">
+               scriptText = "export PATH=&quot;$PATH:/opt/homebrew/bin&quot;&#10;&#10;exec &gt; ${PROJECT_DIR}/prebuild_native_translations.log 2&gt;&amp;1&#10;cd ${PROJECT_DIR} &amp;&amp; yarn workspace translations manage write-plist Aschaffenburg --translations &quot;../translations/translations.json&quot; --destination ${PROJECT_DIR}/Integreat&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/native/ios/Integreat.xcodeproj/xcshareddata/xcschemes/integreat-e2e.xcscheme
+++ b/native/ios/Integreat.xcodeproj/xcshareddata/xcschemes/integreat-e2e.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Setup build config"
-               scriptText = "exec &gt; ${PROJECT_DIR}/prebuild_build_config.log 2&gt;&amp;1&#10;cd ${PROJECT_DIR} &amp;&amp; yarn workspace build-configs manage write-xcconfig &quot;integreat-e2e&quot; ios --directory ${PROJECT_DIR}&#10;">
+               scriptText = "export PATH=&quot;$PATH:/opt/homebrew/bin&quot;&#10;&#10;exec &gt; ${PROJECT_DIR}/prebuild_build_config.log 2&gt;&amp;1&#10;cd ${PROJECT_DIR} &amp;&amp; yarn workspace build-configs manage write-xcconfig &quot;integreat-e2e&quot; ios --directory ${PROJECT_DIR}&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
@@ -26,7 +26,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Setup native translations"
-               scriptText = "exec &gt; ${PROJECT_DIR}/prebuild_native_translations.log 2&gt;&amp;1&#10;cd ${PROJECT_DIR} &amp;&amp; yarn workspace translations manage write-plist Integreat --translations &quot;../translations/translations.json&quot; --destination ${PROJECT_DIR}/Integreat&#10;">
+               scriptText = "export PATH=&quot;$PATH:/opt/homebrew/bin&quot;&#10;&#10;exec &gt; ${PROJECT_DIR}/prebuild_native_translations.log 2&gt;&amp;1&#10;cd ${PROJECT_DIR} &amp;&amp; yarn workspace translations manage write-plist Integreat --translations &quot;../translations/translations.json&quot; --destination ${PROJECT_DIR}/Integreat&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/native/ios/Integreat.xcodeproj/xcshareddata/xcschemes/integreat-test-cms.xcscheme
+++ b/native/ios/Integreat.xcodeproj/xcshareddata/xcschemes/integreat-test-cms.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Setup build config"
-               scriptText = "exec &gt; ${PROJECT_DIR}/prebuild_build_config.log 2&gt;&amp;1&#10;cd ${PROJECT_DIR} &amp;&amp; yarn workspace build-configs manage write-xcconfig &quot;integreat-test-cms&quot; ios --directory ${PROJECT_DIR}&#10;">
+               scriptText = "export PATH=&quot;$PATH:/opt/homebrew/bin&quot;&#10;&#10;exec &gt; ${PROJECT_DIR}/prebuild_build_config.log 2&gt;&amp;1&#10;cd ${PROJECT_DIR} &amp;&amp; yarn workspace build-configs manage write-xcconfig &quot;integreat-test-cms&quot; ios --directory ${PROJECT_DIR}&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
@@ -26,7 +26,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Setup native translations"
-               scriptText = "exec &gt; ${PROJECT_DIR}/prebuild_native_translations.log 2&gt;&amp;1&#10;cd ${PROJECT_DIR} &amp;&amp; yarn workspace translations manage write-plist IntegreatTestCms --translations &quot;../translations/translations.json&quot; --destination ${PROJECT_DIR}/Integreat&#10;">
+               scriptText = "export PATH=&quot;$PATH:/opt/homebrew/bin&quot;&#10;&#10;exec &gt; ${PROJECT_DIR}/prebuild_native_translations.log 2&gt;&amp;1&#10;cd ${PROJECT_DIR} &amp;&amp; yarn workspace translations manage write-plist IntegreatTestCms --translations &quot;../translations/translations.json&quot; --destination ${PROJECT_DIR}/Integreat&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/native/ios/Integreat.xcodeproj/xcshareddata/xcschemes/integreat.xcscheme
+++ b/native/ios/Integreat.xcodeproj/xcshareddata/xcschemes/integreat.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Setup build config"
-               scriptText = "exec &gt; ${PROJECT_DIR}/prebuild_build_config.log 2&gt;&amp;1&#10;cd ${PROJECT_DIR} &amp;&amp; yarn workspace build-configs manage write-xcconfig integreat ios --directory ${PROJECT_DIR}&#10;">
+               scriptText = "export PATH=&quot;$PATH:/opt/homebrew/bin&quot;&#10;&#10;exec &gt; ${PROJECT_DIR}/prebuild_build_config.log 2&gt;&amp;1&#10;cd ${PROJECT_DIR} &amp;&amp; yarn workspace build-configs manage write-xcconfig integreat ios --directory ${PROJECT_DIR}&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
@@ -26,7 +26,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Setup native translations"
-               scriptText = "exec &gt; ${PROJECT_DIR}/prebuild_native_translations.log 2&gt;&amp;1&#10;cd ${PROJECT_DIR} &amp;&amp; yarn workspace translations manage write-plist Integreat --translations &quot;../translations/translations.json&quot; --destination ${PROJECT_DIR}/Integreat&#10;">
+               scriptText = "export PATH=&quot;$PATH:/opt/homebrew/bin&quot;&#10;&#10;exec &gt; ${PROJECT_DIR}/prebuild_native_translations.log 2&gt;&amp;1&#10;cd ${PROJECT_DIR} &amp;&amp; yarn workspace translations manage write-plist Integreat --translations &quot;../translations/translations.json&quot; --destination ${PROJECT_DIR}/Integreat&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/native/ios/Integreat.xcodeproj/xcshareddata/xcschemes/malte.xcscheme
+++ b/native/ios/Integreat.xcodeproj/xcshareddata/xcschemes/malte.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Setup build config"
-               scriptText = "exec &gt; ${PROJECT_DIR}/prebuild_build_config.log 2&gt;&amp;1&#10;cd ${PROJECT_DIR} &amp;&amp; yarn workspace build-configs manage write-xcconfig malte ios --directory ${PROJECT_DIR}&#10;">
+               scriptText = "export PATH=&quot;$PATH:/opt/homebrew/bin&quot;&#10;&#10;exec &gt; ${PROJECT_DIR}/prebuild_build_config.log 2&gt;&amp;1&#10;cd ${PROJECT_DIR} &amp;&amp; yarn workspace build-configs manage write-xcconfig malte ios --directory ${PROJECT_DIR}&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
@@ -26,7 +26,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Setup native translations"
-               scriptText = "exec &gt; ${PROJECT_DIR}/prebuild_native_translations.log 2&gt;&amp;1&#10;cd ${PROJECT_DIR} &amp;&amp; yarn workspace translations manage write-plist Malte --translations &quot;../translations/translations.json&quot; --destination ${PROJECT_DIR}/Integreat&#10;">
+               scriptText = "export PATH=&quot;$PATH:/opt/homebrew/bin&quot;&#10;&#10;exec &gt; ${PROJECT_DIR}/prebuild_native_translations.log 2&gt;&amp;1&#10;cd ${PROJECT_DIR} &amp;&amp; yarn workspace translations manage write-plist Malte --translations &quot;../translations/translations.json&quot; --destination ${PROJECT_DIR}/Integreat&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Fix iOS build scripts as xcode does not find homebew (and therefore yarn) in my path.
Otherwise I always get `yarn: command not found`.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Add homebrew to path before executing build scripts

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

homebrew is always added to the path even if not available/necessary. Should not lead to any problems though.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Build the app on iOS.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: N/A

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
