### PR TITLE
3074: Add debounce function to query search to improve responsiveness

### DIFF
--- a/release-notes/unreleased/3074-debounce-to-search-query.yml
+++ b/release-notes/unreleased/3074-debounce-to-search-query.yml
@@ -1,0 +1,8 @@
+issue_key: 3074
+show_in_stores: true
+platforms:
+  - web
+  - android
+  - ios
+en: Made the search query more responsive.
+de: Die Suchanfrage wurde reaktionsfähiger gemacht.

--- a/shared/hooks/useSearch.ts
+++ b/shared/hooks/useSearch.ts
@@ -7,6 +7,7 @@ import ExtendedPageModel from '../api/models/ExtendedPageModel'
 import PoiModel from '../api/models/PoiModel'
 
 export type SearchResult = ExtendedPageModel
+const DEBOUNCED_QUERY_TIMEOUT = 250
 
 export const prepareSearchDocuments = (
   categories?: CategoriesMapModel | null,
@@ -22,6 +23,18 @@ export const prepareSearchDocuments = (
 // Modifying single documents or replacing documents with a same length array will therefore NOT trigger an update
 const useSearch = (documents: SearchResult[], query: string): SearchResult[] => {
   const [indexing, setIndexing] = useState(false)
+  const [debouncedQuery, setDebouncedQuery] = useState(query)
+
+  useEffect(() => {
+    const debounceQueryTimeout = setTimeout(() => {
+      setDebouncedQuery(debouncedQuery)
+    }, DEBOUNCED_QUERY_TIMEOUT)
+
+    return () => {
+      clearTimeout(debounceQueryTimeout)
+    }
+  }, [debouncedQuery])
+
   const [search] = useState(
     new MiniSearch({
       idField: 'path',

--- a/shared/hooks/useSearch.ts
+++ b/shared/hooks/useSearch.ts
@@ -25,16 +25,6 @@ const useSearch = (documents: SearchResult[], query: string): SearchResult[] => 
   const [indexing, setIndexing] = useState(false)
   const [debouncedQuery, setDebouncedQuery] = useState(query)
 
-  useEffect(() => {
-    const debounceQueryTimeout = setTimeout(() => {
-      setDebouncedQuery(debouncedQuery)
-    }, DEBOUNCED_QUERY_TIMEOUT)
-
-    return () => {
-      clearTimeout(debounceQueryTimeout)
-    }
-  }, [debouncedQuery])
-
   const [search] = useState(
     new MiniSearch({
       idField: 'path',
@@ -49,6 +39,14 @@ const useSearch = (documents: SearchResult[], query: string): SearchResult[] => 
   )
 
   useEffect(() => {
+    const debounceQueryTimeout = setTimeout(() => {
+      setDebouncedQuery(query)
+    }, DEBOUNCED_QUERY_TIMEOUT)
+
+    return () => clearTimeout(debounceQueryTimeout)
+  }, [query])
+
+  useEffect(() => {
     if (!indexing && search.documentCount !== documents.length) {
       setIndexing(true)
       search.removeAll()
@@ -60,7 +58,7 @@ const useSearch = (documents: SearchResult[], query: string): SearchResult[] => 
   }, [indexing, search, documents])
 
   // @ts-expect-error minisearch doesn't add the returned storeFields (e.g. title or path) to its typing
-  return query.length === 0 ? documents : search.search(query)
+  return debouncedQuery.length === 0 ? documents : search.search(debouncedQuery)
 }
 
 export default useSearch


### PR DESCRIPTION
### Short Description

Return the results after several milliseconds to user so that the user could have time to finish typing

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Add debounce function to `useSearch` hook
- Add timeout for 250 Milliseconds

### Side Effects
- should be none

### Testing

Search for something, for ex. "Dolmetscher"
See that the results for the query appear after 250 Milliseconds

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3074 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
