### PR TITLE
3112: Prevent unnecessary tts stop

### DIFF
--- a/native/src/components/TtsContainer.tsx
+++ b/native/src/components/TtsContainer.tsx
@@ -138,11 +138,9 @@ const TtsContainer = ({ children }: TtsContainerProps): ReactElement => {
   const updateSentences = useCallback(
     (newSentences: string[]) => {
       setSentences(newSentences)
-      if (isPlaying) {
-        stop()
-      }
+      stop()
     },
-    [stop, isPlaying],
+    [stop],
   )
 
   const ttsContextValue = useMemo(

--- a/native/src/components/TtsContainer.tsx
+++ b/native/src/components/TtsContainer.tsx
@@ -138,9 +138,11 @@ const TtsContainer = ({ children }: TtsContainerProps): ReactElement => {
   const updateSentences = useCallback(
     (newSentences: string[]) => {
       setSentences(newSentences)
-      stop()
+      if (isPlaying) {
+        stop()
+      }
     },
-    [stop],
+    [stop, isPlaying],
   )
 
   const ttsContextValue = useMemo(

--- a/native/src/utils/sentry.ts
+++ b/native/src/utils/sentry.ts
@@ -48,12 +48,19 @@ export const log = (message: string, level: SeverityLevel = 'debug'): void => {
   }
 }
 
-export const reportError = (err: unknown): void => {
-  if (!(err instanceof NotFoundError) && !(err instanceof FetchError) && sentryEnabled()) {
-    // Report important errors if sentry is enabled (and skip e.g. errors because of no invalid internet connection)
-    Sentry.captureException(err)
+export const reportError = (error: unknown): void => {
+  const isNotFoundError = error instanceof NotFoundError
+  const isNoInternetError = error instanceof FetchError
+  const ignoreError = isNotFoundError || isNoInternetError
+
+  if (ignoreError) {
+    return
+  }
+
+  if (sentryEnabled()) {
+    Sentry.captureException(error)
   }
   if (developerFriendly()) {
-    console.error(err)
+    console.error(error)
   }
 }

--- a/native/src/utils/sentry.ts
+++ b/native/src/utils/sentry.ts
@@ -48,10 +48,17 @@ export const log = (message: string, level: SeverityLevel = 'debug'): void => {
   }
 }
 
+// https://github.com/digitalfabrik/integreat-app/issues/1759
+const storeLastUpdate = 'cannot store last update for unused city'
+// https://github.com/digitalfabrik/integreat-app/issues/3112
+const noTtsEngineInstalled = 'No TTS engine installed'
+const expectedErrors = [storeLastUpdate, noTtsEngineInstalled]
+
 export const reportError = (error: unknown): void => {
   const isNotFoundError = error instanceof NotFoundError
   const isNoInternetError = error instanceof FetchError
-  const ignoreError = isNotFoundError || isNoInternetError
+  const isExpectedError = error instanceof Error && expectedErrors.some(message => error.message.includes(message))
+  const ignoreError = isNotFoundError || isNoInternetError || isExpectedError
 
   if (ignoreError) {
     return


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Prevent unnecessary tts stop causing errors if no tts engine installed.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Prevent unnecessary tts stop causing errors if no tts engine installed.
- Refactor reportError

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- [This error](https://sentry.tuerantuer.org/organizations/digitalfabrik/issues/1502) will not be sent to sentry anymore. We have 537k events for it, which seems more than enough. I [investigated this](#1759) in the past, but wasn't able to fix it. However, it is handled and not a problem.
- ~~I thought of preventing sending a sentry stacktrace for known issues (such as this one), but decided against as it still might be helpful to detect issues such as this one. However, we will continue to get this error for people that try to open the tts player but dont have a tts player installed.~~ Due to the unexpected behavior on language change described below, I reverted the previous changes and ignore the error instead.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Not sure how to test this. Have a degoogled android phone I guess. Or just throw an error in `stop` and ensure that it is not called without actually opening the tts function.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3112

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
