### PR TITLE
3107: Reduce search loading times

### DIFF
--- a/native/src/routes/CategoriesContainer.tsx
+++ b/native/src/routes/CategoriesContainer.tsx
@@ -3,6 +3,7 @@ import { useWindowDimensions } from 'react-native'
 
 import { CATEGORIES_ROUTE, CategoriesRouteType, cityContentPath } from 'shared'
 import { ErrorCode } from 'shared/api'
+import { config } from 'translations'
 
 import Categories from '../components/Categories'
 import DashboardNavigationTiles from '../components/DashboardNavigationTiles'
@@ -30,6 +31,8 @@ const CategoriesContainer = ({ navigation, route }: CategoriesContainerProps): R
   const { navigateTo } = useNavigate()
 
   const { data, ...response } = useLoadCityContent({ cityCode, languageCode })
+  // Preload search results for fallback language
+  useLoadCityContent({ cityCode, languageCode: config.sourceLanguage })
 
   const homeRouteTitle = cityDisplayName(data?.city, deviceWidth)
   const path = route.params.path ?? cityContentPath({ cityCode, languageCode })

--- a/native/src/routes/SearchModal.tsx
+++ b/native/src/routes/SearchModal.tsx
@@ -4,11 +4,9 @@ import { KeyboardAvoidingView, Platform } from 'react-native'
 import styled from 'styled-components/native'
 
 import { parseHTML, SEARCH_FINISHED_SIGNAL_NAME, SEARCH_ROUTE, SearchResult, useSearch } from 'shared'
-import { config } from 'translations'
 
 import FeedbackContainer from '../components/FeedbackContainer'
 import List from '../components/List'
-import ProgressSpinner from '../components/ProgressSpinner'
 import SearchHeader from '../components/SearchHeader'
 import SearchListItem from '../components/SearchListItem'
 import useAnnounceSearchResultsIOS from '../hooks/useAnnounceSearchResultsIOS'
@@ -25,18 +23,14 @@ const Wrapper = styled.View`
   background-color: ${props => props.theme.colors.backgroundColor};
 `
 
-const ProgressSpinnerContainer = styled.View`
-  height: 50%;
-`
-
 const SearchCounter = styled.Text`
   margin: 10px 20px;
   color: ${props => props.theme.colors.textSecondaryColor};
 `
 
 export type SearchModalProps = {
-  allPossibleContentLanguageResults: SearchResult[]
-  allPossibleFallbackLanguageResults: SearchResult[]
+  documents: SearchResult[]
+  fallbackLanguageDocuments: SearchResult[]
   languageCode: string
   cityCode: string
   closeModal: (query: string) => void
@@ -44,8 +38,8 @@ export type SearchModalProps = {
 }
 
 const SearchModal = ({
-  allPossibleContentLanguageResults,
-  allPossibleFallbackLanguageResults,
+  documents,
+  fallbackLanguageDocuments,
   languageCode,
   cityCode,
   closeModal,
@@ -55,13 +49,9 @@ const SearchModal = ({
   const resourceCache = useResourceCache({ cityCode, languageCode })
   const { t } = useTranslation('search')
 
-  const contentLanguageResults = useSearch(allPossibleContentLanguageResults, query)
-  const fallbackLanguageResults = useSearch(allPossibleFallbackLanguageResults, query)
-
-  const searchResults =
-    languageCode === config.sourceLanguage
-      ? contentLanguageResults
-      : contentLanguageResults?.concat(fallbackLanguageResults ?? [])
+  const contentLanguageResults = useSearch(documents, query)
+  const fallbackLanguageResults = useSearch(fallbackLanguageDocuments, query)
+  const searchResults = contentLanguageResults.concat(fallbackLanguageResults)
 
   useAnnounceSearchResultsIOS(searchResults)
 
@@ -74,19 +64,6 @@ const SearchModal = ({
       },
     })
     closeModal(query)
-  }
-
-  if (!searchResults) {
-    return (
-      <Wrapper {...testID('Search-Page')}>
-        <SearchHeader query={query} closeSearchBar={onClose} onSearchChanged={setQuery} />
-        {query.length > 0 && (
-          <ProgressSpinnerContainer>
-            <ProgressSpinner progress={0} />
-          </ProgressSpinnerContainer>
-        )}
-      </Wrapper>
-    )
   }
 
   const renderItem = ({ item }: { item: SearchResult }) => (

--- a/native/src/routes/SearchModalContainer.tsx
+++ b/native/src/routes/SearchModalContainer.tsx
@@ -1,7 +1,6 @@
 import React, { ReactElement } from 'react'
 
-import { SearchRouteType } from 'shared'
-import { formatPossibleSearchResults } from 'shared/hooks/useSearch'
+import { prepareSearchDocuments, SearchRouteType } from 'shared'
 import { config } from 'translations'
 
 import { NavigationProps, RouteProps } from '../constants/NavigationTypes'
@@ -21,13 +20,11 @@ const SearchModalContainer = ({ navigation, route }: SearchModalContainerProps):
   const { data, ...response } = useLoadCityContent({ cityCode, languageCode })
   const { data: fallbackData } = useLoadCityContent({ cityCode, languageCode: config.sourceLanguage })
 
-  const allPossibleContentLanguageResults = formatPossibleSearchResults(data?.categories, data?.events, data?.pois)
-
-  const allPossibleFallbackLanguageResults = formatPossibleSearchResults(
-    fallbackData?.categories,
-    fallbackData?.events,
-    fallbackData?.pois,
-  )
+  const documents = prepareSearchDocuments(data?.categories, data?.events, data?.pois)
+  const fallbackLanguageDocuments =
+    languageCode !== config.sourceLanguage
+      ? prepareSearchDocuments(fallbackData?.categories, fallbackData?.events, fallbackData?.pois)
+      : []
 
   return (
     <LoadingErrorHandler {...response}>
@@ -35,8 +32,8 @@ const SearchModalContainer = ({ navigation, route }: SearchModalContainerProps):
         <SearchModal
           cityCode={cityCode}
           closeModal={navigation.goBack}
-          allPossibleContentLanguageResults={allPossibleContentLanguageResults}
-          allPossibleFallbackLanguageResults={allPossibleFallbackLanguageResults}
+          documents={documents}
+          fallbackLanguageDocuments={fallbackLanguageDocuments}
           languageCode={languageCode}
           initialSearchText={initialSearchText}
         />

--- a/native/src/routes/__tests__/SearchModal.spec.tsx
+++ b/native/src/routes/__tests__/SearchModal.spec.tsx
@@ -43,15 +43,15 @@ describe('SearchModal', () => {
   const eventModels = new EventModelBuilder('testseed', 5, cityCode, languageCode).build()
   const poiModels = new PoiModelBuilder(3).build()
 
-  const allPossibleContentLanguageResults = [
+  const documents = [
     ...categoriesMapModel.toArray().filter(category => !category.isRoot()),
     ...eventModels,
     ...poiModels,
   ]
 
   const props: SearchModalProps = {
-    allPossibleContentLanguageResults,
-    allPossibleFallbackLanguageResults: [],
+    documents,
+    fallbackLanguageDocuments: [],
     languageCode,
     cityCode,
     closeModal: dummy,

--- a/shared/hooks/useSearch.ts
+++ b/shared/hooks/useSearch.ts
@@ -1,7 +1,6 @@
 import MiniSearch from 'minisearch'
-import { useCallback } from 'react'
+import { useEffect, useState } from 'react'
 
-import useLoadAsync from '../api/endpoints/hooks/useLoadAsync'
 import CategoriesMapModel from '../api/models/CategoriesMapModel'
 import EventModel from '../api/models/EventModel'
 import ExtendedPageModel from '../api/models/ExtendedPageModel'
@@ -9,7 +8,7 @@ import PoiModel from '../api/models/PoiModel'
 
 export type SearchResult = ExtendedPageModel
 
-export const formatPossibleSearchResults = (
+export const prepareSearchDocuments = (
   categories?: CategoriesMapModel | null,
   events?: EventModel[] | null,
   pois?: PoiModel[] | null,
@@ -19,9 +18,12 @@ export const formatPossibleSearchResults = (
   ...(pois || []),
 ]
 
-const useSearch = (allPossibleResults: SearchResult[], query: string): SearchResult[] | null => {
-  const initializeMiniSearch = useCallback(async () => {
-    const search = new MiniSearch({
+// WARNING: This uses the document count to check whether the search documents have already been added.
+// Modifying single documents or replacing documents with a same length array will therefore NOT trigger an update
+const useSearch = (documents: SearchResult[], query: string): SearchResult[] => {
+  const [indexing, setIndexing] = useState(false)
+  const [search] = useState(
+    new MiniSearch({
       idField: 'path',
       fields: ['title', 'content'],
       storeFields: ['title', 'content', 'path', 'thumbnail'],
@@ -30,19 +32,22 @@ const useSearch = (allPossibleResults: SearchResult[], query: string): SearchRes
         fuzzy: true,
         prefix: true,
       },
-    })
-    await search.addAllAsync(allPossibleResults)
-    return search
-  }, [allPossibleResults])
+    }),
+  )
 
-  const { data: minisearch } = useLoadAsync(initializeMiniSearch)
-
-  if (!minisearch || minisearch.documentCount !== allPossibleResults.length) {
-    return null
-  }
+  useEffect(() => {
+    if (!indexing && search.documentCount !== documents.length) {
+      setIndexing(true)
+      search.removeAll()
+      search
+        .addAllAsync(documents)
+        .then(() => setIndexing(false))
+        .catch()
+    }
+  }, [indexing, search, documents])
 
   // @ts-expect-error minisearch doesn't add the returned storeFields (e.g. title or path) to its typing
-  return query.length === 0 ? allPossibleResults : minisearch.search(query)
+  return query.length === 0 ? documents : search.search(query)
 }
 
 export default useSearch

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -1,7 +1,7 @@
 import { PreparePoisReturn as ImportedPreparePoisReturn } from './utils/pois'
 
 export type PreparePoisReturn = ImportedPreparePoisReturn
-export { default as useSearch, type SearchResult } from './hooks/useSearch'
+export { default as useSearch, type SearchResult, prepareSearchDocuments } from './hooks/useSearch'
 export { default as useDateFilter } from './hooks/useDateFilter'
 export { default as InternalPathnameParser } from './routes/InternalPathnameParser'
 export * from './routes'

--- a/web/src/hooks/__tests__/useLoadSearchDocuments.spec.ts
+++ b/web/src/hooks/__tests__/useLoadSearchDocuments.spec.ts
@@ -13,29 +13,29 @@ import {
   mockUseLoadFromEndpointWithError,
 } from 'shared/api/endpoints/testing/mockUseLoadFromEndpoint'
 
-import useAllPossibleSearchResults from '../useAllPossibleSearchResults'
+import useLoadSearchDocuments from '../useLoadSearchDocuments'
 
 jest.mock('shared/api', () => ({
   ...jest.requireActual('shared/api'),
   useLoadFromEndpoint: jest.fn(),
 }))
 
-describe('useAllPossibleSearchResults', () => {
+describe('useLoadSearchDocuments', () => {
   beforeEach(() => {
     jest.clearAllMocks()
   })
 
-  const city = new CityModelBuilder(1).build()[0]!.code
-  const language = new LanguageModelBuilder(1).build()[0]!.code
-  const categories = new CategoriesMapModelBuilder(city, language).build()
-  const events = new EventModelBuilder('seed', 2, city, language).build()
+  const cityCode = new CityModelBuilder(1).build()[0]!.code
+  const languageCode = new LanguageModelBuilder(1).build()[0]!.code
+  const categories = new CategoriesMapModelBuilder(cityCode, languageCode).build()
+  const events = new EventModelBuilder('seed', 2, cityCode, languageCode).build()
   const locations = new PoiModelBuilder(3).build()
 
   it('should return the correct results', () => {
     mockUseLoadFromEndpointOnceWithData(categories)
     mockUseLoadFromEndpointOnceWithData(events)
     mockUseLoadFromEndpointOnceWithData(locations)
-    const { result } = renderHook(() => useAllPossibleSearchResults({ city, language, cmsApiBaseUrl: '' }))
+    const { result } = renderHook(() => useLoadSearchDocuments({ cityCode, languageCode, cmsApiBaseUrl: '' }))
     const { data } = result.current
     expect(data).toHaveLength(17)
     expect(data[0]?.title).toBe('Category with id 0')
@@ -48,7 +48,7 @@ describe('useAllPossibleSearchResults', () => {
     mockUseLoadFromEndpointOnceWithData(categories)
     mockUseLoadFromEndpointLoading({ data: events })
     mockUseLoadFromEndpointOnceWithData(locations)
-    const { result } = renderHook(() => useAllPossibleSearchResults({ city, language, cmsApiBaseUrl: '' }))
+    const { result } = renderHook(() => useLoadSearchDocuments({ cityCode, languageCode, cmsApiBaseUrl: '' }))
     const { loading } = result.current
     expect(loading).toBe(true)
   })
@@ -58,7 +58,7 @@ describe('useAllPossibleSearchResults', () => {
     mockUseLoadFromEndpointOnceWithData(events)
     const errorMessage = 'no pois found'
     mockUseLoadFromEndpointWithError(errorMessage)
-    const { result } = renderHook(() => useAllPossibleSearchResults({ city, language, cmsApiBaseUrl: '' }))
+    const { result } = renderHook(() => useLoadSearchDocuments({ cityCode, languageCode, cmsApiBaseUrl: '' }))
     const { error } = result.current
     expect(error).toStrictEqual(new Error(errorMessage))
   })

--- a/web/src/hooks/useLoadSearchDocuments.ts
+++ b/web/src/hooks/useLoadSearchDocuments.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 
+import { prepareSearchDocuments } from 'shared'
 import {
   createCategoriesEndpoint,
   createEventsEndpoint,
@@ -7,41 +8,40 @@ import {
   ExtendedPageModel,
   useLoadFromEndpoint,
 } from 'shared/api'
-import { formatPossibleSearchResults } from 'shared/hooks/useSearch'
 
-type UseAllPossibleSearchResultsProps = {
-  city: string
-  language: string
+type UseLoadSearchDocumentsProps = {
+  cityCode: string
+  languageCode: string
   cmsApiBaseUrl: string
 }
 
-type UseAllPossibleSearchResultsReturn = {
+type UseLoadSearchDocumentsReturn = {
   data: ExtendedPageModel[]
   error: Error | null
   loading: boolean
 }
 
-const useAllPossibleSearchResults = ({
-  city,
-  language,
+const useLoadSearchDocuments = ({
+  cityCode,
+  languageCode,
   cmsApiBaseUrl,
-}: UseAllPossibleSearchResultsProps): UseAllPossibleSearchResultsReturn => {
-  const params = { city, language }
+}: UseLoadSearchDocumentsProps): UseLoadSearchDocumentsReturn => {
+  const params = { city: cityCode, language: languageCode }
 
   const categories = useLoadFromEndpoint(createCategoriesEndpoint, cmsApiBaseUrl, params)
   const events = useLoadFromEndpoint(createEventsEndpoint, cmsApiBaseUrl, params)
   const pois = useLoadFromEndpoint(createPOIsEndpoint, cmsApiBaseUrl, params)
 
-  const allPossibleResults = useMemo(
-    () => formatPossibleSearchResults(categories.data, events.data, pois.data),
+  const documents = useMemo(
+    () => prepareSearchDocuments(categories.data, events.data, pois.data),
     [categories.data, events.data, pois.data],
   )
 
   return {
-    data: allPossibleResults,
+    data: documents,
     loading: categories.loading || events.loading || pois.loading,
     error: categories.error || events.error || pois.error,
   }
 }
 
-export default useAllPossibleSearchResults
+export default useLoadSearchDocuments

--- a/web/src/routes/__tests__/SearchPage.spec.tsx
+++ b/web/src/routes/__tests__/SearchPage.spec.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 import { pathnameFromRouteInformation, SEARCH_ROUTE, SearchResult } from 'shared'
 import { CategoriesMapModelBuilder, CityModelBuilder, EventModelBuilder, PoiModelBuilder } from 'shared/api'
 
-import useAllPossibleSearchResults from '../../hooks/useAllPossibleSearchResults'
+import useLoadSearchDocuments from '../../hooks/useLoadSearchDocuments'
 import { renderRoute } from '../../testing/render'
 import SearchPage from '../SearchPage'
 import { RoutePatterns } from '../index'
@@ -18,7 +18,7 @@ jest.mock('react-i18next', () => ({
   }),
   Trans: ({ i18nKey }: { i18nKey: string }) => i18nKey,
 }))
-jest.mock('../../hooks/useAllPossibleSearchResults')
+jest.mock('../../hooks/useLoadSearchDocuments')
 jest.mock('react-tooltip')
 
 jest.mock('shared', () => ({
@@ -42,15 +42,15 @@ describe('SearchPage', () => {
   const poiModels = new PoiModelBuilder(3).build()
   const poi0 = poiModels[0]!
 
-  const allPossibleResults = [...categoryModels.filter(category => !category.isRoot()), ...eventModels, ...poiModels]
+  const searchDocuments = [...categoryModels.filter(category => !category.isRoot()), ...eventModels, ...poiModels]
 
   const hookReturn = {
-    data: allPossibleResults,
+    data: searchDocuments,
     loading: false,
     error: null,
   }
 
-  mocked(useAllPossibleSearchResults).mockImplementation(() => hookReturn)
+  mocked(useLoadSearchDocuments).mockImplementation(() => hookReturn)
 
   const pathname = pathnameFromRouteInformation({
     route: SEARCH_ROUTE,


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Reduce search loading times by fixing minisearch initialization and rename to documents

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Decouple initialization of minisearch and adding documents
- Avoid rerender if documents are of the same length
- Avoid returning null if not all documents indexed
- Change naming to `(search) documents`

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Search results might appear after some delay

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Test search on native and web thoroughly! Test both searching in German and other languages and make sure that German search terms are also found in other languages.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3107

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
