### PR TITLE
2908: Immediately open link in search

### DIFF
--- a/native/src/components/List.tsx
+++ b/native/src/components/List.tsx
@@ -20,6 +20,7 @@ type ListProps<T> = {
   refresh?: () => void
   onEndReached?: () => void
   style?: ViewStyle
+  keyboardShouldPersistTaps?: 'always' | 'never' | 'handled'
 }
 
 const List = <T,>({
@@ -33,6 +34,7 @@ const List = <T,>({
   onEndReached,
   scrollEnabled,
   style,
+  keyboardShouldPersistTaps = 'never',
 }: ListProps<T>): ReactElement => (
   <FlatList
     data={items}
@@ -51,6 +53,7 @@ const List = <T,>({
     role='list'
     accessibilityLabel={accessibilityLabel}
     style={style}
+    keyboardShouldPersistTaps={keyboardShouldPersistTaps}
   />
 )
 

--- a/native/src/routes/SearchModal.tsx
+++ b/native/src/routes/SearchModal.tsx
@@ -93,6 +93,7 @@ const SearchModal = ({
               renderItem={renderItem}
               accessibilityLabel={t('searchResultsCount', { count: searchResults.length })}
               style={{ flex: 1 }}
+              keyboardShouldPersistTaps='handled'
               noItemsMessage={
                 <FeedbackContainer
                   routeType={SEARCH_ROUTE}


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
When you're in the mobile search, have typed in your query, and then tapped on the result you wanted, the keyboard would close and you would have to tap a second time on the result to actually get there. This PR fixes that, you are now sent immediately to the selected result.

### Proposed Changes

<!-- Describe this PR in more detail. -->
- Added [keyboardShouldPersistTaps](https://reactnative.dev/docs/scrollview#keyboardshouldpersisttaps) to the list of search items

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Hopefully none, the behavior of the other lists shouldn't be affected.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Type in a search, tap on a result, see if it opens immediately.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2908 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
