### PR TITLE
3070: Fix typo in the title of intro slide 5

### DIFF
--- a/native/src/routes/Intro.tsx
+++ b/native/src/routes/Intro.tsx
@@ -85,7 +85,7 @@ const Intro = ({ route, navigation }: IntroProps): ReactElement => {
   if (buildConfig().featureFlags.newsStream) {
     slides.push({
       key: 'news',
-      title: t('newsDescription', { appName }),
+      title: t('news', { appName }),
       description: t('newsDescription', { appName }),
       Content: <StyledIcon Icon={IntroNewsIcon} />,
     })


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
The title of the fifth intro slide contained the content instead of the title. This fixes it.

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Do a fresh installation of the app and check on the intro slides.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3070

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
