### PR TITLE
3066: Add accessibilityLabel to form inputs

### DIFF
--- a/native/src/components/base/InputSection.tsx
+++ b/native/src/components/base/InputSection.tsx
@@ -94,6 +94,7 @@ const InputSection = ({
         invalid={invalid}
         returnKeyType='done'
         blurOnSubmit
+        accessibilityLabel={title}
         role='searchbox'
         testID={title ?? value}
       />


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
The text fields in the form inputs (feedback and Malte help form) didn't have an accessible description, now they do.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Added `accessibilityLabel` to the inputs

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Use VoiceOver or iOS Accessibility Inspector or TalkBack to look at the feedback form.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3066 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
