### PR TITLE
3088: Remove all previous prereleases

### DIFF
--- a/tools/github-promote-release.ts
+++ b/tools/github-promote-release.ts
@@ -25,12 +25,11 @@ const getAllPreReleased = async ({ deliverinoPrivateKey, owner, repo, platform }
   const releasesWithTags = releases.data.filter(
     (release: ReleaseType) => release.tag_name.includes(platform) && release.prerelease,
   )
-  const filteredIds = releasesWithTags.map((release: ReleaseType) => release.id)
   const filteredTagNames = releasesWithTags.map((release: ReleaseType) => release.tag_name)
 
-  if (filteredIds.length > 0) {
+  if (releasesWithTags.length > 0) {
     console.warn('Unset prerelease tags of ', filteredTagNames)
-    return filteredIds
+    return releasesWithTags
   }
 
   console.warn('No release found to unset the prerelease tag for. Latest release may already be non-prerelease')

--- a/tools/github-promote-release.ts
+++ b/tools/github-promote-release.ts
@@ -54,7 +54,8 @@ const removePreRelease = async ({ deliverinoPrivateKey, owner, repo, platform }:
       console.warn('Http response code of updating the result: ', result.status)
     }),
   )
-  return allPreReleases
+  // Returning the least release with PreRelease tag
+  return allPreReleases[0]
 }
 
 program
@@ -69,10 +70,11 @@ program
   .requiredOption('--platform <platform>')
   .action(async (options: Options) => {
     try {
-      const promotedReleases = await removePreRelease(options)
-      if (promotedReleases) {
-        console.log(`The most recent beta version was promoted to production:`)
-        promotedReleases.map((release: ReleaseType) => console.log(`\n[${release.name}](${release.html_url})`))
+      const promotedRelease = await removePreRelease(options)
+      if (promotedRelease) {
+        console.log(
+          `The most recent beta version was promoted to production:\n[${promotedRelease.name}](${promotedRelease.html_url})`,
+        )
       }
     } catch (e) {
       console.error(e)

--- a/tools/github-promote-release.ts
+++ b/tools/github-promote-release.ts
@@ -6,7 +6,7 @@ import authenticate from './github-authentication.js'
 
 const octokit = new Octokit()
 type Releases = GetResponseTypeFromEndpointMethod<typeof octokit.repos.listReleases>
-type ReleaseType = Releases['data']
+type ReleaseType = Releases['data'][number]
 
 type Options = {
   deliverinoPrivateKey: string

--- a/tools/github-promote-release.ts
+++ b/tools/github-promote-release.ts
@@ -6,6 +6,7 @@ import authenticate from './github-authentication.js'
 
 const octokit = new Octokit()
 type Releases = GetResponseTypeFromEndpointMethod<typeof octokit.repos.listReleases>
+type ReleaseType = Releases['data']
 
 type Options = {
   deliverinoPrivateKey: string
@@ -14,36 +15,42 @@ type Options = {
   platform: 'web' | 'android' | 'ios'
 }
 
-const getReleaseId = async ({ deliverinoPrivateKey, owner, repo, platform }: Options) => {
+const getAllReleaseIds = async ({ deliverinoPrivateKey, owner, repo, platform }: Options) => {
   const appOctokit = await authenticate({ deliverinoPrivateKey, owner, repo })
 
   const releases: Releases = await appOctokit.rest.repos.listReleases({
     owner,
     repo,
   })
+  const releasesWithTags = releases.data.filter(
+    (release: ReleaseType) => release.tag_name.includes(platform) && release.prerelease,
+  )
+  const filteredIds = releasesWithTags.map((release: ReleaseType) => release.id)
+  const filteredTagNames = releasesWithTags.map((release: ReleaseType) => release.tag_name)
 
-  const result = releases.data.find(release => release.tag_name.includes(platform))
-  if (result && result.prerelease) {
-    console.log('Unset prerelease tag of ', result.tag_name)
-    return result.id
+  if (filteredIds.length > 0) {
+    console.warn('Unset prerelease tags of ', filteredTagNames)
+    return filteredIds
   }
 
-  console.log('No release found to unset the prerelease tag for. Latest release may already be non-prerelease')
+  console.warn('No release found to unset the prerelease tag for. Latest release may already be non-prerelease')
   return null
 }
 
 const removePreRelease = async ({ deliverinoPrivateKey, owner, repo, platform }: Options) => {
-  const releaseId = await getReleaseId({ deliverinoPrivateKey, owner, repo, platform })
-  if (releaseId !== null) {
+  const releaseIds = await getAllReleaseIds({ deliverinoPrivateKey, owner, repo, platform })
+  if (releaseIds !== null) {
     const appOctokit = await authenticate({ deliverinoPrivateKey, owner, repo })
-    const result = await appOctokit.rest.repos.updateRelease({
-      owner,
-      repo,
-      release_id: releaseId,
-      prerelease: false,
-      make_latest: platform === 'android' ? 'true' : 'false', // We always want android to be the latest release, so a link to the latest github release will go to the apk
+    releaseIds.map(async releaseId => {
+      const result = await appOctokit.rest.repos.updateRelease({
+        owner,
+        repo,
+        release_id: releaseId,
+        prerelease: false,
+        make_latest: platform === 'android' ? 'true' : 'false', // We always want android to be the latest release, so a link to the latest github release will go to the apk
+      })
+      console.warn('Http response code of updating the result: ', result.status)
     })
-    console.log('Http response code of updating the result: ', result.status)
   }
 }
 

--- a/tools/github-promote-release.ts
+++ b/tools/github-promote-release.ts
@@ -23,7 +23,7 @@ const getAllPreReleased = async ({ deliverinoPrivateKey, owner, repo, platform }
   })
   const releasesWithTags = releases.data.filter(release => release.tag_name.includes(platform) && release.prerelease)
   const isLatestPreReleased =
-    releases.data.filter(release => release.tag_name.includes(platform))[0].prerelease === true
+    releases.data.filter(release => release.tag_name?.includes(platform))[0]?.prerelease === true
 
   if (releasesWithTags.length > 0) {
     return { preReleases: releasesWithTags, isLatestPreReleased: isLatestPreReleased }

--- a/tools/github-promote-release.ts
+++ b/tools/github-promote-release.ts
@@ -14,33 +14,23 @@ type Options = {
   platform: 'web' | 'android' | 'ios'
 }
 
-const getAllPreReleased = async ({ deliverinoPrivateKey, owner, repo, platform }: Options) => {
+const getReleases = async ({ deliverinoPrivateKey, owner, repo, platform }: Options) => {
   const appOctokit = await authenticate({ deliverinoPrivateKey, owner, repo })
 
   const releases: Releases = await appOctokit.rest.repos.listReleases({
     owner,
     repo,
   })
-  const releasesWithTags = releases.data.filter(release => release.tag_name.includes(platform) && release.prerelease)
-  const isLatestPreReleased =
-    releases.data.filter(release => release.tag_name?.includes(platform))[0]?.prerelease === true
-
-  if (releasesWithTags.length > 0) {
-    return { preReleases: releasesWithTags, isLatestPreReleased: isLatestPreReleased }
-  }
-
-  console.warn('No release found to unset the prerelease tag for. Latest release may already be non-prerelease')
-  return null
+  return releases.data.filter(release => release.tag_name.includes(platform))
 }
 
-const removePreRelease = async ({ deliverinoPrivateKey, owner, repo, platform }: Options) => {
-  const allPreReleases = await getAllPreReleased({ deliverinoPrivateKey, owner, repo, platform })
-  if (!allPreReleases) {
-    return null
-  }
+const promoteReleases = async ({ deliverinoPrivateKey, owner, repo, platform }: Options) => {
+  const releases = await getReleases({ deliverinoPrivateKey, owner, repo, platform })
+  const preReleases = releases.filter(release => release.prerelease)
+
   const appOctokit = await authenticate({ deliverinoPrivateKey, owner, repo })
   await Promise.all(
-    allPreReleases.preReleases.map(async preRelease => {
+    preReleases.map(async preRelease => {
       const result = await appOctokit.rest.repos.updateRelease({
         owner,
         repo,
@@ -51,15 +41,15 @@ const removePreRelease = async ({ deliverinoPrivateKey, owner, repo, platform }:
       console.warn('Http response code of updating the result: ', result.status)
     }),
   )
-  const filteredTagNames = allPreReleases.preReleases.map(release => release.tag_name)
+
+  const filteredTagNames = preReleases.map(release => release.tag_name)
   console.warn('Unset prerelease tags of ', filteredTagNames)
 
-  if (allPreReleases.isLatestPreReleased) {
-    return allPreReleases.preReleases[0]
-  } else {
-    console.warn('Note: latest release is not tagged with prerelease')
-    return null
+  if (preReleases[0]?.prerelease) {
+    return preReleases[0]
   }
+  console.warn('Nothing to promote')
+  return null
 }
 
 program
@@ -74,7 +64,7 @@ program
   .requiredOption('--platform <platform>')
   .action(async (options: Options) => {
     try {
-      const promotedRelease = await removePreRelease(options)
+      const promotedRelease = await promoteReleases(options)
       if (promotedRelease) {
         console.log(
           `The most recent beta version was promoted to production:\n[${promotedRelease.name}](${promotedRelease.html_url})`,

--- a/tools/github-promote-release.ts
+++ b/tools/github-promote-release.ts
@@ -38,12 +38,9 @@ const promoteReleases = async ({ deliverinoPrivateKey, owner, repo, platform }: 
         prerelease: false,
         make_latest: platform === 'android' ? 'true' : 'false', // We always want android to be the latest release, so a link to the latest github release will go to the apk
       })
-      console.warn('Http response code of updating the result: ', result.status)
+      console.warn(`Release ${preRelease.tag_name} promoted with status:`, result.status)
     }),
   )
-
-  const filteredTagNames = preReleases.map(release => release.tag_name)
-  console.warn('Unset prerelease tags of ', filteredTagNames)
 
   if (preReleases[0]?.prerelease) {
     return preReleases[0]


### PR DESCRIPTION
### Short Description

Currently, only the latest prerelease flag of the latest github release of the current platform is removed during a promotion. Accordingly, there are quite a few releases which still have the prerelease flag set.
However, this is wrong, as also those releases (or whatever is included in those releases) is now on production.


### Proposed Changes

<!-- Describe this PR in more detail. -->

- I filtered all Ids that are related to that platform then updateRelease for each id of these.
Note: this PR will have conflects with #3079

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

None

### Testing

N/A

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3088

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
