### PR TITLE
3117: Fix search term half-stays on language change

### DIFF
--- a/web/src/components/SearchInput.tsx
+++ b/web/src/components/SearchInput.tsx
@@ -74,7 +74,7 @@ const SearchInput = ({
         <TextInput
           placeholder={placeholderText}
           aria-label={placeholderText}
-          defaultValue={filterText}
+          value={filterText}
           onChange={handleFilterTextChange}
           onClick={onClickInput}
           autoFocus

--- a/web/src/routes/SearchPage.tsx
+++ b/web/src/routes/SearchPage.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { useLocation, useNavigate } from 'react-router-dom'
 import styled from 'styled-components'
 
-import { parseHTML, pathnameFromRouteInformation, SEARCH_ROUTE, useSearch } from 'shared'
+import { parseHTML, pathnameFromRouteInformation, SEARCH_ROUTE, useSearch, SEARCH_QUERY_KEY } from 'shared'
 import { config } from 'translations'
 
 import { CityRouteProps } from '../CityContentSwitcher'
@@ -32,7 +32,7 @@ const SearchCounter = styled.p`
 `
 
 const SearchPage = ({ city, cityCode, languageCode, pathname }: CityRouteProps): ReactElement | null => {
-  const query = new URLSearchParams(useLocation().search).get('query') ?? ''
+  const query = new URLSearchParams(useLocation().search).get(SEARCH_QUERY_KEY) ?? ''
   const [filterText, setFilterText] = useState<string>(query)
   const { t } = useTranslation('search')
   const navigate = useNavigate()
@@ -60,7 +60,7 @@ const SearchPage = ({ city, cityCode, languageCode, pathname }: CityRouteProps):
   }
 
   const languageChangePaths = city.languages.map(({ code, name }) => ({
-    path: pathnameFromRouteInformation({ route: SEARCH_ROUTE, cityCode, languageCode: code }),
+    path: `${pathnameFromRouteInformation({ route: SEARCH_ROUTE, cityCode, languageCode: code })}/?${SEARCH_QUERY_KEY}=${query}`,
     name,
     code,
   }))
@@ -82,7 +82,7 @@ const SearchPage = ({ city, cityCode, languageCode, pathname }: CityRouteProps):
 
   const handleFilterTextChanged = (filterText: string): void => {
     setFilterText(filterText)
-    const appendToUrl = filterText.length !== 0 ? `?query=${filterText}` : ''
+    const appendToUrl = filterText.length !== 0 ? `?${SEARCH_QUERY_KEY}=${filterText}` : ''
     navigate(`${pathname}/${appendToUrl}`, { replace: true })
   }
 


### PR DESCRIPTION
### Short Description
Currently search term stays in input after language change but the url query gets cleared out. The query and search term input should be there after language change

### Proposed Changes

- change `defaultValue` to `value` in TextInput because defaultValue contains the default value, while value contains the current value after some changes have been made. 
- use UseEffect to update filterText

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

- Go to the search page
- Search for `Augsburg`
- Change the language
- See that url query and search input text disappear

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3117 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
