### PR TITLE
3131: Fix categories not in alphabetical order

### DIFF
--- a/shared/utils/__tests__/pois.spec.ts
+++ b/shared/utils/__tests__/pois.spec.ts
@@ -126,14 +126,14 @@ describe('preparePois', () => {
       pois,
       params: { slug: 'test', multipoi: 0, poiCategoryId: undefined, currentlyOpen: true },
     })
-    expect(poiCategories1).toEqual([poi1.category, poi2.category])
+    expect(poiCategories1).toEqual([poi2.category, poi3.category])
     expect(poiCategory1).toBeUndefined()
 
     const { poiCategories: poiCategories2, poiCategory: poiCategory2 } = preparePois({
       pois: [...pois, ...pois],
       params: { slug: 'test', multipoi: 0, poiCategoryId: 10, currentlyOpen: true },
     })
-    expect(poiCategories2).toEqual([poi1.category, poi2.category])
+    expect(poiCategories2).toEqual([poi2.category, poi3.category])
     expect(poiCategory2).toEqual(poi1.category)
   })
 })

--- a/shared/utils/pois.ts
+++ b/shared/utils/pois.ts
@@ -55,6 +55,7 @@ export const preparePois = ({ pois: allPois, params }: PreparePoisProps): Prepar
   const poiCategories = allPois
     .map(it => it.category)
     .filter((it, index, array) => array.findIndex(value => value.id === it.id) === index)
+    .sort((a, b) => a.name.localeCompare(b.name))
   const poiCategory = poiCategories.find(it => it.id === poiCategoryId)
 
   return { pois, poi, mapFeature, mapFeatures, poiCategories, poiCategory }


### PR DESCRIPTION
### Short Description
Currently categories in PoiFilters are not sorted alphabetically even though there is a text saying `Categories A-Z`

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Added sort() method
- Adjust tests so that it equals sorted items

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

- Go to Map
- Click on `Filter locations`
- See a sidebar with categories

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3131 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
