### PR TITLE
3135: Fix tooltip being half hidden on language change hover

### DIFF
--- a/web/src/components/base/Tooltip.tsx
+++ b/web/src/components/base/Tooltip.tsx
@@ -3,7 +3,7 @@ import { Tooltip as ReactTooltip, ITooltip as ReactTooltipType } from 'react-too
 import styled from 'styled-components'
 
 const StyledTooltip = styled(ReactTooltip)`
-  z-index: 2;
+  z-index: 60;
 `
 
 type TooltipProps = {

--- a/web/src/components/base/Tooltip.tsx
+++ b/web/src/components/base/Tooltip.tsx
@@ -3,7 +3,7 @@ import { Tooltip as ReactTooltip, ITooltip as ReactTooltipType } from 'react-too
 import styled from 'styled-components'
 
 const StyledTooltip = styled(ReactTooltip)`
-  z-index: 1;
+  z-index: 2;
 `
 
 type TooltipProps = {


### PR DESCRIPTION
### Short Description

Tooltip is being half hidden when a user hovers over `Change Language` button in big width view. 

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Set higher z-index to Tooltip

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

Hover over `Change Language` button in web and see that the language selector container covers the half of the tooltip

### Resolved Issues

Fixes: #3135 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
