### PR TITLE
3132: Fix misalignment of icons and checkboxes in Orte filtern

### DIFF
--- a/web/src/components/PoiFilters.tsx
+++ b/web/src/components/PoiFilters.tsx
@@ -38,7 +38,7 @@ const Section = styled.div`
 const Row = styled.div`
   display: flex;
   gap: 8px;
-  align-items: center
+  align-items: center;
 `
 
 const SortingHint = styled.div`

--- a/web/src/components/PoiFilters.tsx
+++ b/web/src/components/PoiFilters.tsx
@@ -37,6 +37,8 @@ const Section = styled.div`
 
 const Row = styled.div`
   display: flex;
+  gap: 10px;
+  align-items: center
 `
 
 const SortingHint = styled.div`
@@ -60,8 +62,17 @@ const StyledButton = styled(TextButton)`
 `
 
 const StyledIcon = styled(Icon)`
-  width: 24px;
-  height: 24px;
+  width: 30px;
+  height: 30px;
+`
+
+const StyledCheckboxContainer = styled.div`
+  
+    @media (width >= 768px){
+        input[type="checkbox"] {
+            transform: scale(1.3); 
+        }
+    }
 `
 
 type PoiFiltersProps = {
@@ -94,12 +105,14 @@ const PoiFilters = ({
           <SubTitle>{t('openingHours')}</SubTitle>
           <Row>
             <StyledIcon src={ClockIcon} />
+            <StyledCheckboxContainer>
             <Checkbox
               id='poi-filters-currently-opened'
               checked={currentlyOpenFilter}
               setChecked={setCurrentlyOpenFilter}
               label={t('onlyCurrentlyOpen')}
             />
+            </StyledCheckboxContainer>
           </Row>
         </Section>
         <Section>

--- a/web/src/components/PoiFilters.tsx
+++ b/web/src/components/PoiFilters.tsx
@@ -99,7 +99,7 @@ const PoiFilters = ({
           <SubTitle>{t('openingHours')}</SubTitle>
           <Row>
             <StyledIcon src={ClockIcon} />
-            <Checkbox
+            <StyledCheckbox
               id='poi-filters-currently-opened'
               checked={currentlyOpenFilter}
               setChecked={setCurrentlyOpenFilter}

--- a/web/src/components/PoiFilters.tsx
+++ b/web/src/components/PoiFilters.tsx
@@ -37,8 +37,8 @@ const Section = styled.div`
 
 const Row = styled.div`
   display: flex;
-  gap: 10px;
-  align-items: center
+  gap: 8px;
+  align-items: center;
 `
 
 const SortingHint = styled.div`
@@ -62,17 +62,11 @@ const StyledButton = styled(TextButton)`
 `
 
 const StyledIcon = styled(Icon)`
-  width: 30px;
-  height: 30px;
+  min-width: 24px;
 `
 
-const StyledCheckboxContainer = styled.div`
-  
-    @media (width >= 768px){
-        input[type="checkbox"] {
-            transform: scale(1.3); 
-        }
-    }
+const StyledCheckbox = styled(Checkbox)`
+  min-width: 20px;
 `
 
 type PoiFiltersProps = {
@@ -105,14 +99,12 @@ const PoiFilters = ({
           <SubTitle>{t('openingHours')}</SubTitle>
           <Row>
             <StyledIcon src={ClockIcon} />
-            <StyledCheckboxContainer>
             <Checkbox
               id='poi-filters-currently-opened'
               checked={currentlyOpenFilter}
               setChecked={setCurrentlyOpenFilter}
               label={t('onlyCurrentlyOpen')}
             />
-            </StyledCheckboxContainer>
           </Row>
         </Section>
         <Section>


### PR DESCRIPTION
### Short Description

This PR fixes the the appearance of icons and checkboxes in the "Orte filtern" section by adjusting the Icon size of the clock and Checkbox Size for desktop appearance.

### Proposed Changes

<!-- Describe this PR in more detail. -->
Modified the Row styled component in PoiFilters.tsx to use gap between the checkbox and the Icon.
Added align-items: center and a min-height to maintain consistent vertical alignment and prevent layout shifts.
Increased the Icon Size for a better appearance in desktop and web.

### Side Effects

none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Verify that the icons and checkboxes in the "Orte filtern" section are properly aligned, starting from the left and have proper gap in desktop version.
Test the layout responsiveness by resizing the browser window to ensure the grid adjusts correctly with varying numbers of columns.

Check that the alignment remains consistent across different screen sizes (desktop, tablet, mobile).

### Resolved Issues

Fixes: #3132

---

<!--
DOR:
Fixed misalignment of icons and checkboxes in the 'Orte filtern
- Linting: `yarn lint` - did the test
- Typescript: `yarn ts:check` - didnt do the test
- Prettier: `yarn prettier` - couldnt do the test
- Unit tests: `yarn test` - did the test
-->
