### PR TITLE
2934: Show only one tooltip on events' date-icon

### DIFF
--- a/release-notes/unreleased/2934-show-only-one-tooltip-in-events-page.yml
+++ b/release-notes/unreleased/2934-show-only-one-tooltip-in-events-page.yml
@@ -1,0 +1,6 @@
+issue_key: 2934
+show_in_stores: false
+platforms: 
+  - web
+en: The date icon of the events page now only shows one tooltip when hovering over it e.g. 'Today'
+de: -

--- a/web/src/components/EventListItem.tsx
+++ b/web/src/components/EventListItem.tsx
@@ -28,6 +28,7 @@ const Content = styled.div`
 type EventListItemProps = {
   event: EventModel
   languageCode: string
+  index: number
   filterStartDate?: DateTime | null
   filterEndDate?: DateTime | null
 }
@@ -57,6 +58,7 @@ export const getDateIcon = (date: DateModel): { icon: string; tooltip: string } 
 const EventListItem = ({
   event,
   languageCode,
+  index,
   filterStartDate = null,
   filterEndDate = null,
 }: EventListItemProps): ReactElement => {
@@ -65,8 +67,9 @@ const EventListItem = ({
   const { t } = useTranslation('events')
   const dateToDisplay = getDisplayDate(event, filterStartDate, filterEndDate)
 
+  const tooltipId = `calendar-icon-${index}`
   const DateIcon = dateIcon && (
-    <Tooltip id='calendar-icon' tooltipContent={t(dateIcon.tooltip)}>
+    <Tooltip id={tooltipId} tooltipContent={t(dateIcon.tooltip)}>
       <Icon src={dateIcon.icon} id='calendar-icon' title={t(dateIcon.tooltip)} />
     </Tooltip>
   )

--- a/web/src/components/List.tsx
+++ b/web/src/components/List.tsx
@@ -13,7 +13,7 @@ const NoItemsMessage = styled.div`
 type ListProps<T> = {
   items: T[]
   noItemsMessage: string
-  renderItem: (item: T) => ReactNode
+  renderItem: (item: T, index: number) => ReactNode
   borderless?: boolean
 }
 
@@ -24,7 +24,7 @@ class List<T> extends React.PureComponent<ListProps<T>> {
       return <NoItemsMessage>{noItemsMessage}</NoItemsMessage>
     }
 
-    return <StyledList $borderless={borderless}>{items.map(item => renderItem(item))}</StyledList>
+    return <StyledList $borderless={borderless}>{items.map((item, index) => renderItem(item, index))}</StyledList>
   }
 }
 

--- a/web/src/components/__tests__/EventListItem.spec.tsx
+++ b/web/src/components/__tests__/EventListItem.spec.tsx
@@ -21,7 +21,9 @@ describe('EventListItem', () => {
   const excerpt = getExcerpt(event.excerpt, { maxChars: EXCERPT_MAX_CHARS })
 
   it('should show event list item with specific thumbnail', () => {
-    const { getByText, getByRole } = renderWithRouterAndTheme(<EventListItem event={event} languageCode={language} />)
+    const { getByText, getByRole } = renderWithRouterAndTheme(
+      <EventListItem index={0} event={event} languageCode={language} />,
+    )
 
     expect(getByText(event.title)).toBeTruthy()
     expect(getByText(event.date.toFormattedString(language), { collapseWhitespace: false })).toBeTruthy()
@@ -34,7 +36,7 @@ describe('EventListItem', () => {
     const eventWithoutThumbnail = Object.assign(event, { _thumbnail: undefined })
 
     const { getByText, getByRole } = renderWithRouterAndTheme(
-      <EventListItem event={eventWithoutThumbnail} languageCode={language} />,
+      <EventListItem index={0} event={eventWithoutThumbnail} languageCode={language} />,
     )
 
     expect(getByText(event.title)).toBeTruthy()
@@ -63,7 +65,9 @@ describe('EventListItem', () => {
       const event = createEvent()
       expect(getDateIcon(event.date)?.tooltip).toBeUndefined()
 
-      const { queryByText } = renderWithRouterAndTheme(<EventListItem event={event} languageCode={language} />)
+      const { queryByText } = renderWithRouterAndTheme(
+        <EventListItem index={0} event={event} languageCode={language} />,
+      )
 
       expect(queryByText('events:todayRecurring')).toBeFalsy()
       expect(queryByText('events:recurring')).toBeFalsy()
@@ -73,7 +77,9 @@ describe('EventListItem', () => {
     it('should show icon if recurring and today', () => {
       const event = createEvent('DTSTART:20230414T050000\nRRULE:FREQ=WEEKLY;BYDAY=MO;UNTIL=20231029T050000')
 
-      const { queryByText } = renderWithRouterAndTheme(<EventListItem event={event} languageCode={language} />)
+      const { queryByText } = renderWithRouterAndTheme(
+        <EventListItem index={0} event={event} languageCode={language} />,
+      )
 
       expect(queryByText('events:todayRecurring')).toBeTruthy()
       expect(queryByText('events:recurring')).toBeFalsy()
@@ -83,7 +89,9 @@ describe('EventListItem', () => {
     it('should show icon if recurring but not today', () => {
       const event = createEvent('DTSTART:20230414T050000\nRRULE:FREQ=WEEKLY;BYDAY=TU;UNTIL=20231029T050000')
 
-      const { queryByText } = renderWithRouterAndTheme(<EventListItem event={event} languageCode={language} />)
+      const { queryByText } = renderWithRouterAndTheme(
+        <EventListItem index={0} event={event} languageCode={language} />,
+      )
 
       expect(queryByText('events:todayRecurring')).toBeFalsy()
       expect(queryByText('events:recurring')).toBeTruthy()
@@ -93,7 +101,9 @@ describe('EventListItem', () => {
     it('should show icon if today but not recurring', () => {
       const event = createEvent('DTSTART:20230414T050000\nRRULE:FREQ=WEEKLY;BYDAY=MO;UNTIL=20231003T050000')
 
-      const { queryByText } = renderWithRouterAndTheme(<EventListItem event={event} languageCode={language} />)
+      const { queryByText } = renderWithRouterAndTheme(
+        <EventListItem index={0} event={event} languageCode={language} />,
+      )
 
       expect(queryByText('events:todayRecurring')).toBeFalsy()
       expect(queryByText('events:recurring')).toBeFalsy()

--- a/web/src/routes/EventsPage.tsx
+++ b/web/src/routes/EventsPage.tsx
@@ -137,11 +137,12 @@ const EventsPage = ({ city, pathname, languageCode, cityCode }: CityRouteProps):
     )
   }
 
-  const renderEventListItem = (event: EventModel) => (
+  const renderEventListItem = (event: EventModel, index: number) => (
     <EventListItem
       event={event}
       languageCode={languageCode}
       key={event.path}
+      index={index}
       filterStartDate={startDate}
       filterEndDate={endDate}
     />


### PR DESCRIPTION
### Short Description

When hovering over the events' date-icon we show only one tooltip

### Proposed Changes
- the problem was that inside EventListItem Component we did not ascribe a unique id to the tooltip
- in order to generate a unique id I hand in the index from the list of events to a singular item, which then can be used to generate a uniqueId
- (the alternative solution of generating a uniqueId from the events._path property I chose not to implement, since we currently do not guarantee that the path is unique (see: [#3060](https://github.com/digitalfabrik/integreat-cms/issues/3060))

### Side Effects

- ListComponent
- EventsPage
- EventsListItem

### Testing

- go to the events page: http://localhost:9000/muenchen/en/events
- hover over DateIcon of an Event Item 
     -> check that only one tooltip appears 
     -> check that the correct tooltip appears 

### Resolved Issues

Fixes: #2934 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
