### PR TITLE
Decrease chat polling interval

### DIFF
--- a/web/src/components/ChatController.tsx
+++ b/web/src/components/ChatController.tsx
@@ -19,7 +19,7 @@ type ChatControllerProps = {
 }
 
 const LOCAL_STORAGE_ITEM_CHAT_MESSAGES = 'Chat-Device-Id'
-const POLLING_INTERVAL = 16000
+const POLLING_INTERVAL = 8000
 
 const ChatController = ({ city, language }: ChatControllerProps): ReactElement => {
   const [sendingStatus, setSendingStatus] = useState<SendingStatusType>('idle')


### PR DESCRIPTION
### Short Description

With the [latest change of the Integreat CMS](https://github.com/digitalfabrik/integreat-cms/pull/3559) we introduced caching of Zammad responses. This makes the API quite fast and we can decrease polling times to improve the experience for the user.

### Proposed Changes

- Decrease chat polling interval to 8s.

### Side Effects

- More load on the CMS and more bandwidth usage. However, still only a few KB.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: None

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
