### PR TITLE
3000: Padding for external sources

### DIFF
--- a/native/src/routes/Consent.tsx
+++ b/native/src/routes/Consent.tsx
@@ -12,6 +12,7 @@ import buildConfig from '../constants/buildConfig'
 import { useAppContext } from '../hooks/useCityAppContext'
 
 const Description = styled(Text)`
+  padding: 0 16px;
   margin-bottom: 24px;
 `
 const Consent = (): ReactElement | null => {


### PR DESCRIPTION
### Short Description

At External Sources page in the settings the description is touching the edges of the screen.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Added padding to consents description

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

None.

### Testing

- At native go to settings then External Sources.
- The description should have padding.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3000 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
