### PR TITLE
3132: Fix misaligned checkbox

### DIFF
--- a/web/src/components/PoiFilters.tsx
+++ b/web/src/components/PoiFilters.tsx
@@ -37,6 +37,8 @@ const Section = styled.div`
 
 const Row = styled.div`
   display: flex;
+  gap: 8px;
+  align-items: center;
 `
 
 const SortingHint = styled.div`

--- a/web/src/components/base/Checkbox.tsx
+++ b/web/src/components/base/Checkbox.tsx
@@ -12,6 +12,7 @@ const StyledCheckbox = styled.input`
   accent-color: ${props => props.theme.colors.themeColor};
   width: 20px;
   height: 20px;
+  min-width: 20px;
   align-self: center;
 `
 


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Fix misaligned checkbox for poi filter.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Add min-width and align-items center to fix misaligned checkbox in poi filters

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

If using the checkbox in a smaller size than 20px, its now necessary to override the min-width as well.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Go to http://localhost:9000/testumgebung/de/locations and hit `Orte filtern`.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3132

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
