### PR TITLE
3186: Adjust theme for high contrast mode

### DIFF
--- a/build-configs/BuildConfigType.ts
+++ b/build-configs/BuildConfigType.ts
@@ -61,6 +61,7 @@ export type CommonBuildConfigType = {
   internalUrlPattern: string
   featureFlags: FeatureFlagsType
   lightTheme: ThemeType
+  highContrastTheme: ThemeType
   // Translations deviating from the standard integreat translations.
   translationsOverride?: TranslationsType
   // Assets like icons, logos and imprints.

--- a/build-configs/aschaffenburg/index.ts
+++ b/build-configs/aschaffenburg/index.ts
@@ -19,6 +19,7 @@ const commonAschaffenburgBuildConfig: CommonBuildConfigType = {
   appIcon: 'app_icon_aschaffenburg',
   notificationIcon: 'notification_icon_aschaffenburg',
   lightTheme,
+  highContrastTheme: lightTheme,
   assets: ASCHAFFENBURG_ASSETS,
   cmsUrl: 'https://cms.integreat-app.de',
   hostName: 'halloaschaffenburg.de',

--- a/build-configs/common/theme/colors.ts
+++ b/build-configs/common/theme/colors.ts
@@ -1,26 +1,26 @@
 export type ColorsType = {
   themeColor: string
-  themeColorLight?: string
+  themeColorLight: string
   backgroundAccentColor: string
   textColor: string
-  textSecondaryColor?: string
-  textDecorationColor?: string
-  textDisabledColor?: string
-  footerLineColor?: string
-  backgroundColor?: string
-  tunewsThemeColor?: string
-  tunewsThemeColorLight?: string
+  textSecondaryColor: string
+  textDecorationColor: string
+  textDisabledColor: string
+  footerLineColor: string
+  backgroundColor: string
+  tunewsThemeColor: string
+  tunewsThemeColorLight: string
   borderColor: string
-  positiveHighlight?: string
-  negativeHighlight?: string
-  invalidInput?: string
-  warningColor?: string
-  linkColor?: string
-  themeContrast?: string
-  ttsPlayerWarningBackground?: string
-  ttsPlayerWarningColor?: string
-  ttsPlayerBackground?: string
-  ttsPlayerPlayIconColor?: string
+  positiveHighlight: string
+  negativeHighlight: string
+  invalidInput: string
+  warningColor: string
+  linkColor: string
+  themeContrast: string
+  ttsPlayerWarningBackground: string
+  ttsPlayerWarningColor: string
+  ttsPlayerBackground: string
+  ttsPlayerPlayIconColor: string
 }
 export const commonLightColors = {
   backgroundAccentColor: '#fafafa',
@@ -44,6 +44,7 @@ export const commonLightColors = {
   ttsPlayerPlayIconColor: '#232323',
 }
 export const commonHighContrastColors = {
+  ...commonLightColors,
   backgroundAccentColor: '#20293A',
   backgroundColor: '#101217',
   textColor: '#FFFFFF',

--- a/build-configs/common/theme/colors.ts
+++ b/build-configs/common/theme/colors.ts
@@ -1,26 +1,26 @@
 export type ColorsType = {
   themeColor: string
-  themeColorLight: string
+  themeColorLight?: string
   backgroundAccentColor: string
   textColor: string
-  textSecondaryColor: string
-  textDecorationColor: string
-  textDisabledColor: string
-  footerLineColor: string
-  backgroundColor: string
-  tunewsThemeColor: string
-  tunewsThemeColorLight: string
+  textSecondaryColor?: string
+  textDecorationColor?: string
+  textDisabledColor?: string
+  footerLineColor?: string
+  backgroundColor?: string
+  tunewsThemeColor?: string
+  tunewsThemeColorLight?: string
   borderColor: string
-  positiveHighlight: string
-  negativeHighlight: string
-  invalidInput: string
-  warningColor: string
-  linkColor: string
-  themeContrast: string
-  ttsPlayerWarningBackground: string
-  ttsPlayerWarningColor: string
-  ttsPlayerBackground: string
-  ttsPlayerPlayIconColor: string
+  positiveHighlight?: string
+  negativeHighlight?: string
+  invalidInput?: string
+  warningColor?: string
+  linkColor?: string
+  themeContrast?: string
+  ttsPlayerWarningBackground?: string
+  ttsPlayerWarningColor?: string
+  ttsPlayerBackground?: string
+  ttsPlayerPlayIconColor?: string
 }
 export const commonLightColors = {
   backgroundAccentColor: '#fafafa',
@@ -42,4 +42,10 @@ export const commonLightColors = {
   ttsPlayerWarningColor: '#f97c00',
   ttsPlayerBackground: '#dedede',
   ttsPlayerPlayIconColor: '#232323',
+}
+export const commonHighContrastColors = {
+  backgroundAccentColor: '#20293A',
+  backgroundColor: '#101217',
+  textColor: '#FFFFFF',
+  borderColor: '#FFFFFF',
 }

--- a/build-configs/integreat/index.ts
+++ b/build-configs/integreat/index.ts
@@ -8,7 +8,7 @@ import {
 import { APP_STORE_TEAM_ID } from '../common/constants'
 import cityNotCooperatingTemplate from './assets/cityNotCooperatingTemplate'
 import mainImprint from './mainImprint'
-import { lightTheme } from './theme'
+import { lightTheme, highContrastTheme } from './theme'
 
 const APPLICATION_ID = 'tuerantuer.app.integreat'
 const BUNDLE_IDENTIFIER = 'de.integreat-app'
@@ -18,6 +18,7 @@ const commonIntegreatBuildConfig: CommonBuildConfigType = {
   appIcon: 'app_icon_integreat',
   notificationIcon: 'notification_icon_integreat',
   lightTheme,
+  highContrastTheme,
   assets: INTEGREAT_ASSETS,
   cmsUrl: 'https://cms.integreat-app.de',
   switchCmsUrl: 'https://cms-test.integreat-app.de',

--- a/build-configs/integreat/theme/colors.ts
+++ b/build-configs/integreat/theme/colors.ts
@@ -1,4 +1,4 @@
-import { ColorsType, commonLightColors } from '../../common/theme/colors'
+import { ColorsType, commonLightColors, commonHighContrastColors } from '../../common/theme/colors'
 
 const themeColor = '#fbda16'
 const themeColorLight = 'rgba(251, 218, 22, 0.5)'
@@ -9,4 +9,9 @@ export const lightColors: ColorsType = {
   themeColorLight,
   themeContrast,
   ...commonLightColors,
+}
+
+export const highContrastColors: ColorsType = {
+  themeColor,
+  ...commonHighContrastColors,
 }

--- a/build-configs/integreat/theme/colors.ts
+++ b/build-configs/integreat/theme/colors.ts
@@ -13,5 +13,7 @@ export const lightColors: ColorsType = {
 
 export const highContrastColors: ColorsType = {
   themeColor,
+  themeColorLight,
+  themeContrast,
   ...commonHighContrastColors,
 }

--- a/build-configs/integreat/theme/index.ts
+++ b/build-configs/integreat/theme/index.ts
@@ -1,8 +1,13 @@
 import { ThemeType } from '../../ThemeType'
-import { lightColors } from './colors'
+import { lightColors, highContrastColors } from './colors'
 import integreatFonts from './fonts'
 
 export const lightTheme: ThemeType = {
   colors: lightColors,
+  fonts: integreatFonts,
+}
+
+export const highContrastTheme: ThemeType = {
+  colors: highContrastColors,
   fonts: integreatFonts,
 }

--- a/build-configs/malte/index.ts
+++ b/build-configs/malte/index.ts
@@ -19,6 +19,7 @@ const commonMalteBuildConfig: CommonBuildConfigType = {
   appIcon: 'app_icon_malte',
   notificationIcon: 'notification_icon_malte',
   lightTheme,
+  highContrastTheme: lightTheme,
   assets: MALTE_ASSETS,
   cmsUrl: 'https://cms.malteapp.de',
   switchCmsUrl: 'https://malte-test.tuerantuer.org',

--- a/build-configs/obdach/index.ts
+++ b/build-configs/obdach/index.ts
@@ -9,6 +9,7 @@ const commonObdachBuildConfig: CommonBuildConfigType = {
   appName: 'Netzwerk Obdach & Wohnen',
   appIcon: 'app_icon_obdach',
   lightTheme,
+  highContrastTheme: lightTheme,
   assets: OBDACH_ASSETS,
   cmsUrl: 'https://cms.netzwerkobdachwohnen.de',
   hostName: 'netzwerkobdachwohnen.de',

--- a/native/src/constants/__mocks__/buildConfig.ts
+++ b/native/src/constants/__mocks__/buildConfig.ts
@@ -1,6 +1,6 @@
 import { INTEGREAT_ASSETS } from 'build-configs/AssetsType'
 import { CommonBuildConfigType } from 'build-configs/BuildConfigType'
-import { lightTheme } from 'build-configs/integreat/theme'
+import { lightTheme, highContrastTheme } from 'build-configs/integreat/theme'
 
 export const buildConfigIconSet = (): {
   appLogo: string
@@ -16,6 +16,7 @@ const buildConfig = jest.fn<CommonBuildConfigType, []>(
     appIcon: 'app_icon_integreat',
     notificationIcon: 'notification_icon_integreat',
     lightTheme,
+    highContrastTheme,
     assets: INTEGREAT_ASSETS,
     cmsUrl: 'https://cms.integreat-app.de',
     switchCmsUrl: 'https://cms-test.integreat-app.de',


### PR DESCRIPTION
### Short Description

Theme should be adjust in build-configs to accept high contrast theme on integreat

### Proposed Changes

<!-- Describe this PR in more detail. -->

- add high contrast theme
- add colors necessary for high contrast theme
- make adjustments in other platforms to avoid error (we are implementing for now only for integreat)

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3186 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
