### PR TITLE
2928: Improve error reporting and fix search with duplicates

### DIFF
--- a/native/src/routes/SearchModal.tsx
+++ b/native/src/routes/SearchModal.tsx
@@ -10,6 +10,7 @@ import List from '../components/List'
 import SearchHeader from '../components/SearchHeader'
 import SearchListItem from '../components/SearchListItem'
 import useAnnounceSearchResultsIOS from '../hooks/useAnnounceSearchResultsIOS'
+import useReportError from '../hooks/useReportError'
 import useResourceCache from '../hooks/useResourceCache'
 import testID from '../testing/testID'
 import sendTrackingSignal from '../utils/sendTrackingSignal'
@@ -49,10 +50,11 @@ const SearchModal = ({
   const resourceCache = useResourceCache({ cityCode, languageCode })
   const { t } = useTranslation('search')
 
-  const contentLanguageResults = useSearch(documents, query)
-  const fallbackLanguageResults = useSearch(fallbackLanguageDocuments, query)
-  const searchResults = contentLanguageResults.concat(fallbackLanguageResults)
+  const contentLanguageReturn = useSearch(documents, query)
+  const fallbackLanguageReturn = useSearch(fallbackLanguageDocuments, query)
+  const searchResults = contentLanguageReturn.data.concat(fallbackLanguageReturn.data)
 
+  useReportError(contentLanguageReturn.error ?? fallbackLanguageReturn.error)
   useAnnounceSearchResultsIOS(searchResults)
 
   const onClose = (): void => {

--- a/native/src/routes/__tests__/SearchModal.spec.tsx
+++ b/native/src/routes/__tests__/SearchModal.spec.tsx
@@ -27,7 +27,11 @@ jest.mock('react-native-inappbrowser-reborn', () => ({
 
 jest.mock('shared', () => ({
   ...jest.requireActual('shared'),
-  useSearch: (results: SearchResult[], query: string) => (query === 'no results, please' ? [] : results),
+  useSearch: (results: SearchResult[], query: string) => ({
+    data: query === 'no results, please' ? [] : results,
+    error: null,
+    loading: false,
+  }),
 }))
 
 describe('SearchModal', () => {

--- a/release-notes/unreleased/2928-search-duplicates.yml
+++ b/release-notes/unreleased/2928-search-duplicates.yml
@@ -1,0 +1,8 @@
+issue_key: 3104
+show_in_stores: true
+platforms:
+  - android
+  - ios
+  - web
+en: Fix search behaving weirdly in some occurrences.
+de: Unerwartetes Verhalten der Suchfunktion behoben.

--- a/web/src/hooks/__tests__/useReportError.spec.tsx
+++ b/web/src/hooks/__tests__/useReportError.spec.tsx
@@ -1,0 +1,36 @@
+import { render } from '@testing-library/react'
+import React from 'react'
+
+import { MappingError } from 'shared/api'
+
+import { reportError } from '../../utils/sentry'
+import useReportError from '../useReportError'
+
+jest.mock('../../utils/sentry', () => ({
+  reportError: jest.fn(async () => null),
+}))
+
+describe('useReportError', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  const MockComponent = ({ error }: { error: Error | null }) => {
+    useReportError(error)
+    return null
+  }
+
+  it('should report error', async () => {
+    const { rerender } = render(<MockComponent error={null} />)
+    expect(reportError).not.toHaveBeenCalled()
+
+    const error = new MappingError('cities', 'some error')
+    rerender(<MockComponent error={error} />)
+
+    expect(reportError).toHaveBeenCalledTimes(1)
+    expect(reportError).toHaveBeenCalledWith(error)
+
+    rerender(<MockComponent error={null} />)
+    expect(reportError).toHaveBeenCalledTimes(1)
+  })
+})

--- a/web/src/hooks/useReportError.ts
+++ b/web/src/hooks/useReportError.ts
@@ -1,0 +1,13 @@
+import { useEffect } from 'react'
+
+import { reportError } from '../utils/sentry'
+
+const useReportError = (error: Error | null): void => {
+  useEffect(() => {
+    if (error !== null) {
+      reportError(error).catch()
+    }
+  }, [error])
+}
+
+export default useReportError

--- a/web/src/routes/SearchPage.tsx
+++ b/web/src/routes/SearchPage.tsx
@@ -17,6 +17,7 @@ import SearchListItem from '../components/SearchListItem'
 import { helpers } from '../constants/theme'
 import { cmsApiBaseUrl } from '../constants/urls'
 import useLoadSearchDocuments from '../hooks/useLoadSearchDocuments'
+import useReportError from '../hooks/useReportError'
 
 const List = styled.ul`
   list-style-type: none;
@@ -50,10 +51,12 @@ const SearchPage = ({ city, cityCode, languageCode, pathname }: CityRouteProps):
     cmsApiBaseUrl,
   })
 
-  const contentLanguageResults = useSearch(contentLanguageDocuments, query)
+  const contentLanguageReturn = useSearch(contentLanguageDocuments, query)
   const fallbackLanguageDocuments = languageCode !== fallbackLanguage ? fallbackData : []
-  const fallbackLanguageResults = useSearch(fallbackLanguageDocuments, query)
-  const results = contentLanguageResults.concat(fallbackLanguageResults)
+  const fallbackLanguageReturn = useSearch(fallbackLanguageDocuments, query)
+  const results = contentLanguageReturn.data.concat(fallbackLanguageReturn.data)
+
+  useReportError(contentLanguageReturn.error ?? fallbackLanguageReturn.error)
 
   if (!city) {
     return null

--- a/web/src/routes/__tests__/SearchPage.spec.tsx
+++ b/web/src/routes/__tests__/SearchPage.spec.tsx
@@ -23,7 +23,11 @@ jest.mock('react-tooltip')
 
 jest.mock('shared', () => ({
   ...jest.requireActual('shared'),
-  useSearch: (results: SearchResult[], query: string) => (query === 'no results, please' ? [] : results),
+  useSearch: (results: SearchResult[], query: string) => ({
+    data: query === 'no results, please' ? [] : results,
+    error: null,
+    loading: false,
+  }),
 }))
 
 describe('SearchPage', () => {


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Improve error reporting for the search and fix search problems with duplicated documents.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Remove duplicates from documents before searching
- Report errors occurring in search
- Adjust root project code style

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
1. ~~Manually add a duplicated document before sanitizing in `useSearch`(L70):~~ See testing instructions by @LeandraH [here](https://github.com/digitalfabrik/integreat-app/pull/3200#pullrequestreview-2768038950).
2. Ensure that no error is thrown
3. Manually add a duplicated document after sanitizing in `useSearch`(L75):
```ts
        .addAllAsync([...documents, documents[0]!])
```
4. Ensure that the error is caught and reported (i.e. logged in dev mode)

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2928, #3192

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
