### PR TITLE
3204: Add androidXBrowser with defined version at build gradle

### DIFF
--- a/native/android/build.gradle
+++ b/native/android/build.gradle
@@ -6,6 +6,7 @@ buildscript {
         targetSdkVersion = 34
         ndkVersion = "26.1.10909125"
         kotlinVersion = "1.9.22"
+        androidXBrowser = "1.8.0"
     }
     repositories {
         google()


### PR DESCRIPTION
### Short Description

When starting the android app at integreat the build fails :
```
Dependency 'androidx.browser:browser:1.9.0-alpha02' requires libraries and applications that
           depend on it to compile against version 36 or later of the
           Android APIs.
```

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Defined androidXBrowser at `/android/build.gradle` with version 1.8.0.

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

None.

### Testing

- Just start the app for integreat (you may remove all node_modules and re-install)

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3204 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
