### PR TITLE
3187: Save contrast theme in localStorage on web

### DIFF
--- a/web/src/components/ThemeContext.tsx
+++ b/web/src/components/ThemeContext.tsx
@@ -1,10 +1,11 @@
-import React, { createContext, ReactElement, useEffect, useMemo, useState } from 'react'
+import React, { createContext, ReactElement, useMemo } from 'react'
 import { ThemeProvider } from 'styled-components'
 
 import { ThemeType, ThemeKey } from 'build-configs'
 import { UiDirectionType } from 'translations'
 
 import buildConfig from '../constants/buildConfig'
+import useLocalStorage from '../hooks/useLocalStorage'
 
 export type ThemeContextType = {
   theme: ThemeType
@@ -34,29 +35,21 @@ type ThemeContainerProps = {
 }
 
 export const ThemeContainer = ({ children, contentDirection }: ThemeContainerProps): ReactElement => {
-  const [themeType, setThemeType] = useState<ThemeKey>(getSystemTheme)
-
-  useEffect(() => {
-    const updateTheme = () => setThemeType(getSystemTheme())
-
-    updateTheme()
-
-    contrastThemeMediaQueries.forEach(query => query.addEventListener('change', updateTheme))
-
-    return () => {
-      contrastThemeMediaQueries.forEach(query => query.removeEventListener('change', updateTheme))
-    }
-  }, [])
+  const { value: themeType, updateLocalStorageItem: setThemeType } = useLocalStorage<ThemeKey>({
+    key: 'theme',
+    initialValue: getSystemTheme(),
+  })
 
   const contextValue = useMemo(() => {
     const toggleTheme = () => {
-      setThemeType(prev => (prev === 'light' ? 'contrast' : 'light'))
+      const currentTheme = themeType === 'light' ? 'contrast' : 'light'
+      setThemeType(currentTheme)
     }
 
     const baseTheme = themeType === 'contrast' ? themeConfig.contrastTheme : themeConfig.lightTheme
     const theme = { ...baseTheme, contentDirection, isContrastTheme: themeType === 'contrast' }
     return { theme, themeType, toggleTheme }
-  }, [themeType, contentDirection])
+  }, [themeType, setThemeType, contentDirection])
 
   return (
     <ThemeContext.Provider value={contextValue}>


### PR DESCRIPTION
### Short Description

This PR saves the state of the contrast theme in LocalStorage. 

### Proposed Changes

- used LocalStorage Hook to save the state ('light' or 'contrast')

### Side Effects

- none

### Testing
Go to http://localhost:9000/testumgebung/de and see state being persistent. You can also try to enable the dark/contrast theme on your browser and check the page whether it immediately detects the enabled theme on your browser and keeps it persistent throughout the interaction.

### Resolved Issues

Fixes: #3187 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
