### PR TITLE
3154: Check supported languages for TTS

### DIFF
--- a/native/src/components/TtsContainer.tsx
+++ b/native/src/components/TtsContainer.tsx
@@ -57,7 +57,6 @@ const TtsContainer = ({ children }: TtsContainerProps): ReactElement => {
 
   useEffect(() => {
     const checkLanguageSupport = async () => {
-      console.log('language check')
       try {
         const voices = await Tts.voices()
 
@@ -145,7 +144,7 @@ const TtsContainer = ({ children }: TtsContainerProps): ReactElement => {
         stop()
       }
     },
-    [stop, stopPlayer, sentenceIndex, sentences, languageCode],
+    [stop, stopPlayer, sentenceIndex, sentences, languageCode, enabled],
   )
 
   useAppStateListener(appState => {

--- a/native/src/components/TtsContainer.tsx
+++ b/native/src/components/TtsContainer.tsx
@@ -70,7 +70,7 @@ const TtsContainer = ({ children }: TtsContainerProps): ReactElement => {
         })
         return isSupported
       } catch (error) {
-        // reportError(error)
+        reportError(error)
         return false
       }
     }
@@ -134,7 +134,7 @@ const TtsContainer = ({ children }: TtsContainerProps): ReactElement => {
     async (index = sentenceIndex) => {
       const safeIndex = Math.max(0, index)
       const sentence = sentences[safeIndex]
-      if (sentence) {
+      if (sentence && enabled) {
         await stopPlayer()
         setIsPlaying(true)
         setSentenceIndex(safeIndex)

--- a/native/src/components/TtsContainer.tsx
+++ b/native/src/components/TtsContainer.tsx
@@ -62,20 +62,18 @@ const TtsContainer = ({ children }: TtsContainerProps): ReactElement => {
 
         const isSupported = voices.some(({ language }) => {
           if (!language) {
-            return false
+            setIsLanguageSupported(false)
           }
           const code = language.split('-')[0]
           return code === languageCode
         })
-        return isSupported
+        setIsLanguageSupported(isSupported)
       } catch (error) {
         reportError(error)
-        return false
+        setIsLanguageSupported(false)
       }
     }
-    checkLanguageSupport().then(result => {
-      setIsLanguageSupported(result)
-    })
+    checkLanguageSupport()
   }, [languageCode])
 
   const enabled = buildConfig().featureFlags.tts && isLanguageSupported

--- a/native/src/components/__mocks__/react-native-tts.tsx
+++ b/native/src/components/__mocks__/react-native-tts.tsx
@@ -7,6 +7,12 @@ const MockTts = {
   removeAllListeners: jest.fn(),
   getInitStatus: jest.fn(() => Promise.resolve('success')),
   addListener: jest.fn(),
+  voices: jest.fn(() =>
+    Promise.resolve([
+      { language: 'en-US', name: 'English' },
+      { language: 'de-DE', name: 'German' },
+    ]),
+  ),
 }
 
 export default MockTts


### PR DESCRIPTION
### Short Description

We should check every language we support on whether it is supported or not. For supported languages tts should be enabled. If there are differences between android and ios, the language should only be enabled on the corresponding OS.

### Proposed Changes

- Checking Tts.voices() for available languages and return true if current language is supported.
- Used this useEffect to just check for language support only when I change language.
- Added `enabled` flag to `play` function's if statement to prevent users from playing unsupported language while the tts is showed up from previous supported language.

Note: I didn't test this on iOS.

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

None.

### Testing

- Switch to language that is not supported like Persian or Kurmanji.
- Read-aloud button should not appear on these unsupported languages.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3154 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
