### PR TITLE
3225: Add test to contrast theme for web

### DIFF
--- a/native/src/@types/styled.d.ts
+++ b/native/src/@types/styled.d.ts
@@ -4,5 +4,7 @@ import { ThemeType } from 'build-configs/ThemeType'
 
 declare module 'styled-components/native' {
   // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-  export interface DefaultTheme extends ThemeType {}
+  export interface DefaultTheme extends ThemeType {
+    isContrastTheme?: boolean
+  }
 }

--- a/native/src/App.tsx
+++ b/native/src/App.tsx
@@ -6,7 +6,6 @@ import { LogBox } from 'react-native'
 import { SafeAreaProvider } from 'react-native-safe-area-context'
 import { enableScreens } from 'react-native-screens'
 import { HeaderButtonsProvider } from 'react-navigation-header-buttons'
-import { ThemeProvider } from 'styled-components/native'
 
 import { CLOSE_PAGE_SIGNAL_NAME, REDIRECT_ROUTE } from 'shared'
 import { setUserAgent } from 'shared/api'
@@ -19,9 +18,9 @@ import IOSSafeAreaView from './components/IOSSafeAreaView'
 import SnackbarContainer from './components/SnackbarContainer'
 import StaticServerProvider from './components/StaticServerProvider'
 import StatusBar from './components/StatusBar'
+import { ThemeContainer } from './components/ThemeContext'
 import TtsContainer from './components/TtsContainer'
 import { RoutesParamsType } from './constants/NavigationTypes'
-import buildConfig from './constants/buildConfig'
 import { userAgent } from './constants/endpoint'
 import AppContextProvider from './contexts/AppContextProvider'
 import useSendOfflineJpalSignals from './hooks/useSendOfflineJpalSignals'
@@ -82,7 +81,7 @@ const App = (): ReactElement => {
 
   return (
     <>
-      <ThemeProvider theme={buildConfig().lightTheme}>
+      <ThemeContainer>
         <StaticServerProvider>
           <I18nProvider>
             <SafeAreaProvider>
@@ -105,7 +104,7 @@ const App = (): ReactElement => {
             </SafeAreaProvider>
           </I18nProvider>
         </StaticServerProvider>
-      </ThemeProvider>
+      </ThemeContainer>
       <AppStateListener />
     </>
   )

--- a/native/src/components/Header.tsx
+++ b/native/src/components/Header.tsx
@@ -27,6 +27,7 @@ import buildConfig from '../constants/buildConfig'
 import dimensions from '../constants/dimensions'
 import { AppContext } from '../contexts/AppContextProvider'
 import useSnackbar from '../hooks/useSnackbar'
+import { useThemeContext } from '../hooks/useThemeContext'
 import useTtsPlayer from '../hooks/useTtsPlayer'
 import createNavigateToFeedbackModal from '../navigation/createNavigateToFeedbackModal'
 import navigateToLanguageChange from '../navigation/navigateToLanguageChange'
@@ -53,6 +54,7 @@ enum HeaderButtonTitle {
   Location = 'changeLocation',
   Search = 'search',
   ReadAloud = 'readAloud',
+  ContrastTheme = 'contrastTheme',
   Share = 'share',
   Settings = 'settings',
   Feedback = 'feedback',
@@ -86,6 +88,7 @@ const Header = ({
   const [previousRoute] = useState(navigation.getState().routes[navigation.getState().routes.length - 2])
   const [canGoBack] = useState(navigation.canGoBack())
   const { enabled: isTtsEnabled, showTtsPlayer } = useTtsPlayer()
+  const { toggleTheme } = useThemeContext()
 
   const onShare = async () => {
     if (!shareUrl) {
@@ -196,6 +199,7 @@ const Header = ({
           ? [renderOverflowItem(HeaderButtonTitle.Location, () => navigation.navigate(LANDING_ROUTE))]
           : []),
         renderOverflowItem(HeaderButtonTitle.Settings, () => navigation.navigate(SETTINGS_ROUTE)),
+        ...[renderOverflowItem(t(HeaderButtonTitle.ContrastTheme), toggleTheme)],
         ...(isTtsEnabled ? [renderOverflowItem(t(HeaderButtonTitle.ReadAloud), showTtsPlayer)] : []),
         ...(route.name !== NEWS_ROUTE ? [renderOverflowItem(HeaderButtonTitle.Feedback, navigateToFeedback)] : []),
         ...(route.name !== DISCLAIMER_ROUTE

--- a/native/src/components/ThemeContext.tsx
+++ b/native/src/components/ThemeContext.tsx
@@ -1,0 +1,44 @@
+import React, { createContext, ReactElement, useMemo, useState } from 'react'
+import { ThemeProvider } from 'styled-components/native'
+
+import { ThemeType, ThemeKey } from 'build-configs/index'
+
+import buildConfig from '../constants/buildConfig'
+
+export type ThemeContextType = {
+  theme: ThemeType
+  themeType: ThemeKey
+  toggleTheme: () => void
+}
+
+const themeConfig = buildConfig()
+
+export const ThemeContext = createContext<ThemeContextType>({
+  theme: themeConfig.lightTheme,
+  themeType: 'light',
+  toggleTheme: () => undefined,
+})
+
+type ThemeContainerProps = {
+  children: ReactElement
+}
+
+export const ThemeContainer = ({ children }: ThemeContainerProps): ReactElement => {
+  const [themeType, setThemeType] = useState<ThemeKey>('light')
+
+  const contextValue = useMemo(() => {
+    const toggleTheme = () => {
+      setThemeType(prev => (prev === 'light' ? 'contrast' : 'light'))
+    }
+
+    const baseTheme = themeType === 'contrast' ? themeConfig.contrastTheme : themeConfig.lightTheme
+    const theme = { ...baseTheme, isContrastTheme: themeType === 'contrast' }
+    return { theme, themeType, toggleTheme }
+  }, [themeType])
+
+  return (
+    <ThemeContext.Provider value={contextValue}>
+      <ThemeProvider theme={contextValue.theme}>{children}</ThemeProvider>
+    </ThemeContext.Provider>
+  )
+}

--- a/native/src/hooks/useThemeContext.tsx
+++ b/native/src/hooks/useThemeContext.tsx
@@ -1,0 +1,5 @@
+import { useContext } from 'react'
+
+import { ThemeContext, ThemeContextType } from '../components/ThemeContext'
+
+export const useThemeContext = (): ThemeContextType => useContext(ThemeContext)

--- a/web/src/components/__tests__/ContrastThemeToggle.spec.tsx
+++ b/web/src/components/__tests__/ContrastThemeToggle.spec.tsx
@@ -14,7 +14,7 @@ jest.mock('react-i18next')
 
 const TestThemeTypeChange = () => {
   const { themeType } = useThemeContext()
-  return <div data-testid='theme-type'>{themeType}</div>
+  return <div>{themeType}</div>
 }
 
 const toggleContrastTheme = () =>
@@ -39,9 +39,9 @@ describe('ContrastThemeToggle', () => {
 
   it('toggles theme between light and contrast in mobile view', () => {
     mocked(useWindowDimensions).mockImplementation(() => ({ ...mockWindowDimensions, viewportSmall: true }))
-    const { getByRole, getByTestId } = toggleContrastTheme()
+    const { getByRole, getByText } = toggleContrastTheme()
     const toggleButton = getByRole('button', { name: 'layout:contrastTheme' })
-    const themeType = getByTestId('theme-type')
+    const themeType = getByText('light')
     expect(themeType).toHaveTextContent('light')
 
     fireEvent.click(toggleButton)
@@ -60,9 +60,9 @@ describe('ContrastThemeToggle', () => {
 
   it('toggles theme between light and contrast in desktop view', () => {
     mocked(useWindowDimensions).mockImplementation(() => ({ ...mockWindowDimensions, viewportSmall: false }))
-    const { getByRole, getByTestId } = toggleContrastTheme()
+    const { getByRole, getByText } = toggleContrastTheme()
     const toggleButton = getByRole('button', { name: 'layout:contrastTheme' })
-    const themeType = getByTestId('theme-type')
+    const themeType = getByText('light')
     expect(themeType).toHaveTextContent('light')
 
     fireEvent.click(toggleButton)

--- a/web/src/components/__tests__/ContrastThemeToggle.spec.tsx
+++ b/web/src/components/__tests__/ContrastThemeToggle.spec.tsx
@@ -1,0 +1,74 @@
+import { fireEvent } from '@testing-library/react'
+import { mocked } from 'jest-mock'
+import React from 'react'
+
+import { useThemeContext } from '../../hooks/useThemeContext'
+import useWindowDimensions from '../../hooks/useWindowDimensions'
+import { renderWithTheme } from '../../testing/render'
+import { mockWindowDimensions } from '../../testing/utils'
+import ContrastThemeToggle from '../ContrastThemeToggle'
+import { ThemeContainer } from '../ThemeContext'
+
+jest.mock('../../hooks/useWindowDimensions', () => jest.fn(() => ({ viewportSmall: false })))
+jest.mock('react-i18next')
+
+const TestThemeTypeChange = () => {
+  const { themeType } = useThemeContext()
+  return <div data-testid='theme-type'>{themeType}</div>
+}
+
+const toggleContrastTheme = () =>
+  renderWithTheme(
+    <ThemeContainer contentDirection='ltr'>
+      <>
+        <ContrastThemeToggle />
+        <TestThemeTypeChange />
+      </>
+    </ThemeContainer>,
+  )
+
+describe('ContrastThemeToggle', () => {
+  beforeEach(jest.clearAllMocks)
+
+  it('render toggle button in mobile view', () => {
+    mocked(useWindowDimensions).mockImplementation(() => ({ ...mockWindowDimensions, viewportSmall: true }))
+    const { getByRole } = toggleContrastTheme()
+    const toggleButton = getByRole('button', { name: 'layout:contrastTheme' })
+    expect(toggleButton).toBeInTheDocument()
+  })
+
+  it('toggles theme between light and contrast in mobile view', () => {
+    mocked(useWindowDimensions).mockImplementation(() => ({ ...mockWindowDimensions, viewportSmall: true }))
+    const { getByRole, getByTestId } = toggleContrastTheme()
+    const toggleButton = getByRole('button', { name: 'layout:contrastTheme' })
+    const themeType = getByTestId('theme-type')
+    expect(themeType).toHaveTextContent('light')
+
+    fireEvent.click(toggleButton)
+    expect(themeType).toHaveTextContent('contrast')
+
+    fireEvent.click(toggleButton)
+    expect(themeType).toHaveTextContent('light')
+  })
+
+  it('render toggle button in desktop view', () => {
+    mocked(useWindowDimensions).mockImplementation(() => ({ ...mockWindowDimensions, viewportSmall: false }))
+    const { getByRole } = toggleContrastTheme()
+    const toggleButton = getByRole('button', { name: 'layout:contrastTheme' })
+    expect(toggleButton).toBeInTheDocument()
+  })
+
+  it('toggles theme between light and contrast in desktop view', () => {
+    mocked(useWindowDimensions).mockImplementation(() => ({ ...mockWindowDimensions, viewportSmall: false }))
+    const { getByRole, getByTestId } = toggleContrastTheme()
+    const toggleButton = getByRole('button', { name: 'layout:contrastTheme' })
+    const themeType = getByTestId('theme-type')
+    expect(themeType).toHaveTextContent('light')
+
+    fireEvent.click(toggleButton)
+    expect(themeType).toHaveTextContent('contrast')
+
+    fireEvent.click(toggleButton)
+    expect(themeType).toHaveTextContent('light')
+  })
+})


### PR DESCRIPTION
### Short Description

This PR adds test to contrast theme toggle function.It checks whether toggle button is rendered on small and desktop views as well as whether the toggle function toggles the theme type from light->contrast or vice versa.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- create test file ContrastThemeToggle.spec.tsx
- tested render on small and desktop views
- tested whether toggle button changes the theme type (light->contrast or vice versa)

### Resolved Issues
Fixes: #3225 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
