### PR TITLE
Avoid showing complete website url for poi contacts #3208

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "integreat-app",
+  "name": "Anna",
   "license": "MIT",
   "private": true,
   "workspaces": {
@@ -71,5 +71,10 @@
     "ts-jest": "^29.1.2",
     "tsx": "^4.8.2",
     "typescript": "^5.4.5"
-  }
+  },
+  "version": "1.0.0",
+  "description": "3208-avoid-showing-complete-website-url",
+  "main": "index.js",
+  "repository": "https://github.com/Vasianandcarps/integreat-app-3208-avoid-showing-complete-website-url.git",
+  "author": "Anna <anna.2005.nikulina@gmail.com>"
 }

--- a/web/package.json
+++ b/web/package.json
@@ -1,11 +1,11 @@
 {
   "name": "web",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "scripts": {
     "webpack-ts": "cross-env TS_NODE_PROJECT=\"tools/tsconfig.webpack.json\" webpack --config tools/webpack.config.ts --env bundle_analyzer",
     "webpack-dev-server-ts": "cross-env TS_NODE_PROJECT=\"tools/tsconfig.webpack.json\" webpack-dev-server --config tools/webpack.config.ts --progress",
-    "start": "yarn run webpack-dev-server-ts --env config_name=integreat-test-cms --env dev_server",
+    "start": "yarn run webpack-dev-server-ts --env config_name=integreat-test-cms --env dev_server start",
     "start:malte": "yarn run webpack-dev-server-ts --env config_name=malte --env dev_server",
     "start:malte-test-cms": "yarn run webpack-dev-server-ts --env config_name=malte-test-cms --env dev_server",
     "start:aschaffenburg": "yarn run webpack-dev-server-ts --env config_name=aschaffenburg --env dev_server",
@@ -44,6 +44,7 @@
     "maplibre-gl": "^4.6.0",
     "normalize.css": "^8.0.1",
     "react": "18.2.0",
+    "react-datepicker": "^7.5.0",
     "react-dom": "18.2.0",
     "react-helmet": "^6.1.0",
     "react-highlight-words": "^0.20.0",
@@ -57,8 +58,7 @@
     "schema-dts": "^1.1.2",
     "shared": "0.0.1",
     "styled-components": "^6.1.13",
-    "translations": "0.0.1",
-    "react-datepicker": "^7.5.0"
+    "translations": "0.0.1"
   },
   "devDependencies": {
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",
@@ -98,5 +98,8 @@
     "webpack-bundle-analyzer": "^4.10.1",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.4"
-  }
+  },
+  "main": "index.js",
+  "repository": "https://github.com/Vasianandcarps/integreat-app-3208-avoid-showing-complete-website-url",
+  "license": "MIT"
 }

--- a/web/src/components/Contact.tsx
+++ b/web/src/components/Contact.tsx
@@ -17,7 +17,7 @@ const Contact = ({
   return (
     <Collapsible title={headline ?? t('contactInformation')}>
       <div>
-        {!!website && <ContactItem iconSrc={WebsiteIcon} iconAlt={t('website')} link={website} content={'Website'} />}
+        {!!website && <ContactItem iconSrc={WebsiteIcon} iconAlt={t('website')} link={website} isExternalLink={true} content={'Website'} />}
         {!!phoneNumber && (
           <ContactItem iconSrc={PhoneIcon} iconAlt={t('phone')} link={`tel:${phoneNumber}`} content={phoneNumber} />
         )}

--- a/web/src/components/Contact.tsx
+++ b/web/src/components/Contact.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 
 import { ContactModel } from 'shared/api'
 
-import { MailIcon, PhoneIcon, WebsiteIcon } from '../assets'
+import { ExternalLinkIcon, MailIcon, PhoneIcon, WebsiteIcon } from '../assets'
 import Collapsible from './Collapsible'
 import ContactItem from './ContactItem'
 
@@ -17,7 +17,7 @@ const Contact = ({
   return (
     <Collapsible title={headline ?? t('contactInformation')}>
       <div>
-        {!!website && <ContactItem iconSrc={WebsiteIcon} iconAlt={t('website')} link={website} content={website} />}
+        {!!website && <ContactItem iconSrc={WebsiteIcon} iconAlt={t('website')} link={website} content={'Website'} />}
         {!!phoneNumber && (
           <ContactItem iconSrc={PhoneIcon} iconAlt={t('phone')} link={`tel:${phoneNumber}`} content={phoneNumber} />
         )}

--- a/web/src/components/Contact.tsx
+++ b/web/src/components/Contact.tsx
@@ -17,7 +17,15 @@ const Contact = ({
   return (
     <Collapsible title={headline ?? t('contactInformation')}>
       <div>
-        {!!website && <ContactItem iconSrc={WebsiteIcon} iconAlt={t('website')} link={website} isExternalLink={true} content={'Website'} />}
+        {!!website && (
+          <ContactItem
+            iconSrc={WebsiteIcon}
+            iconAlt={t('website')}
+            link={website}
+            content={'Website'}
+            isExternalLink={true}
+          />
+        )}
         {!!phoneNumber && (
           <ContactItem iconSrc={PhoneIcon} iconAlt={t('phone')} link={`tel:${phoneNumber}`} content={phoneNumber} />
         )}

--- a/web/src/components/ContactItem.tsx
+++ b/web/src/components/ContactItem.tsx
@@ -45,7 +45,7 @@ const ContactItem = ({ iconSrc, iconAlt, link, content }: ContactItemProps): Rea
     <Marker src={iconSrc} alt={iconAlt} />
     {content}
     {/* Show icon if Contakt info is Website  */}
-    {content.toLowerCase() === 'website' && <StyledExternalLinkIcon alt=' ' src={ExternalLinkIcon} />}
+    {isExternalLink && <StyledExternalLinkIcon alt=' ' src={ExternalLinkIcon} />}
   </StyledLink>
 )
 

--- a/web/src/components/ContactItem.tsx
+++ b/web/src/components/ContactItem.tsx
@@ -3,9 +3,8 @@ import styled from 'styled-components'
 
 import { ExternalLinkIcon } from '../assets'
 import { helpers } from '../constants/theme'
+import isExternalLink from './Contact'
 import Link from './base/Link'
-
-// импортируем иконку внешней ссылки
 
 const Marker = styled.img`
   width: 20px;
@@ -37,14 +36,14 @@ type ContactItemProps = {
   iconAlt: string
   link: string
   content: string
-  isWebsite?: boolean // Дополнительный проп для отображения иконки только для веб-сайта
+  isExternalLink?: boolean // Дополнительный проп для отображения иконки только для веб-сайта
 }
 
-const ContactItem = ({ iconSrc, iconAlt, link, content }: ContactItemProps): ReactElement => (
+const ContactItem = ({ iconSrc, iconAlt, link, content, isExternalLink }: ContactItemProps): ReactElement => (
   <StyledLink to={link}>
     <Marker src={iconSrc} alt={iconAlt} />
     {content}
-    {/* Show icon if Contakt info is Website  */}
+
     {isExternalLink && <StyledExternalLinkIcon alt=' ' src={ExternalLinkIcon} />}
   </StyledLink>
 )

--- a/web/src/components/ContactItem.tsx
+++ b/web/src/components/ContactItem.tsx
@@ -1,8 +1,11 @@
 import React, { ReactElement } from 'react'
 import styled from 'styled-components'
 
+import { ExternalLinkIcon } from '../assets'
 import { helpers } from '../constants/theme'
 import Link from './base/Link'
+
+// импортируем иконку внешней ссылки
 
 const Marker = styled.img`
   width: 20px;
@@ -20,17 +23,29 @@ const StyledLink = styled(Link)`
   ${helpers.adaptiveFontSize};
 `
 
+// Новый Styled компонент для кнопки с иконкой внешней ссылки
+const StyledExternalLinkIcon = styled.img`
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  object-fit: contain;
+  margin-left: 8px; // Добавляем отступ между текстом и иконкой
+`
+
 type ContactItemProps = {
   iconSrc: string
   iconAlt: string
   link: string
   content: string
+  isWebsite?: boolean // Дополнительный проп для отображения иконки только для веб-сайта
 }
 
 const ContactItem = ({ iconSrc, iconAlt, link, content }: ContactItemProps): ReactElement => (
   <StyledLink to={link}>
     <Marker src={iconSrc} alt={iconAlt} />
     {content}
+    {/* Show icon if Contakt info is Website  */}
+    {content.toLowerCase() === 'website' && <StyledExternalLinkIcon alt=' ' src={ExternalLinkIcon} />}
   </StyledLink>
 )
 

--- a/web/src/components/OrganizationContentInfo.tsx
+++ b/web/src/components/OrganizationContentInfo.tsx
@@ -56,8 +56,7 @@ const OrganizationContentInfo = ({ organization }: OrganizationContentInfoProps)
           <Trans i18nKey='categories:organizationMoreInformation' domain={new URL(organization.url).hostname}>
             This gets{{ organization: organization.name }}replaced
             <a href={organization.url} target='_blank' rel='noopener noreferrer'>
-              {/* @ts-expect-error gets replaced by Trans component */}
-              {{ domain: new URL(organization.url).hostname }}
+              Url
             </a>
             by i18n
           </Trans>


### PR DESCRIPTION
### Short Description

It doesn't display the full website link but instead makes the word "Website" a clickable link. An icon has been added as part of the link.

![image](https://github.com/user-attachments/assets/7b7913f5-fb91-4dba-811e-d9d659ded8c2)
