### PR TITLE
3232: Deliver 3231-design-system-web to future.integreat.app

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -589,6 +589,7 @@ jobs:
                     - production
                     - beta
                     - webnext
+                    - future
                 type: enum
         resource_class: small
         shell: /bin/bash -eo pipefail
@@ -656,6 +657,15 @@ jobs:
                     - run:
                         command: rsync -e "ssh -o StrictHostKeyChecking=no" -arv --delete $HOME/attached_workspace/dist/obdach/ web@web.integreat-app.de:/var/www/webnext.netzwerkobdachwohnen.de
                         name: Obdach webnext delivery
+            - when:
+                condition:
+                    equal:
+                        - future
+                        - << parameters.delivery >>
+                steps:
+                    - run:
+                        command: rsync -e "ssh -o StrictHostKeyChecking=no" -arv --delete $HOME/attached_workspace/dist/integreat-test-cms/ web@web.integreat-app.de:/var/www/future.integreat.app
+                        name: Integreat future delivery
             - notify
     e2e_android:
         docker:
@@ -1020,6 +1030,30 @@ workflows:
                     - main
                     - << pipeline.git.branch >>
                 - << pipeline.parameters.api_triggered >>
+    commit_design_system:
+        jobs:
+            - bump_version:
+                context:
+                    - mattermost
+                prepare_delivery: false
+            - build_web:
+                build_config_name: integreat-test-cms
+                context:
+                    - mattermost
+                requires:
+                    - bump_version
+            - deliver_web:
+                context:
+                    - mattermost
+                delivery: future
+                requires:
+                    - build_web
+        when:
+            and:
+                - equal:
+                    - 3231-design-system-web
+                    - << pipeline.git.branch >>
+                - not: << pipeline.parameters.api_triggered >>
     commit_main:
         jobs:
             - bump_version:

--- a/.circleci/src/jobs/deliver_web.yml
+++ b/.circleci/src/jobs/deliver_web.yml
@@ -1,7 +1,7 @@
 parameters:
   delivery:
     description: Whether to deliver to production, beta or to webnext.
-    enum: [production, beta, webnext]
+    enum: [production, beta, webnext, future]
     type: enum
 docker:
   - image: cimg/node:20.17.0
@@ -65,4 +65,11 @@ steps:
         - run:
             name: Obdach webnext delivery
             command: rsync -e "ssh -o StrictHostKeyChecking=no" -arv --delete $HOME/attached_workspace/dist/obdach/ web@web.integreat-app.de:/var/www/webnext.netzwerkobdachwohnen.de
+  - when:
+      condition:
+        equal: [future, << parameters.delivery >>]
+      steps:
+        - run:
+            name: Integreat future delivery # StrictHostKeyChecking=no is not a security problem. The worst that could happen is a delivery to the wrong domain.
+            command: rsync -e "ssh -o StrictHostKeyChecking=no" -arv --delete $HOME/attached_workspace/dist/integreat-test-cms/ web@web.integreat-app.de:/var/www/future.integreat.app
   - notify

--- a/.circleci/src/workflows/commit_design_system.yml
+++ b/.circleci/src/workflows/commit_design_system.yml
@@ -1,0 +1,21 @@
+when:
+  and:
+    - equal: [3231-design-system-web, << pipeline.git.branch >>]
+    - not: << pipeline.parameters.api_triggered >>
+jobs:
+  - bump_version:
+      prepare_delivery: false
+      context:
+        - mattermost
+  - build_web:
+      build_config_name: integreat-test-cms
+      context:
+        - mattermost
+      requires:
+        - bump_version
+  - deliver_web:
+      delivery: future
+      context:
+        - mattermost
+      requires:
+        - build_web


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Deliver 3231-design-system-web to future.integreat.app.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Add temporary `deliver_design_system` workflow to deliver integreat-test-cms builds to https://future.integreat.app

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
N/A

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3232

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
