### PR TITLE
3218: ChatSecurityInformation popup fix for RTL Support

### DIFF
--- a/build-configs/index.ts
+++ b/build-configs/index.ts
@@ -72,6 +72,9 @@ const loadBuildConfig = <T extends PlatformType>(
     throw Error(`Build config not available for platform: ${platform}`)
   }
 
+  buildConfig.common.featureFlags.cityNotCooperating =
+    !!buildConfig.common.featureFlags.cityNotCooperatingTemplate && !!buildConfig.web.icons.cityNotCooperating
+
   return buildConfig[platform]
 }
 

--- a/build-configs/index.ts
+++ b/build-configs/index.ts
@@ -72,9 +72,6 @@ const loadBuildConfig = <T extends PlatformType>(
     throw Error(`Build config not available for platform: ${platform}`)
   }
 
-  buildConfig.common.featureFlags.cityNotCooperating =
-    !!buildConfig.common.featureFlags.cityNotCooperatingTemplate && !!buildConfig.web.icons.cityNotCooperating
-
   return buildConfig[platform]
 }
 

--- a/web/src/components/ChatSecurityInformation.tsx
+++ b/web/src/components/ChatSecurityInformation.tsx
@@ -26,7 +26,7 @@ const SecurityIcon = styled(Icon)`
   color: ${props => props.theme.colors.textSecondaryColor};
 `
 
-const InformationTooltipContainer = styled.div`
+const InformationTooltipContainer = styled.div<{ $isRtl: boolean }>`
   position: absolute;
   z-index: 2000;
   border: 1px solid;
@@ -34,7 +34,7 @@ const InformationTooltipContainer = styled.div`
   color: white;
   padding: 12px;
   text-align: center;
-  transform: translate(-95%, -90%);
+  transform: ${props => (props.$isRtl ? 'translate(95%, -90%)' : 'translate(-95%, -90%)')};
   white-space: pre-line;
   width: 250px;
 
@@ -44,11 +44,14 @@ const InformationTooltipContainer = styled.div`
 `
 
 const ChatSecurityInformation = (): ReactElement => {
-  const { t } = useTranslation('chat')
+  const { t, i18n } = useTranslation('chat')
   const [securityInformationVisible, setSecurityInformationVisible] = useState<boolean>(false)
+  const isRtl = i18n.dir() === 'rtl'
   return (
     <SecurityInformationContainer>
-      {securityInformationVisible && <InformationTooltipContainer>{t('dataSecurity')}</InformationTooltipContainer>}
+      {securityInformationVisible && (
+        <InformationTooltipContainer $isRtl={isRtl}>{t('dataSecurity')}</InformationTooltipContainer>
+      )}
       <SecurityIconContainer onClick={() => setSecurityInformationVisible(!securityInformationVisible)}>
         <SecurityIcon src={DataSecurityIcon} />
       </SecurityIconContainer>

--- a/web/src/components/ChatSecurityInformation.tsx
+++ b/web/src/components/ChatSecurityInformation.tsx
@@ -26,7 +26,7 @@ const SecurityIcon = styled(Icon)`
   color: ${props => props.theme.colors.textSecondaryColor};
 `
 
-const InformationTooltipContainer = styled.div<{ $isRtl: boolean }>`
+const InformationTooltipContainer = styled.div`
   position: absolute;
   z-index: 2000;
   border: 1px solid;
@@ -34,7 +34,7 @@ const InformationTooltipContainer = styled.div<{ $isRtl: boolean }>`
   color: white;
   padding: 12px;
   text-align: center;
-  transform: ${props => (props.$isRtl ? 'translate(95%, -90%)' : 'translate(-95%, -90%)')};
+  transform: ${props => (props.theme.contentDirection === 'rtl' ? 'translate(95%, -90%)' : 'translate(-95%, -90%)')};
   white-space: pre-line;
   width: 250px;
 
@@ -44,15 +44,12 @@ const InformationTooltipContainer = styled.div<{ $isRtl: boolean }>`
 `
 
 const ChatSecurityInformation = (): ReactElement => {
-  const { t, i18n } = useTranslation('chat')
+  const { t } = useTranslation('chat')
   const [securityInformationVisible, setSecurityInformationVisible] = useState<boolean>(false)
-  const isRtl = i18n.dir() === 'rtl'
 
   return (
     <SecurityInformationContainer>
-      {securityInformationVisible && (
-        <InformationTooltipContainer $isRtl={isRtl}>{t('dataSecurity')}</InformationTooltipContainer>
-      )}
+      {securityInformationVisible && <InformationTooltipContainer>{t('dataSecurity')}</InformationTooltipContainer>}
       <SecurityIconContainer onClick={() => setSecurityInformationVisible(!securityInformationVisible)}>
         <SecurityIcon src={DataSecurityIcon} />
       </SecurityIconContainer>

--- a/web/src/components/ChatSecurityInformation.tsx
+++ b/web/src/components/ChatSecurityInformation.tsx
@@ -47,6 +47,7 @@ const ChatSecurityInformation = (): ReactElement => {
   const { t, i18n } = useTranslation('chat')
   const [securityInformationVisible, setSecurityInformationVisible] = useState<boolean>(false)
   const isRtl = i18n.dir() === 'rtl'
+
   return (
     <SecurityInformationContainer>
       {securityInformationVisible && (


### PR DESCRIPTION
### Short Description

Data security popup not opening at Integreat chat for RTL languages.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Just passed `isRtl` to `InformationTooltipContainer` and changed the x value to 95% to be on the opposite side when the language is RTL.

### Side Effects

None.

-

### Testing

- Go to [http://localhost:9000/muenchen/de'](http://localhost:9000/muenchen/de)
- Switch to Arabic language.
- Open chat.
- Click on the lock icon.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3218 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
