### PR TITLE
2170: Easteregg image should not be focusable by external keyboard

### DIFF
--- a/native/src/components/SwitchCmsUrlIcon.tsx
+++ b/native/src/components/SwitchCmsUrlIcon.tsx
@@ -78,7 +78,12 @@ const SwitchCmsUrlIcon = ({ clearResourcesAndCache }: LandingIconProps): ReactEl
 
   return (
     <Container>
-      <StyledPressable onPress={onImagePress} role='button'>
+      <StyledPressable
+        onPress={onImagePress}
+        role='button'
+        focusable={false}
+        importantForAccessibility='no'
+        accessible={false}>
         <StyledIcon Icon={LocationMarkerIcon} />
       </StyledPressable>
       {apiUrlOverride && apiUrlOverride !== buildConfig().cmsUrl ? (

--- a/native/src/components/SwitchCmsUrlIcon.tsx
+++ b/native/src/components/SwitchCmsUrlIcon.tsx
@@ -83,6 +83,7 @@ const SwitchCmsUrlIcon = ({ clearResourcesAndCache }: LandingIconProps): ReactEl
         role='button'
         focusable={false}
         importantForAccessibility='no'
+        accessibilityElementsHidden={true}
         accessible={false}>
         <StyledIcon Icon={LocationMarkerIcon} />
       </StyledPressable>

--- a/native/src/components/SwitchCmsUrlIcon.tsx
+++ b/native/src/components/SwitchCmsUrlIcon.tsx
@@ -83,7 +83,7 @@ const SwitchCmsUrlIcon = ({ clearResourcesAndCache }: LandingIconProps): ReactEl
         role='button'
         focusable={false}
         importantForAccessibility='no'
-        accessibilityElementsHidden={true}
+        accessibilityElementsHidden
         accessible={false}>
         <StyledIcon Icon={LocationMarkerIcon} />
       </StyledPressable>


### PR DESCRIPTION
### Short Description

The Easteregg image can be selected/focused by the keyboard. This should not be possible.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Changed accessible to false this will prevent user from focusing on the button by keyboard.
- I Disabled screen readers for it too.
- `importantForAccessibility` for Android.
- `accessibilityElementsHidden` for iOS.

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

None.

### Testing

Native: 
- Go to landing view / change location.
- Press tab on keyboard to reach the `SwitchCmsUrlIcon` you may need to go through the whole list to reach it.
- Enable talkback and try to select the cms button.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2170

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
