### PR TITLE
3243: Adjust styles of contrast theme on native

### DIFF
--- a/native/src/@types/styled.d.ts
+++ b/native/src/@types/styled.d.ts
@@ -4,5 +4,7 @@ import { ThemeType } from 'build-configs/ThemeType'
 
 declare module 'styled-components/native' {
   // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-  export interface DefaultTheme extends ThemeType {}
+  export interface DefaultTheme extends ThemeType {
+    isContrastTheme?: boolean
+  }
 }

--- a/native/src/App.tsx
+++ b/native/src/App.tsx
@@ -6,7 +6,6 @@ import { LogBox } from 'react-native'
 import { SafeAreaProvider } from 'react-native-safe-area-context'
 import { enableScreens } from 'react-native-screens'
 import { HeaderButtonsProvider } from 'react-navigation-header-buttons'
-import { ThemeProvider } from 'styled-components/native'
 
 import { CLOSE_PAGE_SIGNAL_NAME, REDIRECT_ROUTE } from 'shared'
 import { setUserAgent } from 'shared/api'
@@ -19,9 +18,9 @@ import IOSSafeAreaView from './components/IOSSafeAreaView'
 import SnackbarContainer from './components/SnackbarContainer'
 import StaticServerProvider from './components/StaticServerProvider'
 import StatusBar from './components/StatusBar'
+import { ThemeContainer } from './components/ThemeContext'
 import TtsContainer from './components/TtsContainer'
 import { RoutesParamsType } from './constants/NavigationTypes'
-import buildConfig from './constants/buildConfig'
 import { userAgent } from './constants/endpoint'
 import AppContextProvider from './contexts/AppContextProvider'
 import useSendOfflineJpalSignals from './hooks/useSendOfflineJpalSignals'
@@ -82,7 +81,7 @@ const App = (): ReactElement => {
 
   return (
     <>
-      <ThemeProvider theme={buildConfig().lightTheme}>
+      <ThemeContainer>
         <StaticServerProvider>
           <I18nProvider>
             <SafeAreaProvider>
@@ -105,7 +104,7 @@ const App = (): ReactElement => {
             </SafeAreaProvider>
           </I18nProvider>
         </StaticServerProvider>
-      </ThemeProvider>
+      </ThemeContainer>
       <AppStateListener />
     </>
   )

--- a/native/src/components/AddressInfo.tsx
+++ b/native/src/components/AddressInfo.tsx
@@ -26,6 +26,10 @@ const IconContainer = styled(Pressable)`
   padding: 0 8px;
 `
 
+const StyledText = styled(Text)`
+  color: ${props => props.theme.colors.textColor};
+`
+
 type AddressInfoProps = {
   location: LocationModel<number>
   language: string
@@ -49,10 +53,10 @@ const AddressInfo = ({ location, language }: AddressInfoProps): ReactElement => 
   return (
     <Container language={language}>
       <Pressable accessibilityLabel={t('copyAddress')} role='button' onPress={copyLocationToClipboard}>
-        <Text>{address}</Text>
-        <Text>
+        <StyledText>{address}</StyledText>
+        <StyledText>
           {postcode} {town}
-        </Text>
+        </StyledText>
       </Pressable>
       <IconContainer role='link' onPress={openExternalMaps} accessibilityLabel={t('openExternalMaps')}>
         <Icon Icon={ExternalLinkIcon} />

--- a/native/src/components/AppointmentOnlyOverlay.tsx
+++ b/native/src/components/AppointmentOnlyOverlay.tsx
@@ -40,7 +40,8 @@ const CloseButton = styled.Pressable`
 
 const CloseButtonText = styled.Text`
   font-weight: 700;
-  color: ${props => props.theme.colors.textSecondaryColor};
+  color: ${props =>
+    props.theme.isContrastTheme ? props.theme.colors.backgroundColor : props.theme.colors.textSecondaryColor};
 `
 
 type AppointmentOnlyOverlayProps = {

--- a/native/src/components/CalendarRangeModal.tsx
+++ b/native/src/components/CalendarRangeModal.tsx
@@ -10,7 +10,8 @@ import Caption from './Caption'
 import TextButton from './base/TextButton'
 
 const DatePickerWrapper = styled.View`
-  background-color: ${props => props.theme.colors.textDecorationColor};
+  background-color: ${props =>
+    props.theme.isContrastTheme ? props.theme.colors.backgroundAccentColor : props.theme.colors.textDecorationColor};
   border-radius: 20px;
   position: absolute;
   width: 90%;
@@ -27,7 +28,9 @@ const StyledView = styled.View`
 
 const DISABLED_OPACITY = 0.5
 
-const StyledTextButton = styled(TextButton)`
+const StyledTextButton = styled(TextButton).attrs(props => ({
+  textStyle: { color: props.theme.isContrastTheme ? props.theme.colors.textColor : undefined },
+}))`
   background-color: transparent;
   opacity: ${props => (props.disabled ? DISABLED_OPACITY : 1)};
   height: 40px;
@@ -105,10 +108,11 @@ const CalendarRangeModal = ({
           markedDates={getMarkedDates(tempStartDate, tempEndDate, theme, currentInput ?? '')}
           onDayPress={handleDayPress}
           theme={{
-            calendarBackground: theme.colors.textDecorationColor,
+            calendarBackground: theme.isContrastTheme ? theme.colors.backgroundColor : theme.colors.textDecorationColor,
             dayTextColor: theme.colors.textColor,
+            monthTextColor: theme.colors.textColor,
             textDisabledColor: theme.colors.textSecondaryColor,
-            todayTextColor: theme.colors.backgroundColor,
+            todayTextColor: theme.isContrastTheme ? theme.colors.linkColor : theme.colors.backgroundColor,
             textSectionTitleColor: theme.colors.textColor,
             arrowColor: theme.colors.textColor,
           }}

--- a/native/src/components/CategoryListItem.tsx
+++ b/native/src/components/CategoryListItem.tsx
@@ -32,6 +32,7 @@ const CategoryEntryContainer = styled.View`
 const TitleDirectionContainer = styled.View<{ language: string }>`
   align-items: center;
   flex-direction: ${props => contentDirection(props.language)};
+  color: ${props => props.theme.colors.textColor};
 `
 
 const CategoryTitle = styled.Text<{ language: string }>`

--- a/native/src/components/CityNotCooperatingFooter.tsx
+++ b/native/src/components/CityNotCooperatingFooter.tsx
@@ -16,6 +16,7 @@ const FooterContainer = styled.View`
 `
 
 const Question = styled.Text`
+  color: ${props => props.theme.colors.textColor};
   margin-top: 5%;
   font-family: ${props => props.theme.fonts.native.decorativeFontBold};
   font-size: 16px;

--- a/native/src/components/Collapsible.tsx
+++ b/native/src/components/Collapsible.tsx
@@ -16,6 +16,7 @@ const CollapseHeaderText = styled.Text`
   font-size: 14px;
   align-self: center;
   font-family: ${props => props.theme.fonts.native.decorativeFontBold};
+  color: ${props => props.theme.colors.textColor};
 `
 
 const CollapseHeaderWrapper = styled.View<{ language: string }>`
@@ -27,6 +28,7 @@ const CollapseHeaderWrapper = styled.View<{ language: string }>`
 `
 
 const StyledIcon = styled(Icon)<{ collapsed: boolean }>`
+  color: ${props => props.theme.colors.textColor};
   transform: rotate(90deg) ${props => (props.collapsed ? 'scale(-1)' : '')};
   margin: 0 4px;
   align-self: center;

--- a/native/src/components/DatePicker.tsx
+++ b/native/src/components/DatePicker.tsx
@@ -34,6 +34,10 @@ const Wrapper = styled.View`
   width: 50%;
 `
 
+const StyledDatePickerInput = styled(DatePickerInput)`
+  color: ${props => props.theme.colors.textColor};
+`
+
 const StyledIconButton = styled(IconButton)<{ $isModalOpen: boolean }>`
   width: 40px;
   height: 40px;
@@ -47,6 +51,7 @@ const StyledTitle = styled.Text`
   top: -12px;
   left: 12px;
   padding: 2px 5px;
+  color: ${props => props.theme.colors.textColor};
   font-size: 12px;
   z-index: 1;
 `
@@ -55,6 +60,10 @@ const StyledError = styled.Text`
   font-size: 12px;
   font-weight: bold;
   color: ${props => props.theme.colors.invalidInput};
+`
+
+const StyledCalendarIcon = styled(Icon)`
+  color: ${props => (props.theme.isContrastTheme ? props.theme.colors.backgroundColor : props.theme.colors.textColor)};
 `
 
 export type DatePickerProps = {
@@ -117,7 +126,7 @@ const DatePicker = ({
       <StyledTitle>{title}</StyledTitle>
       <StyledInputWrapper>
         <Wrapper>
-          <DatePickerInput
+          <StyledDatePickerInput
             ref={dayRef}
             placeholder={placeholderDay}
             nextTargetRef={monthRef}
@@ -126,7 +135,7 @@ const DatePicker = ({
             type='day'
           />
           <Text>.</Text>
-          <DatePickerInput
+          <StyledDatePickerInput
             ref={monthRef}
             placeholder={placeholderMonth}
             nextTargetRef={yearRef}
@@ -136,7 +145,7 @@ const DatePicker = ({
             type='month'
           />
           <Text>.</Text>
-          <DatePickerInput
+          <StyledDatePickerInput
             style={{ marginLeft: 6 }}
             ref={yearRef}
             prevTargetRef={monthRef}
@@ -148,7 +157,7 @@ const DatePicker = ({
         </Wrapper>
         <StyledIconButton
           $isModalOpen={modalOpen}
-          icon={<Icon Icon={CalendarTodayIcon} />}
+          icon={<StyledCalendarIcon Icon={CalendarTodayIcon} />}
           accessibilityLabel={t('common:openCalendar')}
           onPress={() => {
             setModalOpen(true)

--- a/native/src/components/DatePickerInput.tsx
+++ b/native/src/components/DatePickerInput.tsx
@@ -1,7 +1,7 @@
 import { DateTime } from 'luxon'
 import React, { forwardRef, ReactElement, RefObject } from 'react'
 import { NativeSyntheticEvent, StyleProp, TextInput, TextInputKeyPressEventData, ViewStyle } from 'react-native'
-import styled from 'styled-components/native'
+import styled, { useTheme } from 'styled-components/native'
 
 import { zeroPad } from 'shared/utils/dateFilterUtils'
 
@@ -75,23 +75,27 @@ type DatePickerInputProps = {
 }
 
 const DatePickerInput = forwardRef<TextInput, DatePickerInputProps>(
-  ({ nextTargetRef, prevTargetRef, placeholder, type, inputValue, setInputValue, style }, ref): ReactElement => (
-    <Input
-      style={style}
-      ref={ref}
-      placeholder={placeholder}
-      keyboardType='numeric'
-      maxLength={type === 'year' ? yearLength : 2}
-      onBlur={() => validate(inputValue, setInputValue, type)}
-      onChangeText={text => {
-        handleInputChangeAndFocusNext(text, setInputValue, nextTargetRef)
-      }}
-      selectTextOnFocus
-      value={inputValue}
-      onKeyPress={({ nativeEvent }: NativeSyntheticEvent<TextInputKeyPressEventData>) => {
-        handleKeyPress(nativeEvent.key, inputValue, prevTargetRef)
-      }}
-    />
-  ),
+  ({ nextTargetRef, prevTargetRef, placeholder, type, inputValue, setInputValue, style }, ref): ReactElement => {
+    const theme = useTheme()
+    return (
+      <Input
+        style={style}
+        ref={ref}
+        placeholder={placeholder}
+        placeholderTextColor={theme.isContrastTheme ? theme.colors.textColor : theme.colors.textSecondaryColor}
+        keyboardType='numeric'
+        maxLength={type === 'year' ? yearLength : 2}
+        onBlur={() => validate(inputValue, setInputValue, type)}
+        onChangeText={text => {
+          handleInputChangeAndFocusNext(text, setInputValue, nextTargetRef)
+        }}
+        selectTextOnFocus
+        value={inputValue}
+        onKeyPress={({ nativeEvent }: NativeSyntheticEvent<TextInputKeyPressEventData>) => {
+          handleKeyPress(nativeEvent.key, inputValue, prevTargetRef)
+        }}
+      />
+    )
+  },
 )
 export default DatePickerInput

--- a/native/src/components/DatesPageDetail.tsx
+++ b/native/src/components/DatesPageDetail.tsx
@@ -12,6 +12,10 @@ import Text from './base/Text'
 
 const Identifier = styled(Text)`
   font-weight: bold;
+  color: ${props => props.theme.colors.textColor};
+`
+const StyledText = styled(Text)`
+  color: ${props => props.theme.colors.textColor};
 `
 
 type DatesPageDetailProps = {
@@ -30,7 +34,7 @@ const DatesPageDetail = ({ date, languageCode }: DatesPageDetailProps): ReactEle
   }
 
   const Title = <Identifier>{t(hasMoreDates ? 'nextDate_other' : 'date_other')}: </Identifier>
-  const Dates = dates.map(it => <Text key={it}>{it}</Text>)
+  const Dates = dates.map(it => <StyledText key={it}>{it}</StyledText>)
   const AlwaysShownDates = <>{Dates.slice(0, MAX_DATE_RECURRENCES_COLLAPSED)}</>
 
   if (dates.length <= MAX_DATE_RECURRENCES_COLLAPSED) {

--- a/native/src/components/EventsDateFilter.tsx
+++ b/native/src/components/EventsDateFilter.tsx
@@ -29,6 +29,7 @@ const StyledButton = styled.TouchableOpacity`
 const StyledText = styled(Text)`
   font-weight: bold;
   padding: 5px;
+  color: ${props => props.theme.colors.textColor};
 `
 
 type ResetFilterTextProps = {

--- a/native/src/components/Feedback.tsx
+++ b/native/src/components/Feedback.tsx
@@ -22,6 +22,7 @@ const Wrapper = styled.View`
 const Description = styled(Text)`
   font-weight: bold;
   text-align: left;
+  color: ${props => props.theme.colors.textColor};
 `
 
 const StyledButton = styled(TextButton)`

--- a/native/src/components/FeedbackButtons.tsx
+++ b/native/src/components/FeedbackButtons.tsx
@@ -17,8 +17,11 @@ const Spacing = styled.View`
   padding: 10px;
 `
 
-const StyledIcon = styled(Icon)`
-  color: ${props => props.theme.colors.textSecondaryColor};
+const StyledIcon = styled(Icon)<{ active: boolean }>`
+  color: ${props =>
+    props.active && props.theme.isContrastTheme
+      ? props.theme.colors.backgroundColor
+      : props.theme.colors.textSecondaryColor};
   width: 32px;
   height: 32px;
 `
@@ -35,14 +38,14 @@ const FeedbackButtons = ({ isPositiveFeedback, setIsPositiveFeedback }: Feedback
       <ToggleButton
         text={t('useful')}
         onPress={() => setIsPositiveFeedback(isPositiveFeedback !== true ? true : null)}
-        Icon={<StyledIcon Icon={HappySmileyIcon} />}
+        Icon={<StyledIcon active={isPositiveFeedback === true} Icon={HappySmileyIcon} />}
         active={isPositiveFeedback === true}
       />
       <Spacing />
       <ToggleButton
         text={t('notUseful')}
         onPress={() => setIsPositiveFeedback(isPositiveFeedback !== false ? false : null)}
-        Icon={<StyledIcon Icon={SadSmileyIcon} />}
+        Icon={<StyledIcon active={isPositiveFeedback === false} Icon={SadSmileyIcon} />}
         active={isPositiveFeedback === false}
       />
     </Container>

--- a/native/src/components/FeedbackContainer.tsx
+++ b/native/src/components/FeedbackContainer.tsx
@@ -28,6 +28,7 @@ const Title = styled(Text)`
 const Hint = styled(Title)`
   margin-top: 8px;
   text-align: center;
+  color: ${props => props.theme.colors.textColor};
 `
 
 export type SendingStatusType = 'idle' | 'sending' | 'failed' | 'successful'

--- a/native/src/components/FilterToggle.tsx
+++ b/native/src/components/FilterToggle.tsx
@@ -9,6 +9,7 @@ import Text from './base/Text'
 const StyledText = styled(Text)`
   font-weight: bold;
   padding: 5px;
+  color: ${props => props.theme.colors.textColor};
 `
 
 const StyledButton = styled.TouchableOpacity`

--- a/native/src/components/Header.tsx
+++ b/native/src/components/Header.tsx
@@ -27,6 +27,7 @@ import buildConfig from '../constants/buildConfig'
 import dimensions from '../constants/dimensions'
 import { AppContext } from '../contexts/AppContextProvider'
 import useSnackbar from '../hooks/useSnackbar'
+import { useThemeContext } from '../hooks/useThemeContext'
 import useTtsPlayer from '../hooks/useTtsPlayer'
 import createNavigateToFeedbackModal from '../navigation/createNavigateToFeedbackModal'
 import navigateToLanguageChange from '../navigation/navigateToLanguageChange'
@@ -53,6 +54,7 @@ enum HeaderButtonTitle {
   Location = 'changeLocation',
   Search = 'search',
   ReadAloud = 'readAloud',
+  ContrastTheme = 'contrastTheme',
   Share = 'share',
   Settings = 'settings',
   Feedback = 'feedback',
@@ -86,6 +88,7 @@ const Header = ({
   const [previousRoute] = useState(navigation.getState().routes[navigation.getState().routes.length - 2])
   const [canGoBack] = useState(navigation.canGoBack())
   const { enabled: isTtsEnabled, showTtsPlayer } = useTtsPlayer()
+  const { toggleTheme } = useThemeContext()
 
   const onShare = async () => {
     if (!shareUrl) {
@@ -196,6 +199,7 @@ const Header = ({
           ? [renderOverflowItem(HeaderButtonTitle.Location, () => navigation.navigate(LANDING_ROUTE))]
           : []),
         renderOverflowItem(HeaderButtonTitle.Settings, () => navigation.navigate(SETTINGS_ROUTE)),
+        ...[renderOverflowItem(t(HeaderButtonTitle.ContrastTheme), toggleTheme)],
         ...(isTtsEnabled ? [renderOverflowItem(t(HeaderButtonTitle.ReadAloud), showTtsPlayer)] : []),
         ...(route.name !== NEWS_ROUTE ? [renderOverflowItem(HeaderButtonTitle.Feedback, navigateToFeedback)] : []),
         ...(route.name !== DISCLAIMER_ROUTE

--- a/native/src/components/Highlighter.tsx
+++ b/native/src/components/Highlighter.tsx
@@ -4,8 +4,13 @@ import styled from 'styled-components/native'
 
 import { findAllMatches, findNormalizedMatches, normalizeString } from 'shared'
 
+const StyledText = styled(Text)`
+  color: ${props => props.theme.colors.textColor};
+`
+
 const HighlightedText = styled(Text)`
   font-weight: bold;
+  color: ${props => props.theme.isContrastTheme && props.theme.colors.themeColor};
 `
 
 type HighlighterProps = {
@@ -24,12 +29,12 @@ const Highlighter = ({ search, text, style }: HighlighterProps): ReactElement =>
   })
 
   return (
-    <Text style={style}>
+    <StyledText style={style}>
       {chunks.map(chunk => {
         const matchedText = text.substring(chunk.start, chunk.end)
         return chunk.highlight ? <HighlightedText key={chunk.start}>{matchedText}</HighlightedText> : matchedText
       })}
-    </Text>
+    </StyledText>
   )
 }
 

--- a/native/src/components/MapView.tsx
+++ b/native/src/components/MapView.tsx
@@ -201,7 +201,12 @@ const MapView = ({
           <OverlayContainer>{Overlay}</OverlayContainer>
           <MapAttribution />
           <StyledIcon
-            icon={<Icon Icon={locationPermissionIcon} />}
+            icon={
+              <Icon
+                style={{ color: theme.isContrastTheme ? theme.colors.backgroundColor : undefined }}
+                Icon={locationPermissionIcon}
+              />
+            }
             onPress={onRequestLocation}
             position={bottomSheetFullscreen ? 0 : bottomSheetHeight}
             accessibilityLabel={t('showOwnLocation')}

--- a/native/src/components/Modal.tsx
+++ b/native/src/components/Modal.tsx
@@ -8,6 +8,7 @@ import HeaderBox from './HeaderBox'
 
 const Container = styled.SafeAreaView`
   flex: 1;
+  background-color: ${props => props.theme.colors.backgroundColor};
 `
 
 const Header = styled.View`

--- a/native/src/components/NewsListItem.tsx
+++ b/native/src/components/NewsListItem.tsx
@@ -28,7 +28,10 @@ const ReadMoreWrapper = styled.View<{ language: string }>`
 `
 const StyledIcon = styled(Icon)<{ isTunews: boolean }>`
   margin: 6px 4px 0;
-  color: ${props => (props.isTunews ? props.theme.colors.tunewsThemeColor : props.theme.colors.themeColor)};
+  color: ${props =>
+    props.isTunews && !props.theme.isContrastTheme
+      ? props.theme.colors.tunewsThemeColor
+      : props.theme.colors.themeColor};
   width: 14px;
   height: 14px;
 `
@@ -76,7 +79,10 @@ export const ReadMore = styled(Text)<{ isTunews: boolean }>`
   font-size: 12px;
   letter-spacing: 0.5px;
   margin-top: 5px;
-  color: ${props => (props.isTunews ? props.theme.colors.tunewsThemeColor : props.theme.colors.themeColor)};
+  color: ${props =>
+    props.isTunews && !props.theme.isContrastTheme
+      ? props.theme.colors.tunewsThemeColor
+      : props.theme.colors.themeColor};
 `
 
 const NewsListItem = ({ index, newsItem, navigateToNews, isTunews }: NewsListItemProps): ReactElement => {

--- a/native/src/components/Note.tsx
+++ b/native/src/components/Note.tsx
@@ -21,6 +21,7 @@ const NoteText = styled.Text`
 const StyledIcon = styled(Icon)`
   align-self: center;
   margin-right: 12px;
+  ${props => props.theme.isContrastTheme && `color: ${props.theme.colors.backgroundColor}`}
 `
 
 type NoteProps = {

--- a/native/src/components/OpeningEntry.tsx
+++ b/native/src/components/OpeningEntry.tsx
@@ -25,11 +25,13 @@ const TimeSlotEntry = styled.Text<{ isCurrentDay: boolean; notFirstChild?: boole
   font-family: ${props =>
     props.isCurrentDay ? props.theme.fonts.native.contentFontBold : props.theme.fonts.native.contentFontRegular};
   ${props => props.notFirstChild && 'margin-top: 8px'};
+  color: ${props => props.theme.colors.textColor};
 `
 
 const TimeSlotLabel = styled.Text<{ isCurrentDay: boolean }>`
   font-family: ${props =>
     props.isCurrentDay ? props.theme.fonts.native.contentFontBold : props.theme.fonts.native.contentFontRegular};
+  color: ${props => props.theme.colors.textColor};
 `
 
 const AppointmentOnlyContainer = styled.View<{ language: string }>`

--- a/native/src/components/OpeningHours.tsx
+++ b/native/src/components/OpeningHours.tsx
@@ -23,6 +23,12 @@ const OpeningLabel = styled.Text<{ isOpened: boolean; $direction: string }>`
   align-self: center;
 `
 
+const StyledText = styled(Text)`
+  color: ${props => props.theme.colors.textColor};
+  font-weight: bold;
+  align-self: center;
+`
+
 const Content = styled.View`
   font-size: 12px;
 `
@@ -92,7 +98,7 @@ const OpeningHours = ({
 
   const openingHoursTitle = (
     <TitleContainer language={language}>
-      <Text style={{ fontWeight: 'bold', alignSelf: 'center' }}>{t('openingHours')}</Text>
+      <StyledText>{t('openingHours')}</StyledText>
       <OpeningLabel isOpened={isCurrentlyOpen} $direction={contentDirection(language)}>
         {t(getOpeningLabel(isTemporarilyClosed, isCurrentlyOpen, openingHours))}
       </OpeningLabel>

--- a/native/src/components/PoiDetailRow.tsx
+++ b/native/src/components/PoiDetailRow.tsx
@@ -16,6 +16,7 @@ const Container = styled(Pressable)`
 const StyledText = styled(Text)`
   align-self: center;
   padding: 0 8px;
+  color: ${props => props.theme.colors.textColor};
 `
 
 type PoiDetailRowProps = {

--- a/native/src/components/PoiDetails.tsx
+++ b/native/src/components/PoiDetails.tsx
@@ -23,16 +23,19 @@ const Thumbnail = styled(SimpleImage)`
 
 const PoiDetailsContainer = styled.View`
   flex: 1;
+  background-color: ${props => props.theme.colors.backgroundColor};
 `
 
 const Title = styled.Text`
   font-size: 16px;
   font-weight: bold;
+  color: ${props => props.theme.colors.textColor};
 `
 
 const StyledDistance = styled.Text`
   font-size: 12px;
   margin-top: 8px;
+  color: ${props => props.theme.colors.textColor};
 `
 
 const StyledCategory = styled.Text`

--- a/native/src/components/PoiListItem.tsx
+++ b/native/src/components/PoiListItem.tsx
@@ -31,11 +31,13 @@ const StyledPressable = styled(Pressable)<{ language: string }>`
   border-bottom-color: ${props => props.theme.colors.textDisabledColor};
   flex-direction: ${props => contentDirection(props.language)};
   padding: 16px 0;
+  background-color: ${props => props.theme.colors.backgroundColor};
 `
 
 const Description = styled.View`
   flex: 1;
   flex-direction: column;
+  color: ${props => props.theme.colors.textColor};
   font-family: ${props => props.theme.fonts.native.decorativeFontRegular};
   padding: 0 32px;
   justify-content: center;

--- a/native/src/components/PoisBottomSheet.tsx
+++ b/native/src/components/PoisBottomSheet.tsx
@@ -6,7 +6,7 @@ import BottomSheet, {
 import React, { memo, ReactElement, Ref } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Platform } from 'react-native'
-import styled from 'styled-components/native'
+import styled, { useTheme } from 'styled-components/native'
 
 import { LocationType } from 'shared'
 import { ErrorCode, PoiModel } from 'shared/api'
@@ -65,6 +65,7 @@ const PoisBottomSheet = ({
 }: PoiBottomSheetProps): ReactElement | null => {
   const { languageCode } = useCityAppContext()
   const { t } = useTranslation('pois')
+  const theme = useTheme()
   // ios has scrolling issues if content panning gesture is not enabled
   const enableContentPanningGesture = Platform.OS === 'ios' || !isFullscreen
 
@@ -93,6 +94,7 @@ const PoisBottomSheet = ({
       enableContentPanningGesture={enableContentPanningGesture}
       enableDynamicSizing={false}
       animateOnMount
+      backgroundStyle={{ backgroundColor: theme.colors.backgroundColor }}
       handleComponent={BottomSheetHandle}
       onChange={setSnapPointIndex}>
       <BottomSheetContent>

--- a/native/src/components/PrivacyCheckbox.tsx
+++ b/native/src/components/PrivacyCheckbox.tsx
@@ -21,6 +21,10 @@ const StyledLabel = styled(Text)`
   flex: 1;
 `
 
+const StyledLink = styled(Link)`
+  color: ${props => props.theme.colors.linkColor};
+`
+
 type PrivacyCheckboxProps = {
   language: string
   checked: boolean
@@ -36,7 +40,7 @@ const PrivacyCheckbox = ({ language, checked, setChecked }: PrivacyCheckboxProps
       <StyledLabel>
         <Trans i18nKey='common:privacyPolicy'>
           This gets replaced
-          <Link url={privacyUrl}>by react-i18next</Link>
+          <StyledLink url={privacyUrl}>by react-i18next</StyledLink>
         </Trans>
       </StyledLabel>
     </StyledPressable>

--- a/native/src/components/SearchInput.tsx
+++ b/native/src/components/SearchInput.tsx
@@ -10,6 +10,7 @@ const Input = styled.TextInput`
   flex-grow: 1;
   border-bottom-width: 1px;
   border-bottom-color: ${props => props.theme.colors.textSecondaryColor};
+  color: ${props => props.theme.colors.textColor};
 `
 const Wrapper = styled.View<{ space: boolean }>`
   flex-direction: row;

--- a/native/src/components/SearchListItem.tsx
+++ b/native/src/components/SearchListItem.tsx
@@ -20,6 +20,7 @@ const FlexStyledLink = styled(Pressable)`
   display: flex;
   flex-direction: column;
   margin: 0 20px;
+  color: ${props => props.theme.colors.textColor};
 `
 
 const DirectionContainer = styled.View<{ language: string }>`

--- a/native/src/components/ThemeContext.tsx
+++ b/native/src/components/ThemeContext.tsx
@@ -1,0 +1,44 @@
+import React, { createContext, ReactElement, useMemo, useState } from 'react'
+import { ThemeProvider } from 'styled-components/native'
+
+import { ThemeType, ThemeKey } from 'build-configs/index'
+
+import buildConfig from '../constants/buildConfig'
+
+export type ThemeContextType = {
+  theme: ThemeType
+  themeType: ThemeKey
+  toggleTheme: () => void
+}
+
+const themeConfig = buildConfig()
+
+export const ThemeContext = createContext<ThemeContextType>({
+  theme: themeConfig.lightTheme,
+  themeType: 'light',
+  toggleTheme: () => undefined,
+})
+
+type ThemeContainerProps = {
+  children: ReactElement
+}
+
+export const ThemeContainer = ({ children }: ThemeContainerProps): ReactElement => {
+  const [themeType, setThemeType] = useState<ThemeKey>('light')
+
+  const contextValue = useMemo(() => {
+    const toggleTheme = () => {
+      setThemeType(prev => (prev === 'light' ? 'contrast' : 'light'))
+    }
+
+    const baseTheme = themeType === 'contrast' ? themeConfig.contrastTheme : themeConfig.lightTheme
+    const theme = { ...baseTheme, isContrastTheme: themeType === 'contrast' }
+    return { theme, themeType, toggleTheme }
+  }, [themeType])
+
+  return (
+    <ThemeContext.Provider value={contextValue}>
+      <ThemeProvider theme={contextValue.theme}>{children}</ThemeProvider>
+    </ThemeContext.Provider>
+  )
+}

--- a/native/src/components/ThemedSearchBar.tsx
+++ b/native/src/components/ThemedSearchBar.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 import { TextInput, View } from 'react-native'
-import styled from 'styled-components/native'
+import styled, { useTheme } from 'styled-components/native'
 
 import { CloseIcon, SearchIcon } from '../assets'
 import testID from '../testing/testID'
@@ -39,6 +39,7 @@ type ThemedSearchBarProps = {
 
 const ThemedSearchBar = ({ onChangeText, value, autofocus }: ThemedSearchBarProps): ReactElement => {
   const { t } = useTranslation('search')
+  const theme = useTheme()
   return (
     <StyledBackground>
       <StyledIcon Icon={SearchIcon} />
@@ -49,6 +50,7 @@ const ThemedSearchBar = ({ onChangeText, value, autofocus }: ThemedSearchBarProp
         value={value}
         autoFocus={autofocus}
         placeholder={t('searchPlaceholder')}
+        placeholderTextColor={theme.isContrastTheme ? theme.colors.textColor : theme.colors.textSecondaryColor}
       />
       {!!value && (
         <IconButton

--- a/native/src/components/base/InputSection.tsx
+++ b/native/src/components/base/InputSection.tsx
@@ -18,6 +18,10 @@ const TitleContainer = styled.View`
   justify-content: space-between;
 `
 
+const StyledText = styled(Text)`
+  color: ${props => props.theme.colors.textColor};
+`
+
 const ThemedText = styled(Text)`
   display: flex;
   text-align: center;
@@ -78,11 +82,11 @@ const InputSection = ({
       {title || showOptional || hint ? (
         <TitleContainer>
           {title ? <Title>{title}</Title> : null}
-          {hint ? <Text>{hint}</Text> : null}
-          {showOptional && <Text>({t('optional')})</Text>}
+          {hint ? <StyledText>{hint}</StyledText> : null}
+          {showOptional && <StyledText>({t('optional')})</StyledText>}
         </TitleContainer>
       ) : null}
-      {description ? <Text>{description}</Text> : null}
+      {description ? <StyledText>{description}</StyledText> : null}
       <Input
         onChangeText={onChange}
         onBlur={onBlur}

--- a/native/src/components/base/TextButton.tsx
+++ b/native/src/components/base/TextButton.tsx
@@ -15,7 +15,7 @@ const StyledPressable = styled(Pressable)<{ primary: boolean; disabled: boolean 
 `
 
 const StyledText = styled(Text)`
-  color: ${props => props.theme.colors.textColor};
+  color: ${props => (props.theme.isContrastTheme ? props.theme.colors.backgroundColor : props.theme.colors.textColor)};
   font-weight: 500;
   font-size: 18px;
   text-align: center;

--- a/native/src/components/base/ToggleButton.tsx
+++ b/native/src/components/base/ToggleButton.tsx
@@ -20,9 +20,12 @@ const StyledPressable = styled(Pressable)<{ active: boolean }>`
   justify-content: space-around;
 `
 
-const StyledText = styled(Text)`
+const StyledText = styled(Text)<{ active: boolean }>`
   font-size: 12px;
-  color: ${props => props.theme.colors.textSecondaryColor};
+  color: ${props =>
+    props.active && props.theme.isContrastTheme
+      ? props.theme.colors.backgroundColor
+      : props.theme.colors.textSecondaryColor};
   font-family: ${props => props.theme.fonts.native.decorativeFontRegular};
   text-align: center;
   width: 84px;
@@ -39,7 +42,9 @@ type TextButtonProps = {
 const ToggleButton = ({ text, onPress, Icon, active, style }: TextButtonProps): ReactElement => (
   <StyledPressable role='switch' active={active} onPress={onPress} style={style}>
     {Icon}
-    <StyledText numberOfLines={1}>{text}</StyledText>
+    <StyledText active={active} numberOfLines={1}>
+      {text}
+    </StyledText>
   </StyledPressable>
 )
 

--- a/native/src/hooks/useThemeContext.tsx
+++ b/native/src/hooks/useThemeContext.tsx
@@ -1,0 +1,5 @@
+import { useContext } from 'react'
+
+import { ThemeContext, ThemeContextType } from '../components/ThemeContext'
+
+export const useThemeContext = (): ThemeContextType => useContext(ThemeContext)

--- a/native/src/routes/SearchModal.tsx
+++ b/native/src/routes/SearchModal.tsx
@@ -22,6 +22,7 @@ const Wrapper = styled.View`
   left: 0;
   right: 0;
   background-color: ${props => props.theme.colors.backgroundColor};
+  color: ${props => props.theme.colors.textColor};
 `
 
 const SearchCounter = styled.Text`

--- a/native/src/utils/renderHtml.ts
+++ b/native/src/utils/renderHtml.ts
@@ -21,6 +21,7 @@ const renderJS = (
   supportedIframeSources: string[],
   externalSourcePermissions: ExternalSourcePermissions,
   t: TFunction,
+  theme: DefaultTheme,
   deviceWidth: number,
   pageContainerPadding: number,
 ) => `
@@ -91,6 +92,27 @@ const renderJS = (
         )
       }
     }
+  })();
+
+  (function removeBlackColorProperty() {
+    const elements = document.querySelectorAll('*');
+    elements.forEach(element => {
+      if (element instanceof HTMLElement && getComputedStyle(element).color === 'rgb(0, 0, 0)') {
+        element.style.removeProperty('color');
+      }
+    });
+  })();
+
+  (function invertSvgImagesInContrastTheme() {
+    const theme = ${JSON.stringify(theme.isContrastTheme)}
+    if (!theme) return;
+
+    const images = document.querySelectorAll('img');
+    images.forEach(img => {
+      if (img.src.endsWith('.svg')) {
+        img.style.filter = 'invert(1)';
+      }
+    });
   })();
 
   (function addWebviewHeightListeners() {
@@ -300,6 +322,7 @@ const renderHtml = (
         line-height: ${theme.fonts.contentLineHeight};
         font-size-adjust: ${theme.fonts.fontSizeAdjust};
         background-color: ${theme.colors.backgroundColor};
+        color: ${theme.colors.textColor}
       }
 
       body {
@@ -376,9 +399,8 @@ const renderHtml = (
         flex-direction: column;
         border: 1px solid ${theme.colors.borderColor};
         border-radius: 4px;
-        box-shadow:
-          0 1px 3px rgb(0 0 0 / 10%),
-          0 1px 2px rgb(0 0 0 / 15%);
+        box-shadow: 0 1px 3px rgb(0 0 0 / 10%),
+        0 1px 2px rgb(0 0 0 / 15%);
       }
 
       .iframe-info-text {
@@ -422,6 +444,10 @@ const renderHtml = (
         img {
           margin-inline-end: 8px;
         }
+
+        a {
+          color: ${theme.colors.linkColor};
+        }
       }
 
       #opt-in-settings-button {
@@ -448,6 +474,7 @@ const renderHtml = (
     supportedIframeSources,
     externalSourcePermissions,
     t,
+    theme,
     deviceWidth,
     pageContainerPadding,
   )}</script>


### PR DESCRIPTION
### Short Description

This PR adjusts styles on native to be aligned with contrast theme

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Adjusted components text and background colors as well as remote content svg color

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

Go to the app and check whether everything looks good on contrast theme

### Resolved Issues

Fixes: #3243 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
