### PR TITLE
Fix displaying of toolbar and toolbar items

### DIFF
--- a/web/src/components/CityContentToolbar.tsx
+++ b/web/src/components/CityContentToolbar.tsx
@@ -20,9 +20,8 @@ type CityContentToolbarProps = {
   pageTitle: string
   route: RouteType
   isInBottomActionSheet?: boolean
+  maxItems?: number
 }
-
-const COPY_TIMEOUT = 3000
 
 const CityContentToolbar = (props: CityContentToolbarProps) => {
   const { enabled: ttsEnabled, showTtsPlayer, canRead } = useContext(TtsContext)
@@ -37,50 +36,37 @@ const CityContentToolbar = (props: CityContentToolbarProps) => {
     route,
     pageTitle,
     isInBottomActionSheet = false,
+    maxItems,
   } = props
-  const [linkCopied, setLinkCopied] = useState<boolean>(false)
   const { t } = useTranslation('layout')
-  const copyToClipboard = () => {
-    navigator.clipboard.writeText(window.location.href).catch(reportError)
-    setLinkCopied(true)
-    setTimeout(() => {
-      setLinkCopied(false)
-    }, COPY_TIMEOUT)
-  }
+  const items = [
+    children,
+    hasFeedbackOption ? <FeedbackToolbarItem route={route} slug={feedbackTarget} positive /> : undefined,
+    hasFeedbackOption ? <FeedbackToolbarItem route={route} slug={feedbackTarget} positive={false} /> : undefined,
+    <SharingPopup
+      shareUrl={window.location.href}
+      flow={iconDirection === 'row' ? 'vertical' : 'horizontal'}
+      title={pageTitle}
+      portalNeeded={isInBottomActionSheet}
+    />,
+    ttsEnabled ? (
+      <ToolbarItem
+        icon={ReadAloudIcon}
+        isDisabled={!canRead}
+        text={t('readAloud')}
+        tooltip={canRead ? null : t('nothingToReadFullMessage')}
+        onClick={showTtsPlayer}
+        id='read-aloud-icon'
+      />
+    ) : undefined,
+    !viewportSmall ? <ContrastThemeToggle /> : undefined,
+  ]
+    .filter(it => it !== undefined)
+    .slice(0, maxItems)
 
   return (
     <Toolbar iconDirection={iconDirection} hideDivider={hideDivider}>
-      {children}
-
-      {ttsEnabled && (
-        <ToolbarItem
-          icon={ReadAloudIcon}
-          isDisabled={!canRead}
-          text={t('readAloud')}
-          tooltip={canRead ? null : t('nothingToReadFullMessage')}
-          onClick={showTtsPlayer}
-          id='read-aloud-icon'
-        />
-      )}
-
-      <SharingPopup
-        shareUrl={window.location.href}
-        flow={iconDirection === 'row' ? 'vertical' : 'horizontal'}
-        title={pageTitle}
-        portalNeeded={isInBottomActionSheet}
-      />
-
-      <ToolbarItem
-        icon={linkCopied ? DoneIcon : CopyIcon}
-        text={t('copyUrl')}
-        onClick={copyToClipboard}
-        id='copy-icon'
-        tooltip={t('common:copied')}
-        additionalTooltipProps={{ openOnClick: true, isOpen: linkCopied }}
-      />
-      {hasFeedbackOption && <FeedbackToolbarItem route={route} slug={feedbackTarget} positive />}
-      {hasFeedbackOption && <FeedbackToolbarItem route={route} slug={feedbackTarget} positive={false} />}
-      {!viewportSmall && <ContrastThemeToggle />}
+      {items}
     </Toolbar>
   )
 }

--- a/web/src/components/Pois.tsx
+++ b/web/src/components/Pois.tsx
@@ -49,6 +49,7 @@ const Pois = ({ pois: allPois, userLocation, city, languageCode, pageTitle }: Po
   const { viewportSmall, width } = useWindowDimensions()
 
   const slug = params.slug ? normalizePath(params.slug) : undefined
+  const desktopMaxToolbarItems = slug ? 4 : 3
 
   const preparedData = preparePois({
     pois: allPois,
@@ -105,6 +106,7 @@ const Pois = ({ pois: allPois, userLocation, city, languageCode, pageTitle }: Po
       hideDivider
       pageTitle={pageTitle}
       isInBottomActionSheet={viewportSmall}
+      maxItems={viewportSmall ? undefined : desktopMaxToolbarItems}
     />
   )
 

--- a/web/src/components/PoisDesktop.tsx
+++ b/web/src/components/PoisDesktop.tsx
@@ -32,6 +32,7 @@ const ListViewWrapper = styled.div<{ $panelHeights: number; $bottomBarHeight: nu
 `
 
 const ToolbarContainer = styled.div`
+  padding: 0 8px;
   display: flex;
   justify-content: center;
   background-color: ${props => props.theme.colors.backgroundAccentColor};

--- a/web/src/components/SharingPopup.tsx
+++ b/web/src/components/SharingPopup.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { PlacesType } from 'react-tooltip'
 import styled, { css, useTheme } from 'styled-components'
 
-import { CloseIcon, FacebookIcon, MailIcon, ShareIcon, WhatsappIcon } from '../assets'
+import { CloseIcon, CopyIcon, DoneIcon, FacebookIcon, MailIcon, ShareIcon, WhatsappIcon } from '../assets'
 import useWindowDimensions from '../hooks/useWindowDimensions'
 import Portal from './Portal'
 import ToolbarItem from './ToolbarItem'
@@ -64,6 +64,7 @@ const TooltipContainer = styled.div<{
   }
 
   /* White center of the arrow */
+
   &::before {
     z-index: 2000;
     border-bottom: 10px solid ${props => props.theme.colors.backgroundColor};
@@ -106,6 +107,7 @@ const TooltipContainer = styled.div<{
   }
 
   /* Border of the arrow */
+
   &::after {
     z-index: 1000;
     border-bottom: 11px solid ${props => props.theme.colors.textDecorationColor};
@@ -190,9 +192,12 @@ const SharingPopupContainer = styled.div`
   position: relative;
 `
 
+const COPY_TIMEOUT = 3000
+
 const SharingPopup = ({ shareUrl, title, flow, portalNeeded }: SharingPopupProps): ReactElement => {
-  const { t } = useTranslation('socialMedia')
   const [shareOptionsVisible, setShareOptionsVisible] = useState<boolean>(false)
+  const [linkCopied, setLinkCopied] = useState<boolean>(false)
+  const { t } = useTranslation('socialMedia')
 
   const encodedTitle = encodeURIComponent(title)
   const encodedShareUrl = encodeURIComponent(shareUrl)
@@ -202,6 +207,14 @@ const SharingPopup = ({ shareUrl, title, flow, portalNeeded }: SharingPopupProps
   const theme = useTheme()
   const tooltipDirectionMobile: PlacesType = theme.contentDirection === 'ltr' ? 'right' : 'left'
   const tooltipDirection: PlacesType = viewportSmall ? tooltipDirectionMobile : 'top'
+
+  const copyToClipboard = () => {
+    navigator.clipboard.writeText(window.location.href).catch(reportError)
+    setLinkCopied(true)
+    setTimeout(() => {
+      setLinkCopied(false)
+    }, COPY_TIMEOUT)
+  }
 
   const Backdrop = (
     <BackdropContainer onClick={() => setShareOptionsVisible(false)} label={t('closeTooltip')} tabIndex={0}>
@@ -220,6 +233,18 @@ const SharingPopup = ({ shareUrl, title, flow, portalNeeded }: SharingPopupProps
           )}
           {Backdrop}
           <TooltipContainer $flow={portalNeeded ? 'horizontal' : flow} $active={shareOptionsVisible}>
+            <Tooltip
+              id='copy'
+              place={tooltipDirection}
+              tooltipContent={t(linkCopied ? 'common:copied' : 'layout:copyUrl')}>
+              {/*@ts-expect-error wrong types from polymorphic 'as', see https://github.com/styled-components/styled-components/issues/4112 */}
+              <StyledLink
+                as={Button}
+                onClick={copyToClipboard}
+                ariaLabel={t(linkCopied ? 'common:copied' : 'layout:copyUrl')}>
+                <StyledIcon src={linkCopied ? DoneIcon : CopyIcon} />
+              </StyledLink>
+            </Tooltip>
             <Tooltip id='share-whatsapp' place={tooltipDirection} tooltipContent={t('whatsappTooltip')}>
               <StyledLink
                 to={`https://api.whatsapp.com/send?text=${shareMessage}%0a${encodedShareUrl}`}

--- a/web/src/components/StyledSmallViewTip.tsx
+++ b/web/src/components/StyledSmallViewTip.tsx
@@ -6,7 +6,6 @@ const StyledSmallViewTip = styled.p`
   font-weight: 400;
   margin-bottom: 0;
   margin-top: 8px;
-  white-space: nowrap;
   word-break: break-word;
 `
 export default StyledSmallViewTip

--- a/web/src/components/Toolbar.tsx
+++ b/web/src/components/Toolbar.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, ReactNode } from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
 import dimensions from '../constants/dimensions'
 import useWindowDimensions from '../hooks/useWindowDimensions'
@@ -11,11 +11,16 @@ const Container = styled.div`
 const ToolbarContainer = styled.div<{ $direction: 'row' | 'column'; $hasPadding: boolean }>`
   display: flex;
   box-sizing: border-box;
-  flex-flow: wrap;
   flex-direction: ${props => props.$direction};
   align-items: center;
   font-family: ${props => props.theme.fonts.web.contentFont};
 
+  ${props =>
+    props.$direction === 'column' &&
+    css`
+      max-width: 120px;
+      width: max-content;
+    `}
   & > * {
     font-size: 1.5rem;
     transition: 0.2s opacity;


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
The toolbar got very crowded and broke things in a few places.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Move copy item to share item
- Set a `max-width` and allow text wrapping for toolbar items
- Display less toolbar items for desktop pois to allow fitting in one row (hide the contrast mode)

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

The contrast mode can't be toggled anymore from pois web.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Check the toolbar items in different languages/pages/screen sizes, e.g.:
- http://localhost:9000/testumgebung/de
- http://localhost:9000/testumgebung/mk/locations

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: N/A

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
