### PR TITLE
3195: Fix displaying of toolbar and toolbar items

### DIFF
--- a/web/src/components/CityContentToolbar.tsx
+++ b/web/src/components/CityContentToolbar.tsx
@@ -1,7 +1,7 @@
-import React, { memo, ReactNode, useContext, useState } from 'react'
+import React, { memo, ReactNode, useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { CopyIcon, DoneIcon, ReadAloudIcon } from '../assets'
+import { ReadAloudIcon } from '../assets'
 import useWindowDimensions from '../hooks/useWindowDimensions'
 import { RouteType } from '../routes'
 import ContrastThemeToggle from './ContrastThemeToggle'
@@ -38,15 +38,7 @@ const CityContentToolbar = (props: CityContentToolbarProps) => {
     pageTitle,
     isInBottomActionSheet = false,
   } = props
-  const [linkCopied, setLinkCopied] = useState<boolean>(false)
   const { t } = useTranslation('layout')
-  const copyToClipboard = () => {
-    navigator.clipboard.writeText(window.location.href).catch(reportError)
-    setLinkCopied(true)
-    setTimeout(() => {
-      setLinkCopied(false)
-    }, COPY_TIMEOUT)
-  }
 
   return (
     <Toolbar iconDirection={iconDirection} hideDivider={hideDivider}>
@@ -70,14 +62,6 @@ const CityContentToolbar = (props: CityContentToolbarProps) => {
         portalNeeded={isInBottomActionSheet}
       />
 
-      <ToolbarItem
-        icon={linkCopied ? DoneIcon : CopyIcon}
-        text={t('copyUrl')}
-        onClick={copyToClipboard}
-        id='copy-icon'
-        tooltip={t('common:copied')}
-        additionalTooltipProps={{ openOnClick: true, isOpen: linkCopied }}
-      />
       {hasFeedbackOption && <FeedbackToolbarItem route={route} slug={feedbackTarget} positive />}
       {hasFeedbackOption && <FeedbackToolbarItem route={route} slug={feedbackTarget} positive={false} />}
       {!viewportSmall && <ContrastThemeToggle />}

--- a/web/src/components/CityContentToolbar.tsx
+++ b/web/src/components/CityContentToolbar.tsx
@@ -20,14 +20,14 @@ type CityContentToolbarProps = {
   pageTitle: string
   route: RouteType
   isInBottomActionSheet?: boolean
+  maxItems?: number
 }
-
-const COPY_TIMEOUT = 3000
 
 const CityContentToolbar = (props: CityContentToolbarProps) => {
   const { enabled: ttsEnabled, showTtsPlayer, canRead } = useContext(TtsContext)
-
   const { viewportSmall } = useWindowDimensions()
+  const { t } = useTranslation('layout')
+
   const {
     feedbackTarget,
     children,
@@ -37,34 +37,39 @@ const CityContentToolbar = (props: CityContentToolbarProps) => {
     route,
     pageTitle,
     isInBottomActionSheet = false,
+    maxItems,
   } = props
-  const { t } = useTranslation('layout')
+
+  const items = [
+    children,
+    ttsEnabled && (
+      <ToolbarItem
+        key='tts'
+        icon={ReadAloudIcon}
+        isDisabled={!canRead}
+        text={t('readAloud')}
+        tooltip={canRead ? null : t('nothingToReadFullMessage')}
+        onClick={showTtsPlayer}
+        id='read-aloud-icon'
+      />
+    ),
+    <SharingPopup
+      key='share'
+      shareUrl={window.location.href}
+      flow={iconDirection === 'row' ? 'vertical' : 'horizontal'}
+      title={pageTitle}
+      portalNeeded={isInBottomActionSheet}
+    />,
+    hasFeedbackOption && <FeedbackToolbarItem key='positive' route={route} slug={feedbackTarget} positive />,
+    hasFeedbackOption && <FeedbackToolbarItem key='negative' route={route} slug={feedbackTarget} positive={false} />,
+    !viewportSmall && <ContrastThemeToggle key='theme' />,
+  ]
+    .filter(Boolean)
+    .slice(0, maxItems)
 
   return (
     <Toolbar iconDirection={iconDirection} hideDivider={hideDivider}>
-      {children}
-
-      {ttsEnabled && (
-        <ToolbarItem
-          icon={ReadAloudIcon}
-          isDisabled={!canRead}
-          text={t('readAloud')}
-          tooltip={canRead ? null : t('nothingToReadFullMessage')}
-          onClick={showTtsPlayer}
-          id='read-aloud-icon'
-        />
-      )}
-
-      <SharingPopup
-        shareUrl={window.location.href}
-        flow={iconDirection === 'row' ? 'vertical' : 'horizontal'}
-        title={pageTitle}
-        portalNeeded={isInBottomActionSheet}
-      />
-
-      {hasFeedbackOption && <FeedbackToolbarItem route={route} slug={feedbackTarget} positive />}
-      {hasFeedbackOption && <FeedbackToolbarItem route={route} slug={feedbackTarget} positive={false} />}
-      {!viewportSmall && <ContrastThemeToggle />}
+      {items}
     </Toolbar>
   )
 }

--- a/web/src/components/CityContentToolbar.tsx
+++ b/web/src/components/CityContentToolbar.tsx
@@ -42,6 +42,15 @@ const CityContentToolbar = (props: CityContentToolbarProps) => {
 
   const items = [
     children,
+    hasFeedbackOption && <FeedbackToolbarItem key='positive' route={route} slug={feedbackTarget} positive />,
+    hasFeedbackOption && <FeedbackToolbarItem key='negative' route={route} slug={feedbackTarget} positive={false} />,
+    <SharingPopup
+      key='share'
+      shareUrl={window.location.href}
+      flow={iconDirection === 'row' ? 'vertical' : 'horizontal'}
+      title={pageTitle}
+      portalNeeded={isInBottomActionSheet}
+    />,
     ttsEnabled && (
       <ToolbarItem
         key='tts'
@@ -53,15 +62,6 @@ const CityContentToolbar = (props: CityContentToolbarProps) => {
         id='read-aloud-icon'
       />
     ),
-    <SharingPopup
-      key='share'
-      shareUrl={window.location.href}
-      flow={iconDirection === 'row' ? 'vertical' : 'horizontal'}
-      title={pageTitle}
-      portalNeeded={isInBottomActionSheet}
-    />,
-    hasFeedbackOption && <FeedbackToolbarItem key='positive' route={route} slug={feedbackTarget} positive />,
-    hasFeedbackOption && <FeedbackToolbarItem key='negative' route={route} slug={feedbackTarget} positive={false} />,
     !viewportSmall && <ContrastThemeToggle key='theme' />,
   ]
     .filter(Boolean)

--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -21,7 +21,7 @@ const FooterContainer = styled.footer<{ $overlay: boolean }>`
   ${props => (props.$overlay ? 'color: rgba(0, 0, 0, 0.75);' : '')}
   & > * {
     margin: ${props => (props.$overlay ? 0 : '5px')};
-    color: ${props => props.theme.isContrastTheme && props.theme.colors.textColor};
+    color: ${props => props.theme.isContrastTheme && !props.$overlay && props.theme.colors.textColor};
   }
 
   & > *::after {

--- a/web/src/components/MapAttribution.tsx
+++ b/web/src/components/MapAttribution.tsx
@@ -28,7 +28,7 @@ const StyledButton = styled(Button)<{ $expanded: boolean }>`
 
 const OpenStreetMapsLink = styled(Link)`
   text-decoration: underline;
-  color: ${props => props.theme.colors.tunewsThemeColor};
+  color: ${props => props.theme.colors.linkColor};
 `
 
 const Label = styled.span`

--- a/web/src/components/Pois.tsx
+++ b/web/src/components/Pois.tsx
@@ -55,6 +55,9 @@ const Pois = ({ pois: allPois, userLocation, city, languageCode, pageTitle }: Po
     params: { slug, multipoi, poiCategoryId, currentlyOpen: currentlyOpenFilter },
   })
   const { pois, poi, poiCategories, poiCategory } = preparedData
+  const minToolbarItems = 3
+  const toolbarItemsWithTts = 4
+  const desktopMaxToolbarItems = poi ? toolbarItemsWithTts : minToolbarItems
 
   const deselectAll = () => navigate(`.?${toQueryParams({ poiCategoryId })}`)
 
@@ -105,6 +108,7 @@ const Pois = ({ pois: allPois, userLocation, city, languageCode, pageTitle }: Po
       hideDivider
       pageTitle={pageTitle}
       isInBottomActionSheet={viewportSmall}
+      maxItems={viewportSmall ? undefined : desktopMaxToolbarItems}
     />
   )
 

--- a/web/src/components/PoisDesktop.tsx
+++ b/web/src/components/PoisDesktop.tsx
@@ -34,7 +34,7 @@ const ListViewWrapper = styled.div<{ $panelHeights: number; $bottomBarHeight: nu
 const ToolbarContainer = styled.div`
   display: flex;
   justify-content: center;
-  background-color: ${props => props.theme.colors.backgroundAccentColor};
+  background-color: ${props => props.theme.colors.backgroundColor};
   box-shadow: 1px 0 4px 0 rgb(0 0 0 / 20%);
 `
 
@@ -137,17 +137,13 @@ const PoisDesktop = ({
           <ListHeader>{t('listTitle')}</ListHeader>
         )}
 
-        <PoiSharedChildren
-          pois={pois}
-          poi={poi}
-          selectPoi={handleSelectPoi}
-          userLocation={userLocation}
-          toolbar={toolbar}
-          slug={slug}
-        />
+        <PoiSharedChildren pois={pois} poi={poi} selectPoi={handleSelectPoi} userLocation={userLocation} slug={slug} />
       </ListViewWrapper>
       {poi && pois.length > 0 ? (
-        <PoiPanelNavigation switchPoi={switchPoi} />
+        <>
+          <ToolbarContainer>{toolbar}</ToolbarContainer>
+          <PoiPanelNavigation switchPoi={switchPoi} />
+        </>
       ) : (
         <ToolbarContainer>{toolbar}</ToolbarContainer>
       )}

--- a/web/src/components/SharingPopup.tsx
+++ b/web/src/components/SharingPopup.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { PlacesType } from 'react-tooltip'
 import styled, { css, useTheme } from 'styled-components'
 
-import { CloseIcon, FacebookIcon, MailIcon, ShareIcon, WhatsappIcon } from '../assets'
+import { CloseIcon, CopyIcon, DoneIcon, FacebookIcon, MailIcon, ShareIcon, WhatsappIcon } from '../assets'
 import useWindowDimensions from '../hooks/useWindowDimensions'
 import Portal from './Portal'
 import ToolbarItem from './ToolbarItem'
@@ -64,6 +64,7 @@ const TooltipContainer = styled.div<{
   }
 
   /* White center of the arrow */
+
   &::before {
     z-index: 2000;
     border-bottom: 10px solid ${props => props.theme.colors.backgroundColor};
@@ -106,6 +107,7 @@ const TooltipContainer = styled.div<{
   }
 
   /* Border of the arrow */
+
   &::after {
     z-index: 1000;
     border-bottom: 11px solid ${props => props.theme.colors.textDecorationColor};
@@ -190,9 +192,12 @@ const SharingPopupContainer = styled.div`
   position: relative;
 `
 
+const COPY_TIMEOUT = 3000
+
 const SharingPopup = ({ shareUrl, title, flow, portalNeeded }: SharingPopupProps): ReactElement => {
-  const { t } = useTranslation('socialMedia')
   const [shareOptionsVisible, setShareOptionsVisible] = useState<boolean>(false)
+  const [linkCopied, setLinkCopied] = useState<boolean>(false)
+  const { t } = useTranslation('socialMedia')
 
   const encodedTitle = encodeURIComponent(title)
   const encodedShareUrl = encodeURIComponent(shareUrl)
@@ -202,6 +207,14 @@ const SharingPopup = ({ shareUrl, title, flow, portalNeeded }: SharingPopupProps
   const theme = useTheme()
   const tooltipDirectionMobile: PlacesType = theme.contentDirection === 'ltr' ? 'right' : 'left'
   const tooltipDirection: PlacesType = viewportSmall ? tooltipDirectionMobile : 'top'
+
+  const copyToClipboard = () => {
+    navigator.clipboard.writeText(window.location.href).catch(reportError)
+    setLinkCopied(true)
+    setTimeout(() => {
+      setLinkCopied(false)
+    }, COPY_TIMEOUT)
+  }
 
   const Backdrop = (
     <BackdropContainer onClick={() => setShareOptionsVisible(false)} label={t('closeTooltip')} tabIndex={0}>
@@ -220,6 +233,18 @@ const SharingPopup = ({ shareUrl, title, flow, portalNeeded }: SharingPopupProps
           )}
           {Backdrop}
           <TooltipContainer $flow={portalNeeded ? 'horizontal' : flow} $active={shareOptionsVisible}>
+            <Tooltip
+              id='copy'
+              place={tooltipDirection}
+              tooltipContent={t(linkCopied ? 'common:copied' : 'layout:copyUrl')}>
+              {/* @ts-expect-error wrong types from polymorphic 'as', see https://github.com/styled-components/styled-components/issues/4112 */}
+              <StyledLink
+                as={Button}
+                onClick={copyToClipboard}
+                ariaLabel={t(linkCopied ? 'common:copied' : 'layout:copyUrl')}>
+                <StyledIcon src={linkCopied ? DoneIcon : CopyIcon} />
+              </StyledLink>
+            </Tooltip>
             <Tooltip id='share-whatsapp' place={tooltipDirection} tooltipContent={t('whatsappTooltip')}>
               <StyledLink
                 to={`https://api.whatsapp.com/send?text=${shareMessage}%0a${encodedShareUrl}`}

--- a/web/src/components/SharingPopup.tsx
+++ b/web/src/components/SharingPopup.tsx
@@ -232,7 +232,7 @@ const SharingPopup = ({ shareUrl, title, flow, portalNeeded }: SharingPopupProps
             </Portal>
           )}
           {Backdrop}
-          <TooltipContainer $flow={portalNeeded ? 'horizontal' : flow} $active={shareOptionsVisible}>
+          <TooltipContainer $flow={flow} $active={shareOptionsVisible}>
             <Tooltip
               id='copy'
               place={tooltipDirection}

--- a/web/src/components/StyledSmallViewTip.tsx
+++ b/web/src/components/StyledSmallViewTip.tsx
@@ -6,7 +6,6 @@ const StyledSmallViewTip = styled.p`
   font-weight: 400;
   margin-bottom: 0;
   margin-top: 8px;
-  white-space: nowrap;
   word-break: break-word;
 `
 export default StyledSmallViewTip

--- a/web/src/components/Toolbar.tsx
+++ b/web/src/components/Toolbar.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, ReactNode } from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
 import dimensions from '../constants/dimensions'
 import useWindowDimensions from '../hooks/useWindowDimensions'
@@ -11,11 +11,16 @@ const Container = styled.div`
 const ToolbarContainer = styled.div<{ $direction: 'row' | 'column'; $hasPadding: boolean }>`
   display: flex;
   box-sizing: border-box;
-  flex-flow: wrap;
   flex-direction: ${props => props.$direction};
   align-items: center;
   font-family: ${props => props.theme.fonts.web.contentFont};
 
+  ${props =>
+    props.$direction === 'column' &&
+    css`
+      max-width: 120px;
+      width: max-content;
+    `}
   & > * {
     font-size: 1.5rem;
     transition: 0.2s opacity;

--- a/web/src/styles/Aside.css
+++ b/web/src/styles/Aside.css
@@ -2,10 +2,9 @@
   position: fixed;
   top: 35%;
   width: 100px;
-  left: 1%;
 
   @media (min-width: 1100px) {
-    left: 10%;
+    left: 8%;
   }
 
   &:empty {

--- a/web/src/styles/MapView.css
+++ b/web/src/styles/MapView.css
@@ -15,4 +15,5 @@
 .maplibregl-ctrl-top-left,
 .maplibregl-ctrl-top-right {
   z-index: 0;
+  margin-bottom: 48px;
 }


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
The toolbar got very crowded and broke things in a few places. This PR improves this by applying multiple changes.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Change the order of toolbar items (pdf > feedback > share > tts > high contrast)
- Move copy url to share toolbar item
- Set a `max-width` and allow text wrapping for toolbar items
- Display less toolbar items for desktop pois to allow fitting in one row (hide the contrast mode for pois and tts for pois list)
- Remove/reduce aside left spacing to avoid overlap
- Fix contrast of footer on pois desktop
- Fix overlap of footer and zoom buttons on pois desktop

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

The contrast mode can't be toggled anymore from pois web.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Check the toolbar items in different languages/pages/screen sizes, e.g.:
- http://localhost:9000/testumgebung/de
- http://localhost:9000/testumgebung/mk/locations

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3195

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
