### PR TITLE
Limit search results for performance

### DIFF
--- a/native/src/routes/SearchModal.tsx
+++ b/native/src/routes/SearchModal.tsx
@@ -3,7 +3,15 @@ import { useTranslation } from 'react-i18next'
 import { KeyboardAvoidingView, Platform } from 'react-native'
 import styled from 'styled-components/native'
 
-import { parseHTML, SEARCH_FINISHED_SIGNAL_NAME, SEARCH_ROUTE, SearchResult, useSearch, useDebounce } from 'shared'
+import {
+  parseHTML,
+  SEARCH_FINISHED_SIGNAL_NAME,
+  SEARCH_ROUTE,
+  SearchResult,
+  useSearch,
+  useDebounce,
+  MAX_SEARCH_RESULTS,
+} from 'shared'
 
 import FeedbackContainer from '../components/FeedbackContainer'
 import List from '../components/List'
@@ -54,9 +62,10 @@ const SearchModal = ({
   const contentLanguageReturn = useSearch(documents, debouncedQuery)
   const fallbackLanguageReturn = useSearch(fallbackLanguageDocuments, debouncedQuery)
   const searchResults = contentLanguageReturn.data.concat(fallbackLanguageReturn.data)
+  const LimitedResults = searchResults.slice(0, MAX_SEARCH_RESULTS)
 
   useReportError(contentLanguageReturn.error ?? fallbackLanguageReturn.error)
-  useAnnounceSearchResultsIOS(searchResults)
+  useAnnounceSearchResultsIOS(LimitedResults)
 
   const onClose = (): void => {
     sendTrackingSignal({
@@ -88,11 +97,11 @@ const SearchModal = ({
       <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : undefined} style={{ flex: 1 }}>
         {query.length > 0 && (
           <>
-            <SearchCounter accessibilityLiveRegion={searchResults.length === 0 ? 'assertive' : 'polite'}>
-              {t('searchResultsCount', { count: searchResults.length })}
+            <SearchCounter accessibilityLiveRegion={LimitedResults.length === 0 ? 'assertive' : 'polite'}>
+              {t('searchResultsCount', { count: LimitedResults.length })}
             </SearchCounter>
             <List
-              items={searchResults}
+              items={LimitedResults}
               renderItem={renderItem}
               accessibilityLabel={t('searchResultsCount', { count: searchResults.length })}
               style={{ flex: 1 }}
@@ -102,7 +111,7 @@ const SearchModal = ({
                   routeType={SEARCH_ROUTE}
                   language={languageCode}
                   cityCode={cityCode}
-                  noResults={searchResults.length === 0}
+                  noResults={LimitedResults.length === 0}
                   query={query}
                 />
               }

--- a/shared/constants/index.ts
+++ b/shared/constants/index.ts
@@ -1,5 +1,6 @@
 export const MAX_DATE_RECURRENCES = 10
 export const MAX_DATE_RECURRENCES_COLLAPSED = 3
+export const MAX_SEARCH_RESULTS = 80
 export const TTS_MAX_TITLE_DISPLAY_CHARS = 20
 
 export const SPRUNGBRETT_OFFER_ALIAS = 'sprungbrett'

--- a/shared/constants/index.ts
+++ b/shared/constants/index.ts
@@ -1,6 +1,6 @@
 export const MAX_DATE_RECURRENCES = 10
 export const MAX_DATE_RECURRENCES_COLLAPSED = 3
-export const MAX_SEARCH_RESULTS = 80
+export const MAX_SEARCH_RESULTS = 75
 export const TTS_MAX_TITLE_DISPLAY_CHARS = 20
 
 export const SPRUNGBRETT_OFFER_ALIAS = 'sprungbrett'

--- a/web/src/routes/SearchPage.tsx
+++ b/web/src/routes/SearchPage.tsx
@@ -3,7 +3,15 @@ import { useTranslation } from 'react-i18next'
 import { useSearchParams } from 'react-router-dom'
 import styled from 'styled-components'
 
-import { parseHTML, pathnameFromRouteInformation, SEARCH_ROUTE, useSearch, SEARCH_QUERY_KEY, useDebounce } from 'shared'
+import {
+  parseHTML,
+  pathnameFromRouteInformation,
+  SEARCH_ROUTE,
+  useSearch,
+  SEARCH_QUERY_KEY,
+  useDebounce,
+  MAX_SEARCH_RESULTS,
+} from 'shared'
 import { config } from 'translations'
 
 import { CityRouteProps } from '../CityContentSwitcher'
@@ -98,18 +106,20 @@ const SearchPage = ({ city, cityCode, languageCode }: CityRouteProps): ReactElem
     if (loading) {
       return <LoadingSpinner />
     }
+    const LimitedResults = results.slice(0, MAX_SEARCH_RESULTS)
+
     return (
       <>
         <List>
-          <SearchCounter aria-live={results.length === 0 ? 'assertive' : 'polite'}>
-            {t('searchResultsCount', { count: results.length })}
+          <SearchCounter aria-live={LimitedResults.length === 0 ? 'assertive' : 'polite'}>
+            {t('searchResultsCount', { count: LimitedResults.length })}
           </SearchCounter>
-          {results.map(({ title, content, path, thumbnail }) => (
+          {LimitedResults.map(({ title, content, path, thumbnail }) => (
             <SearchListItem
               title={title}
               contentWithoutHtml={parseHTML(content)}
               key={path}
-              query={query}
+              query={debouncedQuery}
               path={path}
               thumbnail={thumbnail}
             />
@@ -119,7 +129,7 @@ const SearchPage = ({ city, cityCode, languageCode }: CityRouteProps): ReactElem
           cityCode={cityCode}
           languageCode={languageCode}
           noResults={results.length === 0}
-          query={query}
+          query={debouncedQuery}
         />
       </>
     )


### PR DESCRIPTION
### Short Description

#3137 Still a bit laggy due rendering a large list with `.map()`.

### Proposed Changes

<!-- Describe this PR in more detail. -->
- Limits number of search result to an amount that can snapper on search and doesn't affect the searching experience.
- Adjusted SearchListItem and SearchFeedback to use debouncedQuery.

~Note: There is another option is to use React-window or React-virtualized that could render the whole list without issues but it needs a fixed sized height.~

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

None.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
- Go to http://localhost:9000/muenchen/en/search
- Test if its snapper typing on the search without lags.


<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
