### PR TITLE
3233: Rename old themes to legacy

### DIFF
--- a/build-configs/BuildConfigType.ts
+++ b/build-configs/BuildConfigType.ts
@@ -1,6 +1,6 @@
 import { TranslationsType } from 'translations'
 
-import { ThemeType } from './ThemeType'
+import { LegacyThemeType } from './LegacyThemeType'
 
 // Build Configs
 // These are the types of our build configs and therefore define the structure and available options.
@@ -60,8 +60,8 @@ export type CommonBuildConfigType = {
   // Regex defining which urls to intercept as they are internal ones.
   internalUrlPattern: string
   featureFlags: FeatureFlagsType
-  lightTheme: ThemeType
-  contrastTheme: ThemeType
+  legacyLightTheme: LegacyThemeType
+  legacyContrastTheme: LegacyThemeType
   // Translations deviating from the standard integreat translations.
   translationsOverride?: TranslationsType
   // Assets like icons, logos and imprints.

--- a/build-configs/LegacyThemeType.ts
+++ b/build-configs/LegacyThemeType.ts
@@ -1,0 +1,7 @@
+import { LegacyColorsType } from './common/theme/colors'
+import { FontsType } from './common/theme/fonts'
+
+export type LegacyThemeType = {
+  colors: LegacyColorsType
+  fonts: FontsType
+}

--- a/build-configs/ThemeType.ts
+++ b/build-configs/ThemeType.ts
@@ -1,7 +1,0 @@
-import { ColorsType } from './common/theme/colors'
-import { FontsType } from './common/theme/fonts'
-
-export type ThemeType = {
-  colors: ColorsType
-  fonts: FontsType
-}

--- a/build-configs/aschaffenburg/index.ts
+++ b/build-configs/aschaffenburg/index.ts
@@ -9,7 +9,7 @@ import {
 } from '../BuildConfigType'
 import { APP_STORE_TEAM_ID } from '../common/constants'
 import mainImprint from './mainImprint'
-import { contrastTheme, lightTheme } from './theme'
+import { legacyContrastTheme, legacyLightTheme } from './theme'
 
 const APPLICATION_ID = 'app.aschaffenburg'
 const BUNDLE_IDENTIFIER = 'app.aschaffenburg'
@@ -18,8 +18,8 @@ const commonAschaffenburgBuildConfig: CommonBuildConfigType = {
   appName: 'hallo aschaffenburg',
   appIcon: 'app_icon_aschaffenburg',
   notificationIcon: 'notification_icon_aschaffenburg',
-  lightTheme,
-  contrastTheme,
+  legacyLightTheme,
+  legacyContrastTheme,
   assets: ASCHAFFENBURG_ASSETS,
   cmsUrl: 'https://cms.integreat-app.de',
   hostName: 'halloaschaffenburg.de',

--- a/build-configs/aschaffenburg/theme/colors.ts
+++ b/build-configs/aschaffenburg/theme/colors.ts
@@ -1,19 +1,19 @@
-import { ColorsType, commonContrastColors, commonLightColors } from '../../common/theme/colors'
+import { legacyCommonContrastColors, LegacyColorsType, legacyCommonLightColors } from '../../common/theme/colors'
 
 const themeColor = '#009684'
 const themeColorLight = 'rgba(0, 150, 132, 0.5)'
 const themeContrast = '#1A1A1A'
 
-export const lightColors: ColorsType = {
+export const legacyLightColors: LegacyColorsType = {
   themeColor,
   themeColorLight,
   themeContrast,
-  ...commonLightColors,
+  ...legacyCommonLightColors,
 }
 
-export const contrastColors: ColorsType = {
+export const legacyContrastColors: LegacyColorsType = {
   themeColor,
   themeColorLight,
   themeContrast,
-  ...commonContrastColors,
+  ...legacyCommonContrastColors,
 }

--- a/build-configs/aschaffenburg/theme/index.ts
+++ b/build-configs/aschaffenburg/theme/index.ts
@@ -1,13 +1,13 @@
-import { ThemeType } from '../../ThemeType'
-import { lightColors, contrastColors } from './colors'
+import { LegacyThemeType } from '../../LegacyThemeType'
+import { legacyContrastColors, legacyLightColors } from './colors'
 import aschaffenburgFonts from './fonts'
 
-export const lightTheme: ThemeType = {
-  colors: lightColors,
+export const legacyLightTheme: LegacyThemeType = {
+  colors: legacyLightColors,
   fonts: aschaffenburgFonts,
 }
 
-export const contrastTheme: ThemeType = {
-  colors: contrastColors,
+export const legacyContrastTheme: LegacyThemeType = {
+  colors: legacyContrastColors,
   fonts: aschaffenburgFonts,
 }

--- a/build-configs/common/theme/colors.ts
+++ b/build-configs/common/theme/colors.ts
@@ -1,4 +1,4 @@
-export type ColorsType = {
+export type LegacyColorsType = {
   themeColor: string
   themeColorLight: string
   backgroundAccentColor: string
@@ -22,7 +22,8 @@ export type ColorsType = {
   ttsPlayerBackground: string
   ttsPlayerPlayIconColor: string
 }
-export const commonLightColors = {
+
+export const legacyCommonLightColors = {
   backgroundAccentColor: '#fafafa',
   textColor: '#000000',
   textSecondaryColor: '#585858',
@@ -43,8 +44,8 @@ export const commonLightColors = {
   ttsPlayerBackground: '#dedede',
   ttsPlayerPlayIconColor: '#232323',
 }
-export const commonContrastColors = {
-  ...commonLightColors,
+export const legacyCommonContrastColors = {
+  ...legacyCommonLightColors,
   backgroundAccentColor: '#20293A',
   textColor: '#FFFFFF',
   textSecondaryColor: '#FFFFFF',

--- a/build-configs/index.ts
+++ b/build-configs/index.ts
@@ -21,7 +21,7 @@ import malteBuildConfigName from './malte/build-config-name'
 import obdachBuildConfig from './obdach'
 import obdachBuildConfigName from './obdach/build-config-name'
 
-export type { ThemeType } from './ThemeType'
+export type { LegacyThemeType } from './LegacyThemeType'
 export type { ThemeKey } from './ThemeKey'
 
 export const COMMON = 'common'

--- a/build-configs/integreat/index.ts
+++ b/build-configs/integreat/index.ts
@@ -8,7 +8,7 @@ import {
 import { APP_STORE_TEAM_ID } from '../common/constants'
 import cityNotCooperatingTemplate from './assets/cityNotCooperatingTemplate'
 import mainImprint from './mainImprint'
-import { lightTheme, contrastTheme } from './theme'
+import { legacyLightTheme, legacyContrastTheme } from './theme'
 
 const APPLICATION_ID = 'tuerantuer.app.integreat'
 const BUNDLE_IDENTIFIER = 'de.integreat-app'
@@ -17,8 +17,8 @@ const commonIntegreatBuildConfig: CommonBuildConfigType = {
   appName: 'Integreat',
   appIcon: 'app_icon_integreat',
   notificationIcon: 'notification_icon_integreat',
-  lightTheme,
-  contrastTheme,
+  legacyLightTheme,
+  legacyContrastTheme,
   assets: INTEGREAT_ASSETS,
   cmsUrl: 'https://cms.integreat-app.de',
   switchCmsUrl: 'https://cms-test.integreat-app.de',
@@ -106,7 +106,7 @@ export const webIntegreatBuildConfig: WebBuildConfigType = {
     favicons: '/favicons/',
   },
   splashScreen: {
-    backgroundColor: lightTheme.colors.themeColor,
+    backgroundColor: legacyLightTheme.colors.themeColor,
     imageUrl: '/app-icon-cornered.svg',
   },
   campaign: {

--- a/build-configs/integreat/theme/colors.ts
+++ b/build-configs/integreat/theme/colors.ts
@@ -1,19 +1,19 @@
-import { ColorsType, commonLightColors, commonContrastColors } from '../../common/theme/colors'
+import { legacyCommonContrastColors, LegacyColorsType, legacyCommonLightColors } from '../../common/theme/colors'
 
 const themeColor = '#fbda16'
 const themeColorLight = 'rgba(251, 218, 22, 0.5)'
 const themeContrast = '#000000'
 
-export const lightColors: ColorsType = {
+export const legacyLightColors: LegacyColorsType = {
   themeColor,
   themeColorLight,
   themeContrast,
-  ...commonLightColors,
+  ...legacyCommonLightColors,
 }
 
-export const contrastColors: ColorsType = {
+export const legacyContrastColors: LegacyColorsType = {
   themeColor,
   themeColorLight,
   themeContrast,
-  ...commonContrastColors,
+  ...legacyCommonContrastColors,
 }

--- a/build-configs/integreat/theme/index.ts
+++ b/build-configs/integreat/theme/index.ts
@@ -1,13 +1,13 @@
-import { ThemeType } from '../../ThemeType'
-import { lightColors, contrastColors } from './colors'
+import { LegacyThemeType } from '../../LegacyThemeType'
+import { legacyContrastColors, legacyLightColors } from './colors'
 import integreatFonts from './fonts'
 
-export const lightTheme: ThemeType = {
-  colors: lightColors,
+export const legacyLightTheme: LegacyThemeType = {
+  colors: legacyLightColors,
   fonts: integreatFonts,
 }
 
-export const contrastTheme: ThemeType = {
-  colors: contrastColors,
+export const legacyContrastTheme: LegacyThemeType = {
+  colors: legacyContrastColors,
   fonts: integreatFonts,
 }

--- a/build-configs/malte/index.ts
+++ b/build-configs/malte/index.ts
@@ -9,7 +9,7 @@ import {
 } from '../BuildConfigType'
 import { APP_STORE_TEAM_ID } from '../common/constants'
 import mainImprint from './mainImprint'
-import { contrastTheme, lightTheme } from './theme'
+import { legacyContrastTheme, legacyLightTheme } from './theme'
 
 const APPLICATION_ID = 'de.malteapp'
 const BUNDLE_IDENTIFIER = 'de.malteapp'
@@ -18,8 +18,8 @@ const commonMalteBuildConfig: CommonBuildConfigType = {
   appName: 'Malte',
   appIcon: 'app_icon_malte',
   notificationIcon: 'notification_icon_malte',
-  lightTheme,
-  contrastTheme,
+  legacyLightTheme,
+  legacyContrastTheme,
   assets: MALTE_ASSETS,
   cmsUrl: 'https://cms.malteapp.de',
   switchCmsUrl: 'https://malte-test.tuerantuer.org',

--- a/build-configs/malte/theme/colors.ts
+++ b/build-configs/malte/theme/colors.ts
@@ -1,19 +1,19 @@
-import { ColorsType, commonContrastColors, commonLightColors } from '../../common/theme/colors'
+import { legacyCommonContrastColors, LegacyColorsType, legacyCommonLightColors } from '../../common/theme/colors'
 
 const themeColor = '#ff0000'
 const themeColorLight = 'rgba(255, 0, 0, 0.5)'
 const themeContrast = '#fff'
 
-export const lightColors: ColorsType = {
+export const legacyLightColors: LegacyColorsType = {
   themeColor,
   themeColorLight,
   themeContrast,
-  ...commonLightColors,
+  ...legacyCommonLightColors,
 }
 
-export const contrastColors: ColorsType = {
+export const legacyContrastColors: LegacyColorsType = {
   themeColor,
   themeColorLight,
   themeContrast,
-  ...commonContrastColors,
+  ...legacyCommonContrastColors,
 }

--- a/build-configs/malte/theme/index.ts
+++ b/build-configs/malte/theme/index.ts
@@ -1,13 +1,13 @@
-import { ThemeType } from '../../ThemeType'
-import { contrastColors, lightColors } from './colors'
+import { LegacyThemeType } from '../../LegacyThemeType'
+import { legacyContrastColors, legacyLightColors } from './colors'
 import malteFonts from './fonts'
 
-export const lightTheme: ThemeType = {
-  colors: lightColors,
+export const legacyLightTheme: LegacyThemeType = {
+  colors: legacyLightColors,
   fonts: malteFonts,
 }
 
-export const contrastTheme: ThemeType = {
-  colors: contrastColors,
+export const legacyContrastTheme: LegacyThemeType = {
+  colors: legacyContrastColors,
   fonts: malteFonts,
 }

--- a/build-configs/obdach/index.ts
+++ b/build-configs/obdach/index.ts
@@ -3,13 +3,13 @@ import obdachOverrideTranslations from 'translations/override-translations/obdac
 import { OBDACH_ASSETS } from '../AssetsType'
 import { CommonBuildConfigType, WebBuildConfigType } from '../BuildConfigType'
 import mainImprint from './mainImprint'
-import { contrastTheme, lightTheme } from './theme'
+import { legacyContrastTheme, legacyLightTheme } from './theme'
 
 const commonObdachBuildConfig: CommonBuildConfigType = {
   appName: 'Netzwerk Obdach & Wohnen',
   appIcon: 'app_icon_obdach',
-  lightTheme,
-  contrastTheme,
+  legacyLightTheme,
+  legacyContrastTheme,
   assets: OBDACH_ASSETS,
   cmsUrl: 'https://cms.netzwerkobdachwohnen.de',
   hostName: 'netzwerkobdachwohnen.de',

--- a/build-configs/obdach/theme/colors.ts
+++ b/build-configs/obdach/theme/colors.ts
@@ -1,19 +1,19 @@
-import { ColorsType, commonContrastColors, commonLightColors } from '../../common/theme/colors'
+import { legacyCommonContrastColors, LegacyColorsType, legacyCommonLightColors } from '../../common/theme/colors'
 
 const themeColor = '#E55129'
 const themeColorLight = 'rgba(229, 81, 41, 0.5)'
 const themeContrast = '#000000'
 
-export const lightColors: ColorsType = {
+export const legacyLightColors: LegacyColorsType = {
   themeColor,
   themeColorLight,
   themeContrast,
-  ...commonLightColors,
+  ...legacyCommonLightColors,
 }
 
-export const contrastColors: ColorsType = {
+export const legacyContrastColors: LegacyColorsType = {
   themeColor,
   themeColorLight,
   themeContrast,
-  ...commonContrastColors,
+  ...legacyCommonContrastColors,
 }

--- a/build-configs/obdach/theme/index.ts
+++ b/build-configs/obdach/theme/index.ts
@@ -1,13 +1,13 @@
-import { ThemeType } from '../../ThemeType'
-import { lightColors, contrastColors } from './colors'
+import { LegacyThemeType } from '../../LegacyThemeType'
+import { legacyContrastColors, legacyLightColors } from './colors'
 import obdachFonts from './fonts'
 
-export const lightTheme: ThemeType = {
-  colors: lightColors,
+export const legacyLightTheme: LegacyThemeType = {
+  colors: legacyLightColors,
   fonts: obdachFonts,
 }
 
-export const contrastTheme: ThemeType = {
-  colors: contrastColors,
+export const legacyContrastTheme: LegacyThemeType = {
+  colors: legacyContrastColors,
   fonts: obdachFonts,
 }

--- a/native/src/@types/styled.d.ts
+++ b/native/src/@types/styled.d.ts
@@ -1,8 +1,8 @@
 import 'styled-components'
 
-import { ThemeType } from 'build-configs/ThemeType'
+import { LegacyThemeType } from 'build-configs/LegacyThemeType'
 
 declare module 'styled-components/native' {
   // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-  export interface DefaultTheme extends ThemeType {}
+  export interface DefaultTheme extends LegacyThemeType {}
 }

--- a/native/src/App.tsx
+++ b/native/src/App.tsx
@@ -82,7 +82,7 @@ const App = (): ReactElement => {
 
   return (
     <>
-      <ThemeProvider theme={buildConfig().lightTheme}>
+      <ThemeProvider theme={buildConfig().legacyLightTheme}>
         <StaticServerProvider>
           <I18nProvider>
             <SafeAreaProvider>

--- a/native/src/__mocks__/styled-components.ts
+++ b/native/src/__mocks__/styled-components.ts
@@ -3,7 +3,7 @@ import buildConfig from '../constants/buildConfig'
 
 const realModule = jest.requireActual('styled-components')
 
-const useTheme = () => buildConfig().lightTheme
+const useTheme = () => buildConfig().legacyLightTheme
 
 module.exports = {
   ...realModule,

--- a/native/src/constants/__mocks__/buildConfig.ts
+++ b/native/src/constants/__mocks__/buildConfig.ts
@@ -1,6 +1,6 @@
 import { INTEGREAT_ASSETS } from 'build-configs/AssetsType'
 import { CommonBuildConfigType } from 'build-configs/BuildConfigType'
-import { lightTheme, contrastTheme } from 'build-configs/integreat/theme'
+import { legacyLightTheme, legacyContrastTheme } from 'build-configs/integreat/theme'
 
 export const buildConfigIconSet = (): {
   appLogo: string
@@ -15,8 +15,8 @@ const buildConfig = jest.fn<CommonBuildConfigType, []>(
     appName: 'Integreat',
     appIcon: 'app_icon_integreat',
     notificationIcon: 'notification_icon_integreat',
-    lightTheme,
-    contrastTheme,
+    legacyLightTheme,
+    legacyContrastTheme,
     assets: INTEGREAT_ASSETS,
     cmsUrl: 'https://cms.integreat-app.de',
     switchCmsUrl: 'https://cms-test.integreat-app.de',

--- a/native/src/constants/layers.ts
+++ b/native/src/constants/layers.ts
@@ -1,6 +1,6 @@
 import { CircleLayerProps, SymbolLayerProps } from '@maplibre/maplibre-react-native'
 
-import { ThemeType } from 'build-configs/ThemeType'
+import { LegacyThemeType } from 'build-configs/LegacyThemeType'
 import {
   circleRadiusLarge,
   circleRadiusSmall,
@@ -14,7 +14,7 @@ import {
   clusterLayerId,
 } from 'shared'
 
-export const clusterLayer = (theme: ThemeType): CircleLayerProps => ({
+export const clusterLayer = (theme: LegacyThemeType): CircleLayerProps => ({
   id: clusterLayerId,
   belowLayerID: 'pointCount',
   filter: ['has', 'point_count'],

--- a/native/src/testing/wrapWithTheme.tsx
+++ b/native/src/testing/wrapWithTheme.tsx
@@ -4,7 +4,7 @@ import { ThemeProvider } from 'styled-components/native'
 import buildConfig from '../constants/buildConfig'
 
 const wrapWithTheme = ({ children }: { children: ReactElement }): ReactElement => (
-  <ThemeProvider theme={buildConfig().lightTheme}>{children}</ThemeProvider>
+  <ThemeProvider theme={buildConfig().legacyLightTheme}>{children}</ThemeProvider>
 )
 
 export default wrapWithTheme

--- a/native/src/utils/PushNotificationsManager.ts
+++ b/native/src/utils/PushNotificationsManager.ts
@@ -130,7 +130,7 @@ export const useForegroundPushNotificationListener = ({
             body: message.notification.body,
             android: {
               smallIcon: buildConfig().notificationIcon,
-              color: buildConfig().lightTheme.colors.themeColor,
+              color: buildConfig().legacyLightTheme.colors.themeColor,
               channelId: androidChannelId,
               importance: AndroidImportance.HIGH,
             },

--- a/native/src/utils/calendarRangeUtils.ts
+++ b/native/src/utils/calendarRangeUtils.ts
@@ -1,6 +1,6 @@
 import { DateTime } from 'luxon'
 
-import { ThemeType } from 'build-configs'
+import { LegacyThemeType } from 'build-configs'
 
 type MarkedDateType = {
   selected: boolean
@@ -11,7 +11,7 @@ type MarkedDateType = {
 export const getMarkedDates = (
   startDate: DateTime | null,
   endDate: DateTime | null,
-  theme: ThemeType,
+  theme: LegacyThemeType,
   currentInput: string,
 ): Record<string, MarkedDateType> => {
   const markedDateStyling = {

--- a/native/src/utils/openExternalUrl.ts
+++ b/native/src/utils/openExternalUrl.ts
@@ -37,7 +37,7 @@ const openExternalUrl = async (rawUrl: string, showSnackbar: (snackbar: Snackbar
       // Workaround by using http:// instead, see #2724
       const url = isInternalLink ? encodedUrl.replace('https://', 'http://') : encodedUrl
       await InAppBrowser.open(url, {
-        toolbarColor: buildConfig().lightTheme.colors.themeColor,
+        toolbarColor: buildConfig().legacyLightTheme.colors.themeColor,
       })
     } else if (isInternalLink) {
       // Opening internal links via Linking opens it in integreat again leading to an endless loop, see #2440

--- a/web/src/@types/styled.d.ts
+++ b/web/src/@types/styled.d.ts
@@ -1,11 +1,11 @@
 import 'styled-components'
 
-import { ThemeType } from 'build-configs/ThemeType'
+import { LegacyThemeType } from 'build-configs/LegacyThemeType'
 import { UiDirectionType } from 'translations'
 
 declare module 'styled-components' {
   // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-  export interface DefaultTheme extends ThemeType {
+  export interface DefaultTheme extends LegacyThemeType {
     contentDirection: UiDirectionType
     isContrastTheme?: boolean
   }

--- a/web/src/components/ThemeContext.tsx
+++ b/web/src/components/ThemeContext.tsx
@@ -1,14 +1,14 @@
 import React, { createContext, ReactElement, useMemo } from 'react'
 import { ThemeProvider } from 'styled-components'
 
-import { ThemeType, ThemeKey } from 'build-configs'
+import { LegacyThemeType, ThemeKey } from 'build-configs'
 import { UiDirectionType } from 'translations'
 
 import buildConfig from '../constants/buildConfig'
 import useLocalStorage from '../hooks/useLocalStorage'
 
 export type ThemeContextType = {
-  theme: ThemeType
+  theme: LegacyThemeType
   themeType: ThemeKey
   toggleTheme: () => void
 }
@@ -16,7 +16,7 @@ export type ThemeContextType = {
 const themeConfig = buildConfig()
 
 export const ThemeContext = createContext<ThemeContextType>({
-  theme: themeConfig.lightTheme,
+  theme: themeConfig.legacyLightTheme,
   themeType: 'light',
   toggleTheme: () => undefined,
 })
@@ -47,7 +47,7 @@ export const ThemeContainer = ({ children, contentDirection }: ThemeContainerPro
       setThemeType(currentTheme)
     }
 
-    const baseTheme = themeType === 'contrast' ? themeConfig.contrastTheme : themeConfig.lightTheme
+    const baseTheme = themeType === 'contrast' ? themeConfig.legacyContrastTheme : themeConfig.legacyLightTheme
     // Set body overflow color (visible on scroll to start/end)
     document.body.style.backgroundColor = baseTheme.colors.backgroundAccentColor
     const theme = { ...baseTheme, contentDirection, isContrastTheme: themeType === 'contrast' }

--- a/web/src/components/__tests__/CityNotCooperatingFooter.spec.tsx
+++ b/web/src/components/__tests__/CityNotCooperatingFooter.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { lightTheme } from 'build-configs/integreat/theme'
+import { legacyLightTheme } from 'build-configs/integreat/theme'
 
 import { renderWithRouterAndTheme } from '../../testing/render'
 import CityNotCooperatingFooter from '../CityNotCooperatingFooter'
@@ -10,7 +10,7 @@ jest.mock('../../constants/buildConfig', () =>
     featureFlags: {
       cityNotCooperating: true,
     },
-    lightTheme,
+    legacyLightTheme,
     icons: {
       cityNotCooperating: 'test',
     },

--- a/web/src/components/__tests__/NewsTab.spec.tsx
+++ b/web/src/components/__tests__/NewsTab.spec.tsx
@@ -16,7 +16,7 @@ describe('NewsTab', () => {
   const active = true
   const destination = '/testcity/en/news/local'
   const t = ((key: string) => key) as TFunction
-  const theme = { ...buildConfig().lightTheme, contentDirection: 'ltr' as UiDirectionType }
+  const theme = { ...buildConfig().legacyLightTheme, contentDirection: 'ltr' as UiDirectionType }
 
   it('should render the local news tab', () => {
     const { getByText, queryByLabelText } = renderWithRouter(

--- a/web/src/components/__tests__/SearchFeedback.spec.tsx
+++ b/web/src/components/__tests__/SearchFeedback.spec.tsx
@@ -21,7 +21,7 @@ describe('SearchFeedback', () => {
   const cityCode = 'augsburg'
   const languageCode = 'de'
 
-  const theme = { ...buildConfig().lightTheme, contentDirection: 'ltr' as UiDirectionType }
+  const theme = { ...buildConfig().legacyLightTheme, contentDirection: 'ltr' as UiDirectionType }
 
   it('should open FeedbackSection on button click', () => {
     const { getByText, queryByText } = renderWithTheme(

--- a/web/src/constants/layers.ts
+++ b/web/src/constants/layers.ts
@@ -1,7 +1,7 @@
 import { Expression } from 'mapbox-gl'
 import { LayerProps } from 'react-map-gl/maplibre'
 
-import { ThemeType } from 'build-configs/ThemeType'
+import { LegacyThemeType } from 'build-configs/LegacyThemeType'
 import {
   circleRadiusLarge,
   circleRadiusSmall,
@@ -15,7 +15,7 @@ import {
   featureLayerId,
 } from 'shared'
 
-export const clusterLayer = (theme: ThemeType): LayerProps => ({
+export const clusterLayer = (theme: LegacyThemeType): LayerProps => ({
   id: clusterLayerId,
   type: 'circle',
   source: 'point',

--- a/web/src/index.ejs
+++ b/web/src/index.ejs
@@ -33,10 +33,10 @@
 
     <meta name="mobile-web-app-capable" content="yes">
 
-    <meta name="theme-color" content="<%= config.lightTheme.colors.themeColor %>">
-    <meta name="msapplication-navbutton-color" content="<%= config.lightTheme.colors.themeColor %>">
+    <meta name="theme-color" content="<%= config.legacyLightTheme.colors.themeColor %>">
+    <meta name="msapplication-navbutton-color" content="<%= config.legacyLightTheme.colors.themeColor %>">
     <meta name="msapplication-starturl" content="/">
-    <meta name="msapplication-TileColor" content="<%= config.lightTheme.colors.themeColor %>">
+    <meta name="msapplication-TileColor" content="<%= config.legacyLightTheme.colors.themeColor %>">
 
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
@@ -69,7 +69,7 @@
 
     <link href='/fonts/noto-sans/noto-sans.css' rel='stylesheet' />
 
-    <% if (config.lightTheme.fonts.web.decorativeFont.includes('Raleway')) { %>
+    <% if (config.legacyLightTheme.fonts.web.decorativeFont.includes('Raleway')) { %>
         <!-- Raleway -->
         <link rel="preload" href="/fonts/raleway/raleway-v12-latin_latin-ext-700.woff2" as="font" type="font/woff2"
               crossorigin />
@@ -78,7 +78,7 @@
         <link href='/fonts/raleway/raleway.css' rel='stylesheet' />
     <% } %>
 
-    <% if (config.lightTheme.fonts.web.decorativeFont.includes('Varela Round')) { %>
+    <% if (config.legacyLightTheme.fonts.web.decorativeFont.includes('Varela Round')) { %>
         <!-- Varela Round -->
         <link rel="preload" href="/fonts/varela-round/varela-round.woff2" as="font" type="font/woff2"
               crossorigin />
@@ -96,7 +96,7 @@
     <link rel="apple-touch-icon" type="image/png" sizes="180x180" href="<%= config.icons.appleTouchIcon %>">
     <link rel="shortcut icon" href="<%= config.icons.favicons %>favicon.ico">
 
-    <link rel="mask-icon" href="/safari-pinned-tab.svg" color="<%= config.lightTheme.colors.themeColor %>">
+    <link rel="mask-icon" href="/safari-pinned-tab.svg" color="<%= config.legacyLightTheme.colors.themeColor %>">
 
     <style><% if (config.splashScreen) { %>
         @keyframes show {

--- a/web/src/testing/render.tsx
+++ b/web/src/testing/render.tsx
@@ -15,7 +15,7 @@ type RenderRouteOptions = {
   childPattern?: string
 }
 
-const theme = { ...buildConfig().lightTheme, contentDirection: 'ltr' as UiDirectionType }
+const theme = { ...buildConfig().legacyLightTheme, contentDirection: 'ltr' as UiDirectionType }
 
 const AllTheProviders = ({ children, options }: { children: ReactNode; options?: { pathname: string } }) => (
   <MemoryRouter initialEntries={options ? [options.pathname] : ['/']}>

--- a/web/tools/webpack.config.ts
+++ b/web/tools/webpack.config.ts
@@ -86,7 +86,7 @@ const generateManifest = (content: Buffer, buildConfig: WebBuildConfigType) => {
 
   manifest.version = readVersionName()
   manifest.homepage_url = buildConfig.aboutUrls.default
-  manifest.theme_color = buildConfig.lightTheme.colors.themeColor
+  manifest.theme_color = buildConfig.legacyLightTheme.colors.themeColor
   manifest.name = buildConfig.appName
   manifest.description = buildConfig.appDescription
 


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
In order to avoid merge conflicts later on, we should merge this change directly to main.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Rename old themes to legacy

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Theming still works as expected.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: N/A

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
