### PR TITLE
Improve a11y for date selection in calendar

### DIFF
--- a/native/src/components/DatePicker.tsx
+++ b/native/src/components/DatePicker.tsx
@@ -1,6 +1,5 @@
 import { DateTime } from 'luxon'
 import React, { ReactElement, useEffect, useRef, useState } from 'react'
-import { useTranslation } from 'react-i18next'
 import { TextInput, View } from 'react-native'
 import styled from 'styled-components/native'
 
@@ -65,6 +64,7 @@ export type DatePickerProps = {
   modalOpen: boolean
   setModalOpen: (open: boolean) => void
   placeholderDate: DateTime
+  calendarLabel: string
 }
 
 const DatePicker = ({
@@ -75,8 +75,8 @@ const DatePicker = ({
   modalOpen,
   setModalOpen,
   placeholderDate,
+  calendarLabel,
 }: DatePickerProps): ReactElement => {
-  const { t } = useTranslation('events')
   const [inputDay, setInputDay] = useState(date?.toFormat('dd'))
   const [inputMonth, setInputMonth] = useState(date?.toFormat('MM'))
   const [inputYear, setInputYear] = useState(date?.toFormat('yyyy'))
@@ -149,10 +149,8 @@ const DatePicker = ({
         <StyledIconButton
           $isModalOpen={modalOpen}
           icon={<Icon Icon={CalendarTodayIcon} />}
-          accessibilityLabel={t('common:openCalendar')}
-          onPress={() => {
-            setModalOpen(true)
-          }}
+          accessibilityLabel={calendarLabel}
+          onPress={() => setModalOpen(true)}
         />
       </StyledInputWrapper>
       <View style={{ width: '80%' }}>

--- a/native/src/components/EventsDateFilter.tsx
+++ b/native/src/components/EventsDateFilter.tsx
@@ -102,6 +102,7 @@ const EventsDateFilter = ({
               error={startDateError ? t(startDateError) : ''}
               date={startDate}
               placeholderDate={today}
+              calendarLabel={t('selectStartDateCalendar')}
             />
             <DatePicker
               modalOpen={modalOpen}
@@ -110,6 +111,7 @@ const EventsDateFilter = ({
               title={t('to')}
               date={endDate}
               placeholderDate={inAWeek}
+              calendarLabel={t('selectEndDateCalendar')}
             />
           </>
         </DateSection>

--- a/native/src/components/__tests__/DatePicker.spec.tsx
+++ b/native/src/components/__tests__/DatePicker.spec.tsx
@@ -29,6 +29,7 @@ describe('DatePickerForNative', () => {
         date={date}
         error={error}
         placeholderDate={placeholderDate}
+        calendarLabel='calendar'
       />,
     )
 
@@ -41,6 +42,7 @@ describe('DatePickerForNative', () => {
       date: DateTime.now(),
       error: '',
       placeholderDate: DateTime.fromISO('1999-01-09'),
+      calendarLabel: 'calendar',
     })
     expect(getByPlaceholderText('01')).toBeTruthy()
     expect(getByPlaceholderText('09')).toBeTruthy()
@@ -57,6 +59,7 @@ describe('DatePickerForNative', () => {
       date: DateTime.now(),
       error: '',
       placeholderDate: DateTime.fromISO('1990-01-01'),
+      calendarLabel: 'calendar',
     })
 
     const dayMonthInput = getAllByPlaceholderText('01')
@@ -80,6 +83,7 @@ describe('DatePickerForNative', () => {
       date: null,
       error: 'Invalid date',
       placeholderDate,
+      calendarLabel: 'calendar',
     })
 
     expect(getByText('Invalid date')).toBeTruthy()
@@ -94,6 +98,7 @@ describe('DatePickerForNative', () => {
       date: null,
       error: '',
       placeholderDate: DateTime.fromISO('1990-01-01'),
+      calendarLabel: 'calendar',
     })
 
     const dayInputs = getAllByPlaceholderText('01')
@@ -115,6 +120,7 @@ describe('DatePickerForNative', () => {
       date: null,
       error: '',
       placeholderDate: DateTime.fromISO('1990-01-01'),
+      calendarLabel: 'calendar',
     })
 
     const monthInputs = getAllByPlaceholderText('01')
@@ -136,6 +142,7 @@ describe('DatePickerForNative', () => {
       date: null,
       error: '',
       placeholderDate: DateTime.fromISO('1990-01-01'),
+      calendarLabel: 'calendar',
     })
 
     const dayInputs = getAllByPlaceholderText('01')

--- a/translations/translations.json
+++ b/translations/translations.json
@@ -1384,8 +1384,7 @@
       "showLess": "कम दिखाएँ",
       "optional": "वैकल्पिक",
       "back": "वापस",
-      "ok": "ठीक",
-      "openCalendar": "कैलेंडर खोलें"
+      "ok": "ठीक"
     },
     "hr": {
       "copied": "kopirano",
@@ -1692,8 +1691,7 @@
       "showLess": "Onyesha machache",
       "optional": "si lazima",
       "back": "Nyuma",
-      "ok": "Sawa",
-      "openCalendar": "Fungua kalenda"
+      "ok": "Sawa"
     },
     "ti": {
       "copied": "ተቐዲሑ",
@@ -1763,8 +1761,7 @@
       "showLess": "Ẩn bớt",
       "optional": "không bắt buộc",
       "back": "Quay lại",
-      "ok": "Ok",
-      "openCalendar": "Mở lịch"
+      "ok": "Ok"
     },
     "zh-CN": {
       "copied": "已复制",
@@ -4038,6 +4035,8 @@
       "resetFilter": "Filter löschen:",
       "invalidDate": "Ungültiges Datum",
       "shouldBeEarlier": "Das Anfangsdatum sollte vor dem Enddatum liegen.",
+      "selectStartDateCalendar": "Startdatum im Kalender auswählen",
+      "selectEndDateCalendar": "Enddatum im Kalender auswählen",
       "hideFilters": "Filter verbergen",
       "showFilters": "Filter anzeigen",
       "selectRange": "Zeitraum auswählen",
@@ -4257,6 +4256,8 @@
       "resetFilter": "reset filter:",
       "invalidDate": "Invalid date",
       "shouldBeEarlier": "The start date should be before the end date.",
+      "selectStartDateCalendar": "Select start date in the calendar",
+      "selectEndDateCalendar": "Select end date in the calendar",
       "hideFilters": "Hide filters",
       "showFilters": "Show filters",
       "selectRange": "Select Range",

--- a/web/src/components/DatePicker.tsx
+++ b/web/src/components/DatePicker.tsx
@@ -75,6 +75,7 @@ export type CustomDatePickerProps = {
   setDate: (date: DateTime | null) => void
   error?: string
   placeholderDate: DateTime
+  calendarLabel: string
 }
 
 const isValidJsDate = (date: Date | null): boolean => {
@@ -92,7 +93,14 @@ const isValidJsDate = (date: Date | null): boolean => {
 }
 const containsOnlyDigits = (str: string) => !Number.isNaN(Number(str))
 
-const CustomDatePicker = ({ title, date, setDate, error, placeholderDate }: CustomDatePickerProps): ReactElement => {
+const CustomDatePicker = ({
+  title,
+  date,
+  setDate,
+  error,
+  placeholderDate,
+  calendarLabel,
+}: CustomDatePickerProps): ReactElement => {
   const { t } = useTranslation('events')
   const [isCalendarOpen, setIsCalendarOpen] = useState(false)
   const [datePickerError, setDatePickerError] = useState('')
@@ -149,11 +157,9 @@ const CustomDatePicker = ({ title, date, setDate, error, placeholderDate }: Cust
           onChangeRaw={e => handleDateError(String((e?.target as HTMLInputElement).value))}
         />
         <StyledIconButton
-          label={t('common:openCalendar')}
+          label={calendarLabel}
           $isCalendarOpen={isCalendarOpen}
-          onClick={() => {
-            setIsCalendarOpen(true)
-          }}>
+          onClick={() => setIsCalendarOpen(true)}>
           <Icon src={CalendarTodayIcon} />
         </StyledIconButton>
       </StyledInputWrapper>

--- a/web/src/components/EventsDateFilter.tsx
+++ b/web/src/components/EventsDateFilter.tsx
@@ -79,8 +79,15 @@ const EventsDateFilter = ({
               setDate={setStartDate}
               error={startDateError ? t(startDateError) : ''}
               placeholderDate={today}
+              calendarLabel={t('selectStartDateCalendar')}
             />
-            <CustomDatePicker title={t('to')} date={endDate} setDate={setEndDate} placeholderDate={inAWeek} />
+            <CustomDatePicker
+              title={t('to')}
+              date={endDate}
+              setDate={setEndDate}
+              placeholderDate={inAWeek}
+              calendarLabel={t('selectEndDateCalendar')}
+            />
           </>
         </DateSection>
       </Accordion>

--- a/web/src/components/__tests__/DatePicker.spec.tsx
+++ b/web/src/components/__tests__/DatePicker.spec.tsx
@@ -12,7 +12,14 @@ describe('DatePicker', () => {
 
   const renderCustomDatePicker = ({ setDate, title, date, error, placeholderDate }: CustomDatePickerProps) =>
     renderWithTheme(
-      <DatePicker setDate={setDate} title={title} date={date} error={error} placeholderDate={placeholderDate} />,
+      <DatePicker
+        setDate={setDate}
+        title={title}
+        date={date}
+        error={error}
+        placeholderDate={placeholderDate}
+        calendarLabel='calendar'
+      />,
     )
 
   it('renders correctly with given props', () => {
@@ -27,6 +34,7 @@ describe('DatePicker', () => {
       setDate,
       error: '',
       placeholderDate,
+      calendarLabel: 'calendar',
     })
 
     expect(getByText(title)).toBeInTheDocument()
@@ -44,6 +52,7 @@ describe('DatePicker', () => {
       setDate,
       error: '',
       placeholderDate,
+      calendarLabel: 'calendar',
     })
 
     const input = getByPlaceholderText(DateTime.fromJSDate(today).toFormat('dd.MM.yyyy'))
@@ -63,6 +72,7 @@ describe('DatePicker', () => {
       setDate,
       error,
       placeholderDate,
+      calendarLabel: 'calendar',
     })
 
     expect(getByText(error)).toBeInTheDocument()


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
We had a missing translation key with some remnants in the translation.json.
For better accessibility I added new (and separate) translations for opening the calendar to select a start/end date.
Good catch @bahaaTuffaha!

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Add individual labels for date selection from calendar
- Remove old translations

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Verify that there is no more warning and that the label is correct.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: N/A

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
