### PR TITLE
Fix ios promotion metadata command

### DIFF
--- a/native/ios/fastlane/Fastfile
+++ b/native/ios/fastlane/Fastfile
@@ -174,7 +174,7 @@ platform :ios do
     puts("promoting #{build_config_name} v#{testflight_version} - #{testflight_build_number} to app store connect")
     puts("skip_screenshots: #{skip_screenshots}")
 
-    prepare_metadata(version_name: testflight_version, build_config_name: build_config_name)
+    `yarn app-toolbelt v0 release-notes prepare-metadata #{build_config_name} appstore --override-version-name #{testflight_version}`
 
     # https://docs.fastlane.tools/actions/deliver/#submit-build
     deliver(
@@ -194,21 +194,6 @@ platform :ios do
       submission_information: { add_id_info_uses_idfa: false } # https://firebase.google.com/docs/analytics/configure-data-collection?platform=ios
     # https://support.google.com/firebase/answer/6318039?hl=en
     )
-  end
-
-  # The following parameters have to be passed:
-  # build_config_name: The name of the build config
-  # version_name: The version name of the release notes to prepare
-  desc "Prepare metadata"
-  lane :prepare_metadata do |options|
-    build_config_name = options[:build_config_name]
-    version_name = options[:version_name]
-
-    if [build_config_name, version_name].include?(nil)
-      raise "'nil' passed as parameter! Aborting..."
-    end
-
-    `yarn --cwd ../../../tools app-toolbelt v0 release-notes prepare-metadata #{build_config_name} appstore --override-version-name #{version_name}`
   end
 
   # The following parameters have to be passed:

--- a/native/ios/fastlane/integreat/metadata/copyright.txt
+++ b/native/ios/fastlane/integreat/metadata/copyright.txt
@@ -1,1 +1,1 @@
-© 2023 Tür an Tür - Digitalfabrik gGmbH
+© 2025 Tür an Tür - Digitalfabrik gGmbH


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
The ios promotion is currently failing due to `command app-toolbelt not found`.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Use the root app-toolbelt for the ios promotion
- Update copyright

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
N/A

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: N/A

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
