### PR TITLE
3296: Fixed search input width

### DIFF
--- a/web/src/components/SearchInput.tsx
+++ b/web/src/components/SearchInput.tsx
@@ -28,7 +28,7 @@ const TextInput = styled.input`
   }
 `
 
-const Wrapper = styled.div`
+const Wrapper = styled.div<{ $smallViewportHorizontalPadding: number }>`
   gap: 4px;
   position: relative;
   width: 100%;
@@ -39,7 +39,7 @@ const Wrapper = styled.div`
   align-items: center;
 
   @media ${dimensions.smallViewport} {
-    padding: 10px 0;
+    padding: 10px ${props => props.$smallViewportHorizontalPadding}%;
     justify-content: center;
   }
 `
@@ -52,6 +52,7 @@ const StyledIcon = styled(Icon)`
 const Column = styled.div`
   display: flex;
   flex-direction: column;
+  width: 100%;
 `
 
 const Description = styled.div`
@@ -68,6 +69,7 @@ type SearchInputProps = {
   onClickInput?: () => void
   description?: string
   searchInputRef?: React.LegacyRef<HTMLDivElement>
+  smallViewportHorizontalPadding?: number
 }
 
 const SearchInput = ({
@@ -78,9 +80,10 @@ const SearchInput = ({
   spaceSearch = false,
   description,
   searchInputRef,
+  smallViewportHorizontalPadding = 0,
 }: SearchInputProps): ReactElement => (
   <Spacer $space={spaceSearch} ref={searchInputRef}>
-    <Wrapper>
+    <Wrapper $smallViewportHorizontalPadding={smallViewportHorizontalPadding}>
       <StyledIcon src={SearchIcon} />
       <Column>
         {/* eslint-disable-next-line styled-components-a11y/no-autofocus -- in a dedicated search modal autofocus is fine */}

--- a/web/src/routes/SearchPage.tsx
+++ b/web/src/routes/SearchPage.tsx
@@ -146,6 +146,7 @@ const SearchPage = ({ city, cityCode, languageCode }: CityRouteProps): ReactElem
         placeholderText={t('searchPlaceholder')}
         onFilterTextChange={setQuery}
         spaceSearch
+        smallViewportHorizontalPadding={10}
       />
       {getPageContent()}
     </CityContentLayout>


### PR DESCRIPTION
### Short Description

Search input width is not correct due to latest changes about the helper text for search input.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Gave `Column` styling `width: 100%;`
- Added `smallViewportHorizontalPadding` to put custom padding to `searchPage` and therefore doesn't affect the one at ScrollingSearchBox/CitySelector (to give CitySelector more space for the helper text).

### Side Effects

None other `searchPage` and `CitySelector` at web.


### Testing

- Check if search input width at searchPage looks like the one we have at https://integreat.app/muenchen/de/search and for small devices.
- Test how CitySelector/location page looks (expecting it without padding).

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3296 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
