### PR TITLE
3305: Fix tts stopping after first paragraph

### DIFF
--- a/native/src/components/TtsContainer.tsx
+++ b/native/src/components/TtsContainer.tsx
@@ -115,7 +115,7 @@ const TtsContainer = ({ children }: TtsContainerProps): ReactElement => {
     async (index = sentenceIndex) => {
       const safeIndex = Math.max(0, index)
       const sentence = sentences[safeIndex]
-      if (sentence) {
+      if (sentence !== undefined) {
         await stopPlayer()
         setIsPlaying(true)
         setSentenceIndex(safeIndex)

--- a/shared/utils/__tests__/index.spec.ts
+++ b/shared/utils/__tests__/index.spec.ts
@@ -4,7 +4,7 @@ import { CategoriesMapModelBuilder } from '../../api'
 import CategoryModel from '../../api/models/CategoryModel'
 import OfferModel from '../../api/models/OfferModel'
 import TileModel from '../../models/TileModel'
-import { addSubdomain, formatDateICal, getCategoryTiles, getSlugFromPath, safeParseInt } from '../index'
+import { addSubdomain, formatDateICal, getCategoryTiles, getSlugFromPath, safeParseInt, segmentText } from '../index'
 
 describe('getSlugFromPath', () => {
   it('should return last path segment', () => {
@@ -148,6 +148,20 @@ describe('getCategoryTiles', () => {
         thumbnail: externalOfferCategory.thumbnail,
         isExternalUrl: true,
       }),
+    ])
+  })
+})
+
+describe('segmentText', () => {
+  it('should filter out empty sentences', () => {
+    expect(
+      segmentText(
+        'Dann könnte Ihnen eine geschulte Person helfen und das Gespräch übersetzen. \n \nKinder oder andere Familien-Mitglieder sind nicht immer passende Personen, wenn Sie eine Übersetzung brauchen.',
+        { languageCode: 'de' },
+      ),
+    ).toEqual([
+      'Dann könnte Ihnen eine geschulte Person helfen und das Gespräch übersetzen.',
+      'Kinder oder andere Familien-Mitglieder sind nicht immer passende Personen, wenn Sie eine Übersetzung brauchen.',
     ])
   })
 })

--- a/shared/utils/index.ts
+++ b/shared/utils/index.ts
@@ -60,5 +60,5 @@ export const segmentText = (content: string, { languageCode }: SegmentOptions): 
   segment(languageCode, content)
     .map(segment => segment.split('\n'))
     .flat()
-    .filter(sentence => sentence.length > 0)
     .map(sentence => sentence.trim())
+    .filter(sentence => sentence.length > 0)

--- a/web/src/components/TtsContainer.tsx
+++ b/web/src/components/TtsContainer.tsx
@@ -86,7 +86,7 @@ const TtsContainer = ({ languageCode, children }: TtsContainerProps): ReactEleme
       const safeIndex = Math.max(0, index)
       const sentence = sentences[safeIndex]
 
-      if (!sentence) {
+      if (sentence === undefined) {
         stop()
         return
       }


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Fix tts stopping after first paragraph due to empty sentences.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Change the conditions on sentences to read
- Filter out empty sentences

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
See issue.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3305

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
