### PR TITLE
3307: Improve visibility of radio buttons

### DIFF
--- a/web/src/components/base/RadioGroup.tsx
+++ b/web/src/components/base/RadioGroup.tsx
@@ -20,7 +20,8 @@ const Radio = styled.input`
   width: 1.3em;
   height: 1.3em;
   align-self: center;
-  accent-color: ${props => props.theme.colors.textSecondaryColor};
+  accent-color: ${props =>
+    props.theme.isContrastTheme ? props.theme.colors.themeColor : props.theme.colors.textSecondaryColor};
   flex-shrink: 0;
 `
 


### PR DESCRIPTION


### Short Description

Currently in the malte help form the active radio box selection is not really good highlighted (white dot) inside white box.
Can be tested here: http://localhost:9000/testumgebung/de/gewaltschutz-kontakformular

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Just used `isContrastTheme` to switch between theme color (for contrast mode) and default color.

### Side Effects

None.

### Testing

- Go to any recurring event and click on export as iCal or go to http://localhost:9000/testumgebung/de/gewaltschutz-kontakformular at malte.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3307 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
