### PR TITLE
3319: Close chat security information tooltip on click outside

### DIFF
--- a/web/src/components/ChatSecurityInformation.tsx
+++ b/web/src/components/ChatSecurityInformation.tsx
@@ -1,9 +1,10 @@
 import styled from '@emotion/styled'
-import React, { ReactElement, useState } from 'react'
+import React, { ReactElement, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { DataSecurityIcon } from '../assets'
 import dimensions from '../constants/dimensions'
+import useOnClickOutside from '../hooks/useOnClickOutside'
 import Icon from './base/Icon'
 
 const SecurityInformationContainer = styled.div`
@@ -44,11 +45,13 @@ const InformationTooltipContainer = styled.div`
 `
 
 const ChatSecurityInformation = (): ReactElement => {
+  const [securityInformationVisible, setSecurityInformationVisible] = useState(false)
+  const securityInformationRef = useRef(null)
+  useOnClickOutside(securityInformationRef, () => setSecurityInformationVisible(false))
   const { t } = useTranslation('chat')
-  const [securityInformationVisible, setSecurityInformationVisible] = useState<boolean>(false)
 
   return (
-    <SecurityInformationContainer>
+    <SecurityInformationContainer ref={securityInformationRef}>
       {securityInformationVisible && <InformationTooltipContainer>{t('dataSecurity')}</InformationTooltipContainer>}
       <SecurityIconContainer onClick={() => setSecurityInformationVisible(!securityInformationVisible)}>
         <SecurityIcon src={DataSecurityIcon} />


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Close chat security information tooltip on click outside.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Use the `onClickOutside` hook to close the tooltip

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Go to the chat, click on the lock icon and then click somewhere outside the dialog (inside the chat).

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3319

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
