### PR TITLE
3277: Remove styled-components

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -32,7 +32,7 @@
     "@emotion/is-prop-valid": "^1.3.1",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
-    "@integreat-app/react-sticky-headroom": "^2.2.1",
+    "@integreat-app/react-sticky-headroom": "^3.0.0",
     "@math.gl/web-mercator": "^3.6.3",
     "@sentry/react": "^8.33.1",
     "@sentry/types": "^8.33.1",
@@ -59,7 +59,6 @@
     "react-tooltip": "^5.28.0",
     "schema-dts": "^1.1.2",
     "shared": "0.0.1",
-    "styled-components": "^6.1.13",
     "translations": "0.0.1",
     "react-datepicker": "^7.5.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2396,10 +2396,10 @@
   resolved "https://registry.yarnpkg.com/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz#56f00962ff0c4e0eb93d34a047d29fa995e3e342"
   integrity sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==
 
-"@integreat-app/react-sticky-headroom@^2.2.1":
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/@integreat-app/react-sticky-headroom/-/react-sticky-headroom-2.2.1.tgz#2fda1e022d6df705bac371e88c443ad9e08ce674"
-  integrity sha512-2I3mJGHJulNL43Cr1k1NOKLZQ051TBplypXchDUjme1sikmOjNZAACdQt1MTNzr2rbgKbFkRvGxX6km7FegciA==
+"@integreat-app/react-sticky-headroom@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@integreat-app/react-sticky-headroom/-/react-sticky-headroom-3.0.0.tgz#6989dd9365c1340c1803547be4d37b0e35a33bb2"
+  integrity sha512-fWTehT3sQYj7qBmxLdM2jJviKeXpZLzyDBb2+9xXuamDcbP9Nyu5zakUYu0tkkiaFLEQVgSQBF16rGALBQknOw==
 
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Upgrade react-sticky-headroom to be able to remove the styled-components dependency.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Upgrade react-sticky-headroom
- Remove styled-components dependency

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Test that the sticky header in the region selection still looks the same.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Follow up to #3277

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
