### PR TITLE
3246: Fix content direction

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -22,6 +22,11 @@ import { initSentry } from './utils/sentry'
 LuxonSettings.throwOnInvalid = true
 LuxonSettings.defaultLocale = config.defaultFallback
 
+const ltrCache = createCache({
+  key: 'muiltr',
+  stylisPlugins: [prefixer],
+})
+
 const rtlCache = createCache({
   key: 'muirtl',
   stylisPlugins: [prefixer, rtlPlugin],
@@ -41,7 +46,7 @@ const App = (): ReactElement => {
   }, [])
 
   return (
-    <CacheProvider value={rtlCache}>
+    <CacheProvider value={contentDirection === 'rtl' ? rtlCache : ltrCache}>
       <ThemeContainer contentDirection={contentDirection}>
         <I18nProvider contentLanguage={contentLanguage}>
           <>


### PR DESCRIPTION
Just a small fix for the content direction in the MUI-text-button branch, now the it's only `rtl` when the language is actually a `rtl` one