### PR TITLE
3345: Fix color of date filter toggle in browser in iOS

### DIFF
--- a/web/src/components/FilterToggle.tsx
+++ b/web/src/components/FilterToggle.tsx
@@ -17,7 +17,7 @@ const StyledButton = styled(Button)`
 `
 
 const Text = styled.span`
-  color: ${props => props.theme.isContrastTheme && props.theme.colors.textColor};
+  color: ${props => props.theme.colors.textColor};
 `
 
 const FilterToggle = ({


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
The button to toggle the date filter in mobile Safari was blue, with this it's black again.

### Proposed Changes

<!-- Describe this PR in more detail. -->
- Using the `theme.colors.textColor` even when we're not in high contrast mode

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Use an iPhone and check in its browser that the color is correct

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3345 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`

-->

<img src="https://github.com/user-attachments/assets/1626c652-43e6-4419-8686-73b3777018bb" width="300px" />
