### PR TITLE
3362: Fix domain and text color for organization info

### DIFF
--- a/native/src/components/OrganizationContentInfo.tsx
+++ b/native/src/components/OrganizationContentInfo.tsx
@@ -8,6 +8,7 @@ import { OrganizationModel } from 'shared/api'
 import HighlightBox from './HighlightBox'
 import Link from './Link'
 import SimpleImage from './SimpleImage'
+import Text from './base/Text'
 
 const Thumbnail = styled(SimpleImage)`
   height: 80px;
@@ -20,12 +21,12 @@ const Box = styled(HighlightBox)`
   border-radius: 4px;
 `
 
-const OrganizationContent = styled.Text`
+const OrganizationContent = styled(Text)`
   font-family: ${props => props.theme.fonts.native.decorativeFontBold};
   padding: 16px 0 8px;
 `
 
-const StyledText = styled.Text`
+const StyledText = styled(Text)`
   flex-flow: row wrap;
 `
 

--- a/native/src/components/OrganizationContentInfo.tsx
+++ b/native/src/components/OrganizationContentInfo.tsx
@@ -47,7 +47,8 @@ const OrganizationContentInfo = ({ organization }: OrganizationContentInfoProps)
         <StyledText>
           <Trans i18nKey='categories:organizationMoreInformation' domain={new URL(organization.url).hostname}>
             This gets{{ organization: organization.name }}replaced
-            <StyledLink url={organization.url}>{new URL(organization.url).hostname}</StyledLink>
+            {/* @ts-expect-error gets replaced by Trans component */}
+            <StyledLink url={organization.url}>{{ domain: new URL(organization.url).hostname }}</StyledLink>
             by i18n
           </Trans>
         </StyledText>

--- a/web/src/components/OrganizationContentInfo.tsx
+++ b/web/src/components/OrganizationContentInfo.tsx
@@ -6,6 +6,7 @@ import { OrganizationModel } from 'shared/api'
 
 import useWindowDimensions from '../hooks/useWindowDimensions'
 import HighlightBox from './HighlightBox'
+import Link from './base/Link'
 
 const StyledImage = styled.img<{ viewportSmall: boolean }>`
   width: 100%;
@@ -55,10 +56,10 @@ const OrganizationContentInfo = ({ organization }: OrganizationContentInfoProps)
         <span>
           <Trans i18nKey='categories:organizationMoreInformation' domain={new URL(organization.url).hostname}>
             This gets{{ organization: organization.name }}replaced
-            <a href={organization.url} target='_blank' rel='noopener noreferrer'>
+            <Link to={organization.url} highlighted>
               {/* @ts-expect-error gets replaced by Trans component */}
               {{ domain: new URL(organization.url).hostname }}
-            </a>
+            </Link>
             by i18n
           </Trans>
         </span>


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Fix domain and text and link color for organization info.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Correctly display the domain of the organization url (native)
- Fix the text color for high contrast mode (native)
- Fix the link highlighting (web)

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Go to https://webnext.integreat.app/testumgebung/de/elektronische-patientenakte-epa on both web and native.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3362

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
