### PR TITLE
3237: Add breakpoints to Mui theme

### DIFF
--- a/web/src/components/AppointmentOnlyIcon.tsx
+++ b/web/src/components/AppointmentOnlyIcon.tsx
@@ -4,7 +4,6 @@ import React, { ReactElement } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 
-import dimensions from '../constants/dimensions'
 import Icon from './base/Icon'
 import Tooltip from './base/Tooltip'
 
@@ -33,7 +32,7 @@ const StyledIcon = styled(Icon)`
 `
 
 const TooltipContent = styled.span`
-  @media ${dimensions.smallViewport} {
+  ${props => props.theme.breakpoints.down('md')} {
     font-size: 14px;
   }
 `
@@ -42,7 +41,7 @@ const TooltipTitle = styled.div`
   font-weight: 700;
   margin-bottom: 8px;
 
-  @media ${dimensions.smallViewport} {
+  ${props => props.theme.breakpoints.down('md')} {
     font-size: 14px;
   }
 `

--- a/web/src/components/Caption.tsx
+++ b/web/src/components/Caption.tsx
@@ -1,14 +1,12 @@
 import styled from '@emotion/styled'
 import React, { ReactElement } from 'react'
 
-import dimensions from '../constants/dimensions'
-
 const H1 = styled.h1`
   margin: 25px 0;
   font-size: 2rem;
   text-align: center;
 
-  @media ${dimensions.smallViewport} {
+  ${props => props.theme.breakpoints.down('md')} {
     margin: 10px 0;
   }
 `

--- a/web/src/components/Chat.tsx
+++ b/web/src/components/Chat.tsx
@@ -6,7 +6,6 @@ import { useTranslation } from 'react-i18next'
 
 import ChatMessageModel from 'shared/api/models/ChatMessageModel'
 
-import dimensions from '../constants/dimensions'
 import ChatConversation from './ChatConversation'
 import ChatSecurityInformation from './ChatSecurityInformation'
 import LoadingSpinner from './LoadingSpinner'
@@ -21,7 +20,7 @@ const Container = styled.div`
   flex-direction: column;
   justify-content: space-between;
 
-  @media ${dimensions.mediumLargeViewport} {
+  ${props => props.theme.breakpoints.up('md')} {
     height: 600px;
     min-width: 300px;
   }

--- a/web/src/components/ChatContainer.tsx
+++ b/web/src/components/ChatContainer.tsx
@@ -27,7 +27,7 @@ const ChatButtonContainer = styled.div<{ bottom: number }>`
   flex-direction: column;
   align-items: center;
 
-  @media ${dimensions.smallViewport} {
+  ${props => props.theme.breakpoints.down('md')} {
     inset-inline-end: 12px;
   }
 `
@@ -40,7 +40,7 @@ const StyledIcon = styled(Icon)`
   justify-content: center;
   color: ${props => props.theme.colors.backgroundColor};
 
-  @media ${dimensions.smallViewport} {
+  ${props => props.theme.breakpoints.down('md')} {
     width: 40px;
     height: 40px;
   }

--- a/web/src/components/ChatContentWrapper.tsx
+++ b/web/src/components/ChatContentWrapper.tsx
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled'
 import React, { ReactElement, ReactNode } from 'react'
 
-import dimensions from '../constants/dimensions'
 import { helpers } from '../constants/theme'
 import useWindowDimensions from '../hooks/useWindowDimensions'
 import ChatMenu from './ChatMenu'
@@ -14,7 +13,7 @@ const Container = styled.div`
   flex: 1;
   width: 400px;
 
-  @media ${dimensions.smallViewport} {
+  ${props => props.theme.breakpoints.down('md')} {
     width: 100%;
   }
 `
@@ -30,12 +29,12 @@ const Header = styled.div<{ small: boolean }>`
   background-color: ${props => props.theme.colors.themeColor};
   padding: 4px 8px;
 
-  @media ${dimensions.mediumLargeViewport} {
+  ${props => props.theme.breakpoints.up('md')} {
     border-start-start-radius: 5px;
     border-start-end-radius: 5px;
   }
 
-  @media ${dimensions.smallViewport} {
+  ${props => props.theme.breakpoints.down('md')} {
     padding: 8px 16px;
     gap: 12px;
   }

--- a/web/src/components/ChatMenu.tsx
+++ b/web/src/components/ChatMenu.tsx
@@ -4,7 +4,6 @@ import CloseFullscreenIcon from '@mui/icons-material/CloseFullscreen'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import dimensions from '../constants/dimensions'
 import { helpers } from '../constants/theme'
 import useWindowDimensions from '../hooks/useWindowDimensions'
 import Button from './base/Button'
@@ -21,7 +20,7 @@ const StyledIcon = styled(Icon)`
   display: flex;
   color: ${props => props.theme.colors.backgroundColor};
 
-  @media ${dimensions.smallViewport} {
+  ${props => props.theme.breakpoints.down('md')} {
     ${helpers.adaptiveThemeTextColor}
   }
 `

--- a/web/src/components/ChatModal.tsx
+++ b/web/src/components/ChatModal.tsx
@@ -3,7 +3,6 @@ import FocusTrap from 'focus-trap-react'
 import React, { ReactElement, ReactNode, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import dimensions from '../constants/dimensions'
 import ChatModalContent from './ChatContentWrapper'
 import { LAYOUT_ELEMENT_ID } from './Layout'
 import Button from './base/Button'
@@ -27,7 +26,7 @@ const ModalContainer = styled.div`
 `
 
 const ModalContentContainer = styled.div`
-  @media ${dimensions.mediumLargeViewport} {
+  ${props => props.theme.breakpoints.up('md')} {
     margin-inline-end: 20px;
   }
 
@@ -37,7 +36,7 @@ const ModalContentContainer = styled.div`
   background-color: ${props => props.theme.colors.backgroundColor};
   border-radius: 5px;
 
-  @media ${dimensions.smallViewport} {
+  ${props => props.theme.breakpoints.down('md')} {
     height: 100%;
     align-items: center;
     width: 100%;

--- a/web/src/components/ChatSecurityInformation.tsx
+++ b/web/src/components/ChatSecurityInformation.tsx
@@ -3,7 +3,6 @@ import LockOutlinedIcon from '@mui/icons-material/LockOutlined'
 import React, { ReactElement, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import dimensions from '../constants/dimensions'
 import useOnClickOutside from '../hooks/useOnClickOutside'
 import Icon from './base/Icon'
 
@@ -42,7 +41,7 @@ const InformationTooltipContainer = styled.div`
   white-space: pre-line;
   width: 250px;
 
-  @media ${dimensions.smallViewport} {
+  ${props => props.theme.breakpoints.down('md')} {
     width: 70vw;
   }
 `

--- a/web/src/components/DropDownContainer.tsx
+++ b/web/src/components/DropDownContainer.tsx
@@ -28,7 +28,8 @@ const DropDownContainer = styled.div<{ active: boolean }>`
   }
 
   ${props => props.theme.breakpoints.up('lg')} {
-    padding-inline: calc((100vw - ${dimensions.maxWidth}px) / 2) calc((200% - 100vw - ${dimensions.maxWidth}px) / 2);
+    padding-inline: calc((100vw - ${props => props.theme.breakpoints.values.lg}px) / 2)
+      calc((200% - 100vw - ${props => props.theme.breakpoints.values.lg}px) / 2);
   }
 `
 

--- a/web/src/components/DropDownContainer.tsx
+++ b/web/src/components/DropDownContainer.tsx
@@ -21,13 +21,13 @@ const DropDownContainer = styled.div<{ active: boolean }>`
   background-color: ${props => props.theme.colors.backgroundColor};
   visibility: ${props => (props.active ? 'visible' : 'hidden')};
 
-  @media ${dimensions.smallViewport} {
+  ${props => props.theme.breakpoints.down('md')} {
     top: ${dimensions.headerHeightSmall}px;
     height: calc(100% - ${dimensions.headerHeightSmall}px);
     overflow: hidden auto;
   }
 
-  @media ${dimensions.minMaxWidth} {
+  ${props => props.theme.breakpoints.up('lg')} {
     padding-inline: calc((100vw - ${dimensions.maxWidth}px) / 2) calc((200% - 100vw - ${dimensions.maxWidth}px) / 2);
   }
 `

--- a/web/src/components/EventsDateFilter.tsx
+++ b/web/src/components/EventsDateFilter.tsx
@@ -4,7 +4,6 @@ import { DateTime } from 'luxon'
 import React, { ReactElement, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import dimensions from '../constants/dimensions'
 import Accordion from './Accordion'
 import CustomDatePicker from './DatePicker'
 import FilterToggle from './FilterToggle'
@@ -17,7 +16,7 @@ const DateSection = styled.div`
   margin: 15px 5px;
   justify-content: space-evenly;
 
-  @media ${dimensions.smallViewport} {
+  ${props => props.theme.breakpoints.down('md')} {
     flex-direction: column;
     align-items: center;
   }

--- a/web/src/components/Feedback.tsx
+++ b/web/src/components/Feedback.tsx
@@ -5,7 +5,6 @@ import React, { ReactElement, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import buildConfig from '../constants/buildConfig'
-import dimensions from '../constants/dimensions'
 import FeedbackButtons from './FeedbackButtons'
 import { SendingStatusType } from './FeedbackContainer'
 import Note from './Note'
@@ -28,7 +27,7 @@ export const Container = styled.div<{ fullWidth?: boolean }>`
   align-self: center;
   gap: 16px;
 
-  @media ${dimensions.mediumLargeViewport} {
+  ${props => props.theme.breakpoints.up('md')} {
     width: ${props => (props.fullWidth ? 'auto' : '400px')};
   }
 `

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -34,7 +34,8 @@ const HeaderContainer = styled.header`
   box-shadow: 0 2px 5px -3px rgb(0 0 0 / 20%);
 
   ${props => props.theme.breakpoints.up('lg')} {
-    padding-inline: calc((100vw - ${dimensions.maxWidth}px) / 2) calc((200% - 100vw - ${dimensions.maxWidth}px) / 2);
+    padding-inline: calc((100vw - ${props => props.theme.breakpoints.values.lg}px) / 2)
+      calc((200% - 100vw - ${props => props.theme.breakpoints.values.lg}px) / 2);
   }
 `
 

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -33,7 +33,7 @@ const HeaderContainer = styled.header`
   overflow: visible;
   box-shadow: 0 2px 5px -3px rgb(0 0 0 / 20%);
 
-  @media ${dimensions.minMaxWidth} {
+  ${props => props.theme.breakpoints.up('lg')} {
     padding-inline: calc((100vw - ${dimensions.maxWidth}px) / 2) calc((200% - 100vw - ${dimensions.maxWidth}px) / 2);
   }
 `
@@ -47,7 +47,7 @@ const Row = styled.div`
   flex-direction: row;
   justify-content: space-between;
 
-  @media ${dimensions.smallViewport} {
+  ${props => props.theme.breakpoints.down('md')} {
     background-color: ${props => props.theme.colors.backgroundAccentColor};
     justify-content: space-between;
     flex-wrap: wrap;
@@ -65,7 +65,7 @@ const HeaderSeparator = styled.div`
   background-color: ${props => props.theme.colors.textDecorationColor};
   order: 2;
 
-  @media ${dimensions.smallViewport} {
+  ${props => props.theme.breakpoints.down('md')} {
     display: none;
   }
 `
@@ -78,7 +78,7 @@ const ActionBar = styled.nav`
   gap: 12px;
   padding: 0 16px;
 
-  @media ${dimensions.smallViewport} {
+  ${props => props.theme.breakpoints.down('md')} {
     order: 2;
   }
 `
@@ -90,7 +90,7 @@ const NavigationBar = styled.nav`
   justify-content: center;
   gap: 24px;
 
-  @media ${dimensions.mediumLargeViewport} {
+  ${props => props.theme.breakpoints.up('md')} {
     padding: 0 10px;
   }
 `

--- a/web/src/components/HeaderActionItemLink.tsx
+++ b/web/src/components/HeaderActionItemLink.tsx
@@ -4,7 +4,6 @@ import { SvgIconProps } from '@mui/material'
 import React, { ElementType, ReactElement } from 'react'
 import { PlacesType } from 'react-tooltip'
 
-import dimensions from '../constants/dimensions'
 import useWindowDimensions from '../hooks/useWindowDimensions'
 import { spacesToDashes } from '../utils/stringUtils'
 import Icon from './base/Icon'
@@ -28,7 +27,7 @@ const HeaderActionItemLink = ({ to, text, iconSrc }: HeaderActionItemLinkProps):
   const theme = useTheme()
   const { width } = useWindowDimensions()
   const bufferForTooltipOverflow = 130
-  const isMediumViewport = width < dimensions.maxWidth + bufferForTooltipOverflow
+  const isMediumViewport = width < theme.breakpoints.values.lg + bufferForTooltipOverflow
   const tooltipDirectionMediumDesktop: PlacesType = theme.contentDirection === 'ltr' ? 'left' : 'right'
   const tooltipDirection: PlacesType = isMediumViewport ? tooltipDirectionMediumDesktop : 'bottom'
 

--- a/web/src/components/HeaderLogo.tsx
+++ b/web/src/components/HeaderLogo.tsx
@@ -27,7 +27,7 @@ const LogoContainer = styled.div`
     height: 60%;
   }
 
-  @media ${dimensions.smallViewport} {
+  ${props => props.theme.breakpoints.down('md')} {
     height: ${dimensions.headerHeightSmall}px;
     max-width: ${dimensions.headerHeightSmall}px;
     flex: 1 1 0%; /* The % unit is necessary for IE11 */
@@ -43,7 +43,7 @@ const StyledLogoIcon = styled(Icon)`
   width: 200px;
   max-width: 200px;
 
-  @media ${dimensions.smallViewport} {
+  ${props => props.theme.breakpoints.down('md')} {
     max-width: 44px;
   }
 `

--- a/web/src/components/HeaderNavigationItem.tsx
+++ b/web/src/components/HeaderNavigationItem.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled'
 import { SvgIconProps } from '@mui/material'
 import React, { ElementType, ReactElement } from 'react'
 
-import dimensions from '../constants/dimensions'
 import { helpers } from '../constants/theme'
 import Icon from './base/Icon'
 import Link from './base/Link'
@@ -26,7 +25,7 @@ const StyledLink = styled(Link)<{ active: boolean }>`
   transition: color 0.2s;
   height: 100%;
 
-  @media ${dimensions.smallViewport} {
+  ${props => props.theme.breakpoints.down('md')} {
     font-size: ${props => props.theme.fonts.decorativeFontSizeSmall};
     font-weight: 400;
     min-width: 50px;
@@ -73,7 +72,7 @@ const Circle = styled.div`
   justify-content: center;
   align-items: center;
 
-  @media ${dimensions.mediumLargeViewport} {
+  ${props => props.theme.breakpoints.up('md')} {
     background-color: ${props => props.theme.colors.backgroundColor};
     box-sizing: border-box;
     border-radius: 100%;
@@ -86,7 +85,7 @@ const Circle = styled.div`
     border: ${props => props.theme.colors.backgroundColor} 2px solid;
   }
 
-  @media ${dimensions.smallViewport} {
+  ${props => props.theme.breakpoints.down('md')} {
     height: ${ICON_SIZE_SMALL}px;
     width: ${ICON_SIZE_SMALL}px;
   }

--- a/web/src/components/HeaderTitle.tsx
+++ b/web/src/components/HeaderTitle.tsx
@@ -17,11 +17,11 @@ const HeaderTitleContainer = styled.div<{ long: boolean }>`
   padding: 0 10px;
   box-sizing: border-box;
 
-  @media ${dimensions.minMaxWidth} {
+  ${props => props.theme.breakpoints.up('lg')} {
     font-size: ${props => (props.long ? '1.5rem' : '1.8rem')};
   }
 
-  @media ${dimensions.smallViewport} {
+  ${props => props.theme.breakpoints.down('md')} {
     font-family: ${props => props.theme.fonts.web.decorativeFont};
     font-size: ${props => props.theme.fonts.decorativeFontSize};
     height: ${HEADER_TITLE_HEIGHT}px;

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -66,14 +66,16 @@ const Body = styled.div<{ fullWidth: boolean; disableScrollingSafari: boolean }>
     !props.fullWidth &&
     css`
       ${props.theme.breakpoints.up('lg')} {
-        padding-inline: calc((100vw - ${dimensions.maxWidth}px) / 2) calc((200% - 100vw - ${dimensions.maxWidth}px) / 2);
+        padding-inline: calc((100vw - ${props.theme.breakpoints.values.lg}px) / 2)
+          calc((200% - 100vw - ${props.theme.breakpoints.values.lg}px) / 2);
       }
     `};
 `
 
 const Main = styled.main<{ fullWidth: boolean }>`
   display: inline-block;
-  width: ${props => (props.fullWidth ? '100%' : `${dimensions.maxWidth - 2 * dimensions.toolbarWidth}px`)};
+  width: ${props =>
+    props.fullWidth ? '100%' : `${props.theme.breakpoints.values.lg - 2 * dimensions.toolbarWidth}px`};
   max-width: ${props => (props.fullWidth ? '100%' : `calc(100% - ${dimensions.toolbarWidth}px)`)};
   box-sizing: border-box;
   margin: 0 auto;

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -65,7 +65,7 @@ const Body = styled.div<{ fullWidth: boolean; disableScrollingSafari: boolean }>
   ${props =>
     !props.fullWidth &&
     css`
-      @media screen and ${dimensions.minMaxWidth} {
+      ${props.theme.breakpoints.up('lg')} {
         padding-inline: calc((100vw - ${dimensions.maxWidth}px) / 2) calc((200% - 100vw - ${dimensions.maxWidth}px) / 2);
       }
     `};
@@ -85,7 +85,7 @@ const Main = styled.main<{ fullWidth: boolean }>`
     margin: ${props => props.theme.fonts.standardParagraphMargin} 0;
   }
 
-  @media screen and ${dimensions.smallViewport} {
+  ${props => props.theme.breakpoints.down('md')} {
     position: static;
     width: 100%;
     max-width: initial;
@@ -99,7 +99,7 @@ const Aside = styled.aside`
   width: 100px;
   left: 0;
 
-  @media ${dimensions.minMaxWidth} {
+  ${props => props.theme.breakpoints.up('lg')} {
     inset-inline-start: 8%;
   }
 

--- a/web/src/components/MobileBanner.tsx
+++ b/web/src/components/MobileBanner.tsx
@@ -5,7 +5,6 @@ import React, { ReactElement, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import buildConfig from '../constants/buildConfig'
-import dimensions from '../constants/dimensions'
 import useLocalStorage from '../hooks/useLocalStorage'
 import Button from './base/Button'
 import Icon from './base/Icon'
@@ -19,7 +18,7 @@ const StyledBanner = styled.div<{ isInstalled: boolean }>`
   transition: all 2s ease-out;
   height: ${props => (props.isInstalled ? 'fit-content' : '80px')};
 
-  @media ${dimensions.smallViewport} {
+  ${props => props.theme.breakpoints.down('md')} {
     display: flex;
   }
 `

--- a/web/src/components/Modal.tsx
+++ b/web/src/components/Modal.tsx
@@ -4,7 +4,6 @@ import FocusTrap from 'focus-trap-react'
 import React, { CSSProperties, ReactElement, ReactNode, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import dimensions from '../constants/dimensions'
 import useLockedBody from '../hooks/useLockedBody'
 import useScrollToTop from '../hooks/useScrollToTop'
 import useWindowDimensions from '../hooks/useWindowDimensions'
@@ -37,7 +36,7 @@ const ModalContentContainer = styled.div`
   display: flex;
   flex-direction: column;
 
-  @media ${dimensions.smallViewport} {
+  ${props => props.theme.breakpoints.down('md')} {
     height: 100%;
     align-items: center;
     width: 100%;

--- a/web/src/components/NavigationBarScrollContainer.tsx
+++ b/web/src/components/NavigationBarScrollContainer.tsx
@@ -34,7 +34,7 @@ const ScrollContainer = styled.div<{ showArrowContainer: boolean }>`
   min-height: ${dimensions.headerHeightLarge}px;
   flex-direction: row;
 
-  @media ${dimensions.smallViewport} {
+  ${props => props.theme.breakpoints.down('md')} {
     background-color: ${props => props.theme.colors.backgroundAccentColor};
     justify-content: space-between;
     flex-wrap: wrap;

--- a/web/src/components/PoiDetails.tsx
+++ b/web/src/components/PoiDetails.tsx
@@ -9,7 +9,6 @@ import { getExternalMapsLink } from 'shared'
 import { PoiModel } from 'shared/api'
 
 import { PoiThumbnailPlaceholderLarge } from '../assets'
-import dimensions from '../constants/dimensions'
 import { helpers } from '../constants/theme'
 import useWindowDimensions from '../hooks/useWindowDimensions'
 import Collapsible from './Collapsible'
@@ -44,7 +43,7 @@ const Thumbnail = styled.img`
   object-fit: cover;
   border-radius: 10px;
 
-  @media screen and (${dimensions.smallViewport}) {
+  ${props => props.theme.breakpoints.down('md')} {
     order: 1;
     margin-top: 12px;
   }
@@ -71,7 +70,7 @@ const AddressContent = styled.div`
   flex-direction: column;
   ${helpers.adaptiveFontSize};
 
-  @media ${dimensions.smallViewport} {
+  ${props => props.theme.breakpoints.down('md')} {
     align-self: center;
   }
 `
@@ -108,7 +107,7 @@ const DetailSection = styled.div`
   display: flex;
   flex-direction: column;
 
-  @media screen and (${dimensions.smallViewport}) {
+  ${props => props.theme.breakpoints.down('md')} {
     flex-direction: row;
     justify-content: space-between;
   }

--- a/web/src/components/PoiListItem.tsx
+++ b/web/src/components/PoiListItem.tsx
@@ -5,7 +5,6 @@ import { useTranslation } from 'react-i18next'
 import { PoiModel } from 'shared/api'
 
 import { PoiThumbnailPlaceholder } from '../assets'
-import dimensions from '../constants/dimensions'
 import { helpers } from '../constants/theme'
 import Button from './base/Button'
 
@@ -16,7 +15,7 @@ const ListItemContainer = styled.ul`
   border-bottom: 1px solid ${props => props.theme.colors.borderColor};
   cursor: pointer;
 
-  @media screen and (${dimensions.smallViewport}) {
+  ${props => props.theme.breakpoints.down('md')} {
     &:last-child {
       border-bottom: none;
     }

--- a/web/src/components/RemoteContentSandBox.ts
+++ b/web/src/components/RemoteContentSandBox.ts
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled'
 
 import { ExternalLinkIcon, PersonIcon } from '../assets'
-import dimensions from '../constants/dimensions'
 import { helpers } from '../constants/theme'
 
 const RemoteContentSandBox = styled.div<{ centered: boolean; smallText: boolean }>`
@@ -105,7 +104,7 @@ const RemoteContentSandBox = styled.div<{ centered: boolean; smallText: boolean 
     border: none;
     border-bottom: 1px solid ${props => props.theme.colors.borderColor};
 
-    @media ${dimensions.smallViewport} {
+    ${props => props.theme.breakpoints.down('md')} {
       max-width: 100%;
     }
   }
@@ -175,7 +174,7 @@ const RemoteContentSandBox = styled.div<{ centered: boolean; smallText: boolean 
       margin-inline-end: 8px;
     }
 
-    @media ${dimensions.smallViewport} {
+    ${props => props.theme.breakpoints.down('md')} {
       width: 100%;
     }
   }

--- a/web/src/components/SearchInput.tsx
+++ b/web/src/components/SearchInput.tsx
@@ -2,7 +2,6 @@ import styled from '@emotion/styled'
 import SearchOutlinedIcon from '@mui/icons-material/SearchOutlined'
 import React, { ReactElement } from 'react'
 
-import dimensions from '../constants/dimensions'
 import { helpers } from '../constants/theme'
 import Icon from './base/Icon'
 
@@ -38,7 +37,7 @@ const Wrapper = styled.div`
   display: flex;
   align-items: center;
 
-  @media ${dimensions.smallViewport} {
+  ${props => props.theme.breakpoints.down('md')} {
     padding: 10px 5%;
     justify-content: center;
   }

--- a/web/src/components/Selector.tsx
+++ b/web/src/components/Selector.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/react'
+import { css, Theme } from '@emotion/react'
 import styled from '@emotion/styled'
 import React, { ReactElement } from 'react'
 
@@ -7,7 +7,7 @@ import SelectorItemModel from '../models/SelectorItemModel'
 import Link from './base/Link'
 import Tooltip from './base/Tooltip'
 
-const selectorItemStyle = css`
+const selectorItemStyle = ({ theme }: { theme: Theme }) => css`
   height: ${dimensions.headerHeightLarge}px;
   min-width: 90px;
   padding: 0 5px;
@@ -21,7 +21,7 @@ const selectorItemStyle = css`
     border-radius 0.2s;
   user-select: none;
 
-  @media ${dimensions.smallViewport} {
+  ${theme.breakpoints.down('md')} {
     height: ${dimensions.headerHeightSmall}px;
     width: 100%;
     flex: 1 1 auto;

--- a/web/src/components/ThemeContainer.tsx
+++ b/web/src/components/ThemeContainer.tsx
@@ -30,6 +30,15 @@ const createTheme = (
   contentDirection,
   isContrastTheme: themeType === 'contrast',
   ...createMuiTheme({
+    breakpoints: {
+      values: {
+        xs: 0,
+        sm: 600,
+        md: 840,
+        lg: 1200,
+        xl: 1600,
+      },
+    },
     direction: contentDirection,
     colorSchemes: {
       light: buildConfig().lightTheme,

--- a/web/src/components/ThemeContainer.tsx
+++ b/web/src/components/ThemeContainer.tsx
@@ -22,6 +22,14 @@ const rtlCache = createCache({
   stylisPlugins: [prefixer, rtlPlugin],
 })
 
+export const BREAKPOINTS = {
+  xs: 0,
+  sm: 600,
+  md: 840,
+  lg: 1200,
+  xl: 1600,
+}
+
 const createTheme = (
   themeType: 'light' | 'contrast',
   contentDirection: UiDirectionType,
@@ -31,13 +39,7 @@ const createTheme = (
   isContrastTheme: themeType === 'contrast',
   ...createMuiTheme({
     breakpoints: {
-      values: {
-        xs: 0,
-        sm: 600,
-        md: 840,
-        lg: 1200,
-        xl: 1600,
-      },
+      values: BREAKPOINTS,
     },
     direction: contentDirection,
     colorSchemes: {

--- a/web/src/components/Tiles.tsx
+++ b/web/src/components/Tiles.tsx
@@ -3,22 +3,16 @@ import React, { ReactElement } from 'react'
 
 import { TileModel } from 'shared'
 
-import dimensions from '../constants/dimensions'
 import Caption from './Caption'
 import Tile from './Tile'
 
 const TilesRow = styled.div`
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+
+  /* https://css-tricks.com/intrinsically-responsive-css-grid-with-minmax-and-min/ */
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 16px;
   padding: 10px 0;
-
-  @media ${dimensions.mediumViewport} {
-    grid-template-columns: repeat(3, 1fr);
-  }
-
-  @media ${dimensions.smallViewport} {
-    grid-template-columns: repeat(2, 1fr);
-  }
 `
 
 type TilesProps = {

--- a/web/src/components/Toolbar.tsx
+++ b/web/src/components/Toolbar.tsx
@@ -2,7 +2,6 @@ import { css } from '@emotion/react'
 import styled from '@emotion/styled'
 import React, { ReactElement, ReactNode } from 'react'
 
-import dimensions from '../constants/dimensions'
 import useWindowDimensions from '../hooks/useWindowDimensions'
 
 const Container = styled.div`
@@ -35,7 +34,7 @@ const ToolbarContainer = styled.div<{ direction: 'row' | 'column'; hasPadding: b
     margin: 0.5rem 0 0;
   }
 
-  @media ${dimensions.smallViewport} {
+  ${props => props.theme.breakpoints.down('md')} {
     width: 100%;
     flex-flow: row wrap;
     justify-content: center;

--- a/web/src/components/ToolbarItem.tsx
+++ b/web/src/components/ToolbarItem.tsx
@@ -4,7 +4,6 @@ import { SvgIconProps } from '@mui/material'
 import React, { ElementType, ReactElement } from 'react'
 import { PlacesType } from 'react-tooltip'
 
-import dimensions from '../constants/dimensions'
 import useWindowDimensions from '../hooks/useWindowDimensions'
 import { spacesToDashes } from '../utils/stringUtils'
 import StyledSmallViewTip from './StyledSmallViewTip'
@@ -21,7 +20,7 @@ const toolbarItemStyle = ({ theme }: { theme: Theme }): SerializedStyles => css`
   background-color: transparent;
   text-align: center;
 
-  @media ${dimensions.smallViewport} {
+  ${theme.breakpoints.down('md')} {
     line-height: 1.15;
   }
 `

--- a/web/src/components/TtsPlayer.tsx
+++ b/web/src/components/TtsPlayer.tsx
@@ -7,7 +7,6 @@ import PlayArrowIcon from '@mui/icons-material/PlayArrow'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import dimensions from '../constants/dimensions'
 import useWindowDimensions from '../hooks/useWindowDimensions'
 import Button from './base/Button'
 import Icon from './base/Icon'
@@ -31,7 +30,7 @@ const StyledTtsPlayer = styled.dialog<{ isPlaying: boolean; footerHeight: number
   gap: ${props => (props.isPlaying ? '4px;' : '36px')};
   border-color: transparent;
 
-  @media ${dimensions.smallViewport} {
+  ${props => props.theme.breakpoints.down('md')} {
     width: auto;
   }
 `

--- a/web/src/constants/dimensions.ts
+++ b/web/src/constants/dimensions.ts
@@ -1,5 +1,4 @@
 export type DimensionsType = {
-  maxWidth: number
   toolbarWidth: number
   toolbarHeight: number
   ttsPlayerHeight: number
@@ -13,7 +12,6 @@ export type DimensionsType = {
 }
 
 const dimensions: DimensionsType = {
-  maxWidth: 1200,
   toolbarWidth: 200,
   poiDetailNavigation: 42,
   toolbarHeight: 66,

--- a/web/src/constants/dimensions.ts
+++ b/web/src/constants/dimensions.ts
@@ -1,9 +1,4 @@
 export type DimensionsType = {
-  maxWidthViewportSmall: number
-  smallViewport: string
-  mediumViewport: string
-  mediumLargeViewport: string
-  minMaxWidth: string
   maxWidth: number
   toolbarWidth: number
   toolbarHeight: number
@@ -18,12 +13,7 @@ export type DimensionsType = {
 }
 
 const dimensions: DimensionsType = {
-  maxWidthViewportSmall: 768,
-  smallViewport: '(max-width: 768px)',
-  mediumViewport: '(min-width: 769px) and (max-width: 1100px)',
-  mediumLargeViewport: '(min-width: 769px)',
-  minMaxWidth: '(min-width: 1101px)',
-  maxWidth: 1100,
+  maxWidth: 1200,
   toolbarWidth: 200,
   poiDetailNavigation: 42,
   toolbarHeight: 66,

--- a/web/src/hooks/__tests__/useWindowDimensions.spec.tsx
+++ b/web/src/hooks/__tests__/useWindowDimensions.spec.tsx
@@ -4,6 +4,20 @@ import React from 'react'
 import useWindowDimensions from '../useWindowDimensions'
 
 jest.mock('react-i18next')
+jest.mock('@mui/material', () => ({
+  useTheme: () => ({
+    breakpoints: {
+      values: {
+        xs: 0,
+        sm: 600,
+        md: 840,
+        lg: 1200,
+        xl: 1600,
+      },
+    },
+  }),
+}))
+
 describe('useWindowDimensions', () => {
   const MockComponent = () => {
     const { width, height, viewportSmall } = useWindowDimensions()
@@ -21,9 +35,9 @@ describe('useWindowDimensions', () => {
   })
 
   it('should correctly set all properties', () => {
-    // The small viewport media queries kick in with width <= 768.
-    const width = 769
-    const height = 400
+    // The small viewport media queries kick in with width <= 840.
+    const width = 841
+    const height = 800
     Object.defineProperty(window, 'innerWidth', { value: width })
     Object.defineProperty(window, 'innerHeight', { value: height })
 

--- a/web/src/hooks/__tests__/useWindowDimensions.spec.tsx
+++ b/web/src/hooks/__tests__/useWindowDimensions.spec.tsx
@@ -35,7 +35,7 @@ describe('useWindowDimensions', () => {
   })
 
   it('should correctly set all properties', () => {
-    // The small viewport media queries kick in with width <= 840.
+    // The small viewport media queries kick in with width < 840.
     const width = 841
     const height = 800
     Object.defineProperty(window, 'innerWidth', { value: width })

--- a/web/src/hooks/__tests__/useWindowDimensions.spec.tsx
+++ b/web/src/hooks/__tests__/useWindowDimensions.spec.tsx
@@ -4,19 +4,6 @@ import React from 'react'
 import useWindowDimensions from '../useWindowDimensions'
 
 jest.mock('react-i18next')
-jest.mock('@mui/material', () => ({
-  useTheme: () => ({
-    breakpoints: {
-      values: {
-        xs: 0,
-        sm: 600,
-        md: 840,
-        lg: 1200,
-        xl: 1600,
-      },
-    },
-  }),
-}))
 
 describe('useWindowDimensions', () => {
   const MockComponent = () => {

--- a/web/src/hooks/useWindowDimensions.ts
+++ b/web/src/hooks/useWindowDimensions.ts
@@ -1,5 +1,5 @@
-import { useTheme } from '@mui/material'
 import { useState, useEffect } from 'react'
+import { BREAKPOINTS } from 'src/components/ThemeContainer'
 
 export type WindowDimensionsType = {
   width: number
@@ -11,7 +11,7 @@ export type WindowDimensionsType = {
   visibleFooterHeight: number
 }
 
-const getWindowDimensions = (maxWidthViewportSmall: number): WindowDimensionsType => {
+const getWindowDimensions = (): WindowDimensionsType => {
   const { innerWidth: width, innerHeight: height, scrollY } = window
   const footer = document.querySelector('footer')
   const footerHeight = footer?.offsetHeight ?? 0
@@ -20,7 +20,7 @@ const getWindowDimensions = (maxWidthViewportSmall: number): WindowDimensionsTyp
     width,
     height,
     scrollY,
-    viewportSmall: width <= maxWidthViewportSmall,
+    viewportSmall: width <= BREAKPOINTS.md,
     footerHeight,
     documentHeight,
     visibleFooterHeight: Math.max(0, height + scrollY + footerHeight - documentHeight),
@@ -28,27 +28,25 @@ const getWindowDimensions = (maxWidthViewportSmall: number): WindowDimensionsTyp
 }
 
 const useWindowDimensions = (): WindowDimensionsType => {
-  const theme = useTheme()
-  const maxWidthViewportSmall = theme.breakpoints.values.md
-  const [windowDimensions, setWindowDimensions] = useState(getWindowDimensions(maxWidthViewportSmall))
+  const [windowDimensions, setWindowDimensions] = useState(getWindowDimensions())
 
   useEffect(() => {
     // Observe changes to the DOM body and recalculate all window dimensions (e.g. for adding/removing the tts player)
-    const resizeObserver = new ResizeObserver(() => setWindowDimensions(getWindowDimensions(maxWidthViewportSmall)))
+    const resizeObserver = new ResizeObserver(() => setWindowDimensions(getWindowDimensions()))
     resizeObserver.observe(document.body)
     return () => resizeObserver.disconnect()
-  }, [maxWidthViewportSmall])
+  }, [])
 
   useEffect(() => {
     // Observe changes to the window sizes or the scroll position and recalculate all window dimensions
-    const handleResize = () => setWindowDimensions(getWindowDimensions(maxWidthViewportSmall))
+    const handleResize = () => setWindowDimensions(getWindowDimensions())
     window.addEventListener('resize', handleResize)
     window.addEventListener('scroll', handleResize)
     return () => {
       window.removeEventListener('resize', handleResize)
       window.removeEventListener('scroll', handleResize)
     }
-  }, [maxWidthViewportSmall])
+  }, [])
 
   return windowDimensions
 }

--- a/web/src/hooks/useWindowDimensions.ts
+++ b/web/src/hooks/useWindowDimensions.ts
@@ -1,6 +1,5 @@
+import { useTheme } from '@mui/material'
 import { useState, useEffect } from 'react'
-
-import dimensions from '../constants/dimensions'
 
 export type WindowDimensionsType = {
   width: number
@@ -12,7 +11,7 @@ export type WindowDimensionsType = {
   visibleFooterHeight: number
 }
 
-const getWindowDimensions = (): WindowDimensionsType => {
+const getWindowDimensions = (maxWidthViewportSmall: number): WindowDimensionsType => {
   const { innerWidth: width, innerHeight: height, scrollY } = window
   const footer = document.querySelector('footer')
   const footerHeight = footer?.offsetHeight ?? 0
@@ -21,7 +20,7 @@ const getWindowDimensions = (): WindowDimensionsType => {
     width,
     height,
     scrollY,
-    viewportSmall: width <= dimensions.maxWidthViewportSmall,
+    viewportSmall: width <= maxWidthViewportSmall,
     footerHeight,
     documentHeight,
     visibleFooterHeight: Math.max(0, height + scrollY + footerHeight - documentHeight),
@@ -29,25 +28,27 @@ const getWindowDimensions = (): WindowDimensionsType => {
 }
 
 const useWindowDimensions = (): WindowDimensionsType => {
-  const [windowDimensions, setWindowDimensions] = useState(getWindowDimensions())
+  const theme = useTheme()
+  const maxWidthViewportSmall = theme.breakpoints.values.md
+  const [windowDimensions, setWindowDimensions] = useState(getWindowDimensions(maxWidthViewportSmall))
 
   useEffect(() => {
     // Observe changes to the DOM body and recalculate all window dimensions (e.g. for adding/removing the tts player)
-    const resizeObserver = new ResizeObserver(() => setWindowDimensions(getWindowDimensions()))
+    const resizeObserver = new ResizeObserver(() => setWindowDimensions(getWindowDimensions(maxWidthViewportSmall)))
     resizeObserver.observe(document.body)
     return () => resizeObserver.disconnect()
-  }, [])
+  }, [maxWidthViewportSmall])
 
   useEffect(() => {
     // Observe changes to the window sizes or the scroll position and recalculate all window dimensions
-    const handleResize = () => setWindowDimensions(getWindowDimensions())
+    const handleResize = () => setWindowDimensions(getWindowDimensions(maxWidthViewportSmall))
     window.addEventListener('resize', handleResize)
     window.addEventListener('scroll', handleResize)
     return () => {
       window.removeEventListener('resize', handleResize)
       window.removeEventListener('scroll', handleResize)
     }
-  }, [])
+  }, [maxWidthViewportSmall])
 
   return windowDimensions
 }

--- a/web/src/hooks/useWindowDimensions.ts
+++ b/web/src/hooks/useWindowDimensions.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
-import { BREAKPOINTS } from 'src/components/ThemeContainer'
+
+import { BREAKPOINTS } from '../components/ThemeContainer'
 
 export type WindowDimensionsType = {
   width: number

--- a/web/stylelint.config.js
+++ b/web/stylelint.config.js
@@ -5,8 +5,5 @@ module.exports = {
   rules: {
     // Enforce better ltr / rtl handling
     'csstools/use-logical': [true, { except: [/bottom$/, /top$/, /width$/, /height$/] }],
-
-    // False positives for string interpolated values e.g. '@media screen and ${dimensions.smallViewport}'
-    'media-query-no-invalid': null,
   },
 }


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
This PR adds our new breakpoints to the Mui theme

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Add our new breakpoints to the theme (https://www.figma.com/design/o5p3ArtrrmOqG6lJggAQE5/%F0%9F%9F%A8-Designsystem-Integreat--MUI-?node-id=2831-14804&p=f&m=dev)
- Replace the uses of our old breakpoints from `dimensions.ts`

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- The new breakpoints are a little different, in particular the medium size now goes up to 840px instead of 768px
- We sometimes used screen in the media queries, and sometimes didn't. I removed them all since our pages aren't really concerned with printing. I assume if someone wants to print our page (ouch!), they'll use the button to generate a PDF first
- I also removed the hard-coded amount of columns for `Tiles` and instead let that fill in dynamically because it looked weird to have only three columns at 840px. I assume we will be rewriting that some more in the future when the design system is finished.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Everything, really

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3237

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
