### PR TITLE
2172: Support external keyboard usage

### DIFF
--- a/native/package.json
+++ b/native/package.json
@@ -82,6 +82,7 @@
     "react-native-get-random-values": "^1.11.0",
     "react-native-inappbrowser-reborn": "^3.7.0",
     "react-native-keyboard-aware-scroll-view": "^0.9.5",
+    "react-native-external-keyboard": "^0.6.0",
     "react-native-localize": "^3.4.1",
     "react-native-pdf": "^6.7.7",
     "react-native-permissions": "^5.3.0",

--- a/native/src/components/CalendarRangeModal.tsx
+++ b/native/src/components/CalendarRangeModal.tsx
@@ -103,7 +103,7 @@ const CalendarRangeModal = ({
     <View>
       <Modal animationType='slide' transparent visible={modalVisible} onRequestClose={closeModal}>
         <Background onPress={closeModal} />
-        <DatePickerWrapper>
+        <DatePickerWrapper accessibilityViewIsModal role='dialog'>
           <Caption title={t('selectRange')} />
           <Calendar
             markingType='period'

--- a/native/src/components/Categories.tsx
+++ b/native/src/components/Categories.tsx
@@ -64,6 +64,7 @@ const Categories = ({
       lastUpdate={category.lastUpdate}
       language={language}
       path={category.path}
+      accessible={children.length === 0}
       AfterContent={category.organization && <OrganizationContentInfo organization={category.organization} />}
       Footer={
         children.length ? (

--- a/native/src/components/DatePickerInput.tsx
+++ b/native/src/components/DatePickerInput.tsx
@@ -1,11 +1,12 @@
 import { DateTime } from 'luxon'
 import React, { ReactElement, RefObject } from 'react'
 import { NativeSyntheticEvent, StyleProp, TextInput, TextInputKeyPressEventData, ViewStyle } from 'react-native'
+import { KeyboardExtendedInput } from 'react-native-external-keyboard'
 import styled, { useTheme } from 'styled-components/native'
 
 import { zeroPad } from 'shared/utils/dateFilterUtils'
 
-const Input = styled(TextInput)`
+const Input = styled(KeyboardExtendedInput)`
   text-align: center;
   min-width: 20%;
   color: ${props => props.theme.colors.textColor};
@@ -90,6 +91,8 @@ const DatePickerInput = ({
   return (
     <Input
       style={style}
+      focusType='default'
+      blurType='auto'
       ref={ref}
       placeholder={placeholder}
       placeholderTextColor={theme.isContrastTheme ? theme.colors.textColor : theme.colors.textSecondaryColor}

--- a/native/src/components/DatePickerInput.tsx
+++ b/native/src/components/DatePickerInput.tsx
@@ -1,7 +1,6 @@
 import { DateTime } from 'luxon'
 import React, { ReactElement, RefObject } from 'react'
 import { NativeSyntheticEvent, StyleProp, TextInput, TextInputKeyPressEventData, ViewStyle } from 'react-native'
-// react-native-external-keyboard can be removed after we update react native to 0.80.0 which fixes the keyboard focus issue for TextInput
 import { KeyboardExtendedInput } from 'react-native-external-keyboard'
 import styled, { useTheme } from 'styled-components/native'
 

--- a/native/src/components/DatePickerInput.tsx
+++ b/native/src/components/DatePickerInput.tsx
@@ -1,6 +1,7 @@
 import { DateTime } from 'luxon'
 import React, { ReactElement, RefObject } from 'react'
 import { NativeSyntheticEvent, StyleProp, TextInput, TextInputKeyPressEventData, ViewStyle } from 'react-native'
+// react-native-external-keyboard can be removed after we update react native to 0.80.0 which fixes the keyboard focus issue for TextInput
 import { KeyboardExtendedInput } from 'react-native-external-keyboard'
 import styled, { useTheme } from 'styled-components/native'
 

--- a/native/src/components/DatePickerInput.tsx
+++ b/native/src/components/DatePickerInput.tsx
@@ -9,7 +9,7 @@ import { zeroPad } from 'shared/utils/dateFilterUtils'
 
 const Input = styled(KeyboardExtendedInput)`
   text-align: center;
-  min-width: 20%;
+  min-width: 40%;
   color: ${props => props.theme.colors.textColor};
 `
 

--- a/native/src/components/EventsDateFilter.tsx
+++ b/native/src/components/EventsDateFilter.tsx
@@ -93,29 +93,31 @@ const EventsDateFilter = ({
       )}
       <FilterToggle isDateFilterActive={showDateFilter} setToggleDateFilter={setShowDateFilter} />
       <Accordion isOpen={showDateFilter} viewKey='Accordion'>
-        <DateSection>
-          <>
-            <DatePicker
-              modalOpen={modalOpen}
-              setModalOpen={setModalOpenAndCurrentInputFrom}
-              setDate={setStartDate}
-              title={t('from')}
-              error={startDateError ? t(startDateError) : ''}
-              date={startDate}
-              placeholderDate={today}
-              calendarLabel={t('selectStartDateCalendar')}
-            />
-            <DatePicker
-              modalOpen={modalOpen}
-              setModalOpen={setModalOpenAndCurrentInputTo}
-              setDate={setEndDate}
-              title={t('to')}
-              date={endDate}
-              placeholderDate={inAWeek}
-              calendarLabel={t('selectEndDateCalendar')}
-            />
-          </>
-        </DateSection>
+        {showDateFilter ? (
+          <DateSection>
+            <>
+              <DatePicker
+                modalOpen={modalOpen}
+                setModalOpen={setModalOpenAndCurrentInputFrom}
+                setDate={setStartDate}
+                title={t('from')}
+                error={startDateError ? t(startDateError) : ''}
+                date={startDate}
+                placeholderDate={today}
+                calendarLabel={t('selectStartDateCalendar')}
+              />
+              <DatePicker
+                modalOpen={modalOpen}
+                setModalOpen={setModalOpenAndCurrentInputTo}
+                setDate={setEndDate}
+                title={t('to')}
+                date={endDate}
+                placeholderDate={inAWeek}
+                calendarLabel={t('selectEndDateCalendar')}
+              />
+            </>
+          </DateSection>
+        ) : null}
       </Accordion>
       <>
         {(startDate || endDate) && (

--- a/native/src/components/Feedback.tsx
+++ b/native/src/components/Feedback.tsx
@@ -82,7 +82,12 @@ const Feedback = ({
     <KeyboardAwareScrollView>
       <Wrapper>
         {isSearchFeedback ? (
-          <InputSection title={t('searchTermDescription')} value={searchTerm} onChange={setSearchTerm} />
+          <InputSection
+            title={t('searchTermDescription')}
+            value={searchTerm}
+            onChange={setSearchTerm}
+            accessibilityRole='search'
+          />
         ) : (
           <>
             <Caption title={t('headline')} />
@@ -96,6 +101,7 @@ const Feedback = ({
           onChange={onCommentChanged}
           multiline
           showOptional
+          accessibilityRole='text'
         />
         <InputSection
           title={t('contactMailAddress')}
@@ -103,6 +109,7 @@ const Feedback = ({
           onChange={onFeedbackContactMailChanged}
           keyboardType='email-address'
           showOptional
+          accessibilityRole='text'
         />
         {sendingStatus === 'failed' && <Description>{t('failedSendingFeedback')}</Description>}
         <PrivacyCheckbox language={language} checked={privacyPolicyAccepted} setChecked={setPrivacyPolicyAccepted} />

--- a/native/src/components/FilterToggle.tsx
+++ b/native/src/components/FilterToggle.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
+import { withKeyboardFocus } from 'react-native-external-keyboard'
 import styled from 'styled-components/native'
 
 import { ExpandIcon, ShrinkIcon } from '../assets'
@@ -19,6 +20,8 @@ const StyledButton = styled.TouchableOpacity`
   gap: 5px;
 `
 
+const KeyboardedTouchable = withKeyboardFocus(StyledButton)
+
 type DateFilterToggleProps = {
   isDateFilterActive: boolean
   setToggleDateFilter: (isEnabled: boolean) => void
@@ -27,10 +30,10 @@ type DateFilterToggleProps = {
 const FilterToggle = ({ isDateFilterActive, setToggleDateFilter }: DateFilterToggleProps): ReactElement => {
   const { t } = useTranslation('events')
   return (
-    <StyledButton onPress={() => setToggleDateFilter(!isDateFilterActive)}>
+    <KeyboardedTouchable onPress={() => setToggleDateFilter(!isDateFilterActive)}>
       <Icon Icon={isDateFilterActive ? ShrinkIcon : ExpandIcon} />
       <StyledText>{t(isDateFilterActive ? 'hideFilters' : 'showFilters')}</StyledText>
-    </StyledButton>
+    </KeyboardedTouchable>
   )
 }
 

--- a/native/src/components/FilterToggle.tsx
+++ b/native/src/components/FilterToggle.tsx
@@ -30,7 +30,7 @@ type DateFilterToggleProps = {
 const FilterToggle = ({ isDateFilterActive, setToggleDateFilter }: DateFilterToggleProps): ReactElement => {
   const { t } = useTranslation('events')
   return (
-    <KeyboardedTouchable onPress={() => setToggleDateFilter(!isDateFilterActive)}>
+    <KeyboardedTouchable onPress={() => setToggleDateFilter(!isDateFilterActive)} focusable autoFocus>
       <Icon Icon={isDateFilterActive ? ShrinkIcon : ExpandIcon} />
       <StyledText>{t(isDateFilterActive ? 'hideFilters' : 'showFilters')}</StyledText>
     </KeyboardedTouchable>

--- a/native/src/components/News.tsx
+++ b/native/src/components/News.tsx
@@ -93,6 +93,7 @@ const News = ({
               : selectedNewsItem.content
           }
           language={languageCode}
+          accessible
           Footer={
             selectedNewsItem instanceof LocalNewsModel && (
               <TimeStampContent language={languageCode}>

--- a/native/src/components/Page.tsx
+++ b/native/src/components/Page.tsx
@@ -46,6 +46,7 @@ type PageProps = {
   lastUpdate?: DateTime
   path?: string
   padding?: boolean
+  accessible?: boolean
 }
 
 const Page = ({
@@ -58,6 +59,7 @@ const Page = ({
   lastUpdate,
   path,
   padding = true,
+  accessible,
 }: PageProps): ReactElement => {
   const { cityCode, languageCode } = useCityAppContext()
   const resourceCache = useResourceCache({ cityCode, languageCode })
@@ -80,7 +82,7 @@ const Page = ({
   const onLoad = useCallback(() => setLoading(false), [setLoading])
 
   return (
-    <Container $padding={padding}>
+    <Container $padding={padding} accessible={accessible}>
       {!loading && title ? <Caption title={title} language={language} /> : null}
       {!loading && BeforeContent}
       <RemoteContent

--- a/native/src/components/PoiDetails.tsx
+++ b/native/src/components/PoiDetails.tsx
@@ -93,7 +93,7 @@ const PoiDetails = ({ poi, language, distance }: PoiDetailsProps): ReactElement 
       {content.length > 0 && (
         <>
           <Collapsible headerContent={t('description')} language={language}>
-            <Page content={content} language={language} path={poi.path} padding={false} />
+            <Page content={content} language={language} path={poi.path} padding={false} accessible />
           </Collapsible>
           <HorizontalLine />
         </>

--- a/native/src/components/SearchInput.tsx
+++ b/native/src/components/SearchInput.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement } from 'react'
 import { Text, View, Keyboard } from 'react-native'
-// react-native-external-keyboard can be removed after we update react native to 0.80.0 which fixes the keyboard focus issue for TextInput
 import { KeyboardExtendedInput } from 'react-native-external-keyboard'
 import styled, { useTheme } from 'styled-components/native'
 
@@ -63,9 +62,7 @@ const SearchInput = ({
           {...testID('Search-Input')}
           multiline={false}
           autoFocus
-          onBlur={() => {
-            Keyboard.dismiss()
-          }}
+          onBlur={Keyboard.dismiss}
           placeholderTextColor={theme.colors.textSecondaryColor}
           placeholder={placeholderText}
           aria-label={placeholderText}

--- a/native/src/components/SearchInput.tsx
+++ b/native/src/components/SearchInput.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from 'react'
 import { Text, View, Keyboard } from 'react-native'
+// react-native-external-keyboard can be removed after we update react native to 0.80.0 which fixes the keyboard focus issue for TextInput
 import { KeyboardExtendedInput } from 'react-native-external-keyboard'
 import styled, { useTheme } from 'styled-components/native'
 

--- a/native/src/components/SearchInput.tsx
+++ b/native/src/components/SearchInput.tsx
@@ -1,18 +1,26 @@
 import React, { ReactElement } from 'react'
-import { Text, View } from 'react-native'
+import { Text, View, Keyboard } from 'react-native'
+import { KeyboardExtendedInput } from 'react-native-external-keyboard'
 import styled, { useTheme } from 'styled-components/native'
 
 import { SearchIcon } from '../assets'
 import testID from '../testing/testID'
 import Icon from './base/Icon'
 
-const Input = styled.TextInput`
+const InputWrapper = styled.View`
   margin: 0 4px;
   flex-grow: 1;
   border-bottom-width: 1px;
   border-bottom-color: ${props => props.theme.colors.textSecondaryColor};
   color: ${props => props.theme.colors.textColor};
 `
+
+const Input = (props: React.ComponentProps<typeof KeyboardExtendedInput>) => (
+  <InputWrapper>
+    <KeyboardExtendedInput {...props} />
+  </InputWrapper>
+)
+
 const Wrapper = styled.View<{ space: boolean }>`
   flex-direction: row;
   ${props => (props.space ? 'margin: 50px 0;' : '')}
@@ -53,10 +61,14 @@ const SearchInput = ({
         <Input
           {...testID('Search-Input')}
           multiline={false}
+          autoFocus
+          onBlur={() => {
+            Keyboard.dismiss()
+          }}
           placeholderTextColor={theme.colors.textSecondaryColor}
           placeholder={placeholderText}
           aria-label={placeholderText}
-          defaultValue={filterText}
+          value={filterText}
           onChangeText={onFilterTextChange}
           role='searchbox'
         />

--- a/native/src/components/SettingItem.tsx
+++ b/native/src/components/SettingItem.tsx
@@ -85,7 +85,7 @@ const SettingItem = ({
   role,
   hasBadge = false,
 }: SettingItemProps): ReactElement => (
-  <Pressable onPress={onPress} role={role ?? 'none'} accessible={false}>
+  <Pressable onPress={onPress} role={role ?? 'none'} accessible>
     <PadView>
       <ContentContainer>
         <View>

--- a/native/src/components/base/InputSection.tsx
+++ b/native/src/components/base/InputSection.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
-import { KeyboardTypeOptions } from 'react-native'
+import { AccessibilityRole, KeyboardTypeOptions } from 'react-native'
+import { KeyboardExtendedInput } from 'react-native-external-keyboard'
 import styled, { css } from 'styled-components/native'
 
 import Text from './Text'
@@ -30,7 +31,7 @@ const Title = styled(ThemedText)`
   text-align: left;
 `
 
-const Input = styled.TextInput<{ numberOfLines: number; invalid: boolean }>`
+const Input = styled(KeyboardExtendedInput)<{ numberOfLines: number; invalid: boolean }>`
   border-width: 1px;
   border-color: ${props => (props.invalid ? props.theme.colors.invalidInput : props.theme.colors.textDecorationColor)};
   color: ${props => props.theme.colors.textColor};
@@ -56,6 +57,7 @@ type InputSectionProps = {
   maxLength?: number
   showOptional?: boolean
   invalid?: boolean
+  accessibilityRole?: AccessibilityRole
 }
 
 const InputSection = ({
@@ -71,10 +73,11 @@ const InputSection = ({
   showOptional = false,
   invalid = false,
   hint,
+  accessibilityRole,
 }: InputSectionProps): ReactElement => {
   const { t } = useTranslation('common')
   return (
-    <Container>
+    <Container accessible>
       {title || showOptional || hint ? (
         <TitleContainer>
           {title ? <Title>{title}</Title> : null}
@@ -82,9 +85,10 @@ const InputSection = ({
           {showOptional && <Text>({t('optional')})</Text>}
         </TitleContainer>
       ) : null}
-      {description ? <Text>{description}</Text> : null}
+      {description ? <Text nativeID={description}>{description}</Text> : null}
       <Input
         onChangeText={onChange}
+        focusable
         onBlur={onBlur}
         value={value}
         multiline={multiline}
@@ -94,8 +98,9 @@ const InputSection = ({
         invalid={invalid}
         returnKeyType='done'
         blurOnSubmit
+        accessibilityRole={accessibilityRole ?? 'search'}
         accessibilityLabel={title}
-        role='searchbox'
+        accessibilityLabelledBy={description}
         testID={title ?? value}
       />
     </Container>

--- a/native/src/components/base/InputSection.tsx
+++ b/native/src/components/base/InputSection.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 import { AccessibilityRole, KeyboardTypeOptions } from 'react-native'
+// react-native-external-keyboard can be removed after we update react native to 0.80.0 which fixes the keyboard focus issue for TextInput
 import { KeyboardExtendedInput } from 'react-native-external-keyboard'
 import styled, { css } from 'styled-components/native'
 

--- a/native/src/components/base/InputSection.tsx
+++ b/native/src/components/base/InputSection.tsx
@@ -1,7 +1,6 @@
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 import { AccessibilityRole, KeyboardTypeOptions } from 'react-native'
-// react-native-external-keyboard can be removed after we update react native to 0.80.0 which fixes the keyboard focus issue for TextInput
 import { KeyboardExtendedInput } from 'react-native-external-keyboard'
 import styled, { css } from 'styled-components/native'
 

--- a/native/src/components/base/TextButton.tsx
+++ b/native/src/components/base/TextButton.tsx
@@ -1,11 +1,14 @@
 import React, { ReactElement } from 'react'
 import { StyleProp, TextStyle, ViewStyle } from 'react-native'
+import { withKeyboardFocus } from 'react-native-external-keyboard'
 import styled from 'styled-components/native'
 
 import Pressable from './Pressable'
 import Text from './Text'
 
-const StyledPressable = styled(Pressable)<{ primary: boolean; disabled: boolean }>`
+const KeyboardPressable = withKeyboardFocus(Pressable)
+
+const StyledPressable = styled(KeyboardPressable)<{ primary: boolean; disabled: boolean }>`
   padding: 8px;
   border-radius: 8px;
   background-color: ${props => {

--- a/native/src/routes/Events.tsx
+++ b/native/src/routes/Events.tsx
@@ -71,6 +71,7 @@ const Events = ({ cityModel, language, navigateTo, events, slug, refresh }: Even
             title={event.title}
             lastUpdate={event.lastUpdate}
             language={language}
+            accessible
             path={event.path}
             BeforeContent={
               <PageDetailsContainer>

--- a/native/src/routes/TuNewsDetail.tsx
+++ b/native/src/routes/TuNewsDetail.tsx
@@ -53,7 +53,7 @@ const TuNewsDetail = ({ route, navigation, data, newsId }: TuNewsProps): ReactEl
           <HeaderImageWrapper>
             <StyledIcon Icon={TuNewsActiveIcon} />
           </HeaderImageWrapper>
-          <Page title={tuNews.title} content={tuNews.content} language={languageCode} />
+          <Page title={tuNews.title} content={tuNews.content} language={languageCode} accessible />
         </>
       )}
     </LoadingErrorHandler>

--- a/yarn.lock
+++ b/yarn.lock
@@ -12764,6 +12764,11 @@ react-native-calendars@^1.1310.0:
   optionalDependencies:
     moment "^2.29.4"
 
+react-native-external-keyboard@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/react-native-external-keyboard/-/react-native-external-keyboard-0.6.0.tgz#b7729d62851456dd09c801a8e1fea0a1fccd0562"
+  integrity sha512-o4xYn5GwnuYbWXnqSnvFRxsQH5fDf+XGIuHD6sjGv4w7tMTPxQs4iSIFU6IBU6j8RBkBdivUwHJkAilriet7nA==
+
 react-native-gesture-handler@^2.25.0:
   version "2.27.1"
   resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-2.27.1.tgz#8865b2345f4c65536517f20cedc420481fc72d49"


### PR DESCRIPTION
### Short Description
Currently not all elements can be navigated easily with external keyboard (for ex. Bluetooth or usb), the problem still exists because of the WebView [(existing issue)](https://github.com/react-native-webview/react-native-webview/issues/2326) and cannot be fully fixed because of this, additionally TextInput from react-native has an  [issue](https://github.com/facebook/react-native/issues/31820) with focusing. Thus [react-native-external-keyboard](https://github.com/ArturKalach/react-native-external-keyboard) has been used to solve the issue with TextInput.
### Proposed Changes

<!-- Describe this PR in more detail. -->

- Use react-native-external-keyboard to solve the issue with TextInput for now untill we switch to react-native 0.80.0 version where this issue has been fixed
- DatePickerInput.tsx has been fixed
- EventsDateFilter.tsx has been adjusted to hide it from keyboard navigation when it is closed
- SearchInput has been changed to focus on the input because there is a problem with tab being stuck in Back button (solution: to autofocus on the input)
- TextButton.tsx has been adjusted to be able to focus after WebView on export calendar button with tab on event when it is scrolled to footer 

### Side Effects

- should be none

### Testing

Test all the components using external keyboard by navigating using Tab, arrow down, arrow up, arrow left and right keys

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2172 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
