### PR TITLE
3311: Mui chip button

### DIFF
--- a/build-configs/ThemeType.ts
+++ b/build-configs/ThemeType.ts
@@ -19,6 +19,22 @@ export type ActionColor = {
   focus?: string
 }
 
+type ToneColor = {
+  /* eslint-disable no-magic-numbers */
+  1000?: string
+  900: string
+  800: string
+  700: string
+  600: string
+  500: string
+  400: string
+  300: string
+  200: string
+  100: string
+  50: string
+  /* eslint-enable no-magic-numbers */
+}
+
 export type CommonColors = {
   primary: PaletteColor
   tertiary: PaletteColor
@@ -30,6 +46,7 @@ export type CommonColors = {
   action: ActionColor
   divider: string
   link: string
+  neutral: ToneColor
 }
 
 export type PaletteMode = 'light' | 'dark'

--- a/build-configs/common/theme/colors.ts
+++ b/build-configs/common/theme/colors.ts
@@ -39,6 +39,19 @@ const commonColors: CommonColors = {
     disabledBackground: '#C9C9C9',
     disabled: '#FFFFFF',
   },
+  neutral: {
+    1000: '#020202',
+    900: 'rgba(0, 0, 0, 0.87)',
+    800: 'rgba(0, 0, 0, 0.60)',
+    700: 'rgba(0, 0, 0, 0.58)',
+    600: 'rgba(0, 0, 0, 0.54)',
+    500: 'rgba(0, 0, 0, 0.42)',
+    400: 'rgba(0, 0, 0, 0.38)',
+    300: 'rgba(0, 0, 0, 0.26)',
+    200: 'rgba(0, 0, 0, 0.18)',
+    100: 'rgba(0, 0, 0, 0.06)',
+    50: '#FFFFFF',
+  },
 }
 
 export const commonLightColors: CommonColorPalette = {

--- a/web/src/@types/mui-theme.d.ts
+++ b/web/src/@types/mui-theme.d.ts
@@ -1,10 +1,13 @@
+/* eslint-disable no-magic-numbers */
+
+/* eslint-disable @typescript-eslint/consistent-type-definitions */
+
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { TypographyPropsVariantOverrides } from '@mui/material/Typography'
 
 // Enable and disable typography variants according to our design system
 // docs: https://mui.com/material-ui/customization/typography/#adding-amp-disabling-variants
 declare module '@mui/material/Typography' {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface TypographyPropsVariantOverrides {
     display1: true
     display2: true
@@ -27,5 +30,39 @@ declare module '@mui/material/Typography' {
     subtitle2: false
     caption: false
     overline: false
+  }
+}
+
+declare module '@mui/material/styles' {
+  interface Palette {
+    neutral: {
+      1000?: string
+      900: string
+      800: string
+      700: string
+      600: string
+      500: string
+      400: string
+      300: string
+      200: string
+      100: string
+      50: string
+    }
+  }
+
+  interface PaletteOptions {
+    neutral: {
+      1000?: string
+      900: string
+      800: string
+      700: string
+      600: string
+      500: string
+      400: string
+      300: string
+      200: string
+      100: string
+      50: string
+    }
   }
 }

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled'
 import Headroom from '@integreat-app/react-sticky-headroom'
+import PersonIcon from '@mui/icons-material/Person'
 import React, { ReactElement, ReactNode } from 'react'
 
 import dimensions from '../constants/dimensions'
@@ -10,6 +11,7 @@ import { HeaderNavigationItemProps } from './HeaderNavigationItem'
 import HeaderTitle from './HeaderTitle'
 import KebabMenu from './KebabMenu'
 import NavigationBarScrollContainer from './NavigationBarScrollContainer'
+import ChipButton from './base/ChipButton'
 
 type HeaderProps = {
   navigationItems: ReactElement<HeaderNavigationItemProps>[]
@@ -134,6 +136,55 @@ export const Header = ({
             )}
           </ActionBar>
         </Row>
+        <div style={{ display: 'flex', gap: '8px', marginBottom: '8px', alignItems: 'center' }}>
+          <ChipButton label='x-small chip' onDelete={() => console.log('click')} size='xs' icon={<PersonIcon />} />
+          <ChipButton label='small chip' onDelete={() => console.log('click')} size='sm' icon={<PersonIcon />} />
+          <ChipButton label='default chip' onDelete={() => console.log('click')} icon={<PersonIcon />} />
+        </div>
+        <div style={{ display: 'flex', gap: '8px', marginBottom: '8px', alignItems: 'center' }}>
+          <ChipButton
+            label='x-small chip'
+            onDelete={() => console.log('click')}
+            size='xs'
+            variant='primary'
+            icon={<PersonIcon />}
+          />
+          <ChipButton
+            label='small chip'
+            onDelete={() => console.log('click')}
+            size='sm'
+            variant='primary'
+            icon={<PersonIcon />}
+          />
+          <ChipButton
+            label='default chip'
+            onDelete={() => console.log('click')}
+            variant='primary'
+            icon={<PersonIcon />}
+          />
+        </div>
+        <div style={{ display: 'flex', gap: '8px', marginBottom: '8px', alignItems: 'center' }}>
+          <ChipButton
+            label='x-small chip'
+            onDelete={() => console.log('click')}
+            size='xs'
+            variant='outlined'
+            icon={<PersonIcon />}
+          />
+          <ChipButton
+            label='small chip'
+            onDelete={() => console.log('click')}
+            size='sm'
+            variant='outlined'
+            icon={<PersonIcon />}
+          />
+          <ChipButton
+            label='default chip'
+            onDelete={() => console.log('click')}
+            variant='outlined'
+            icon={<PersonIcon />}
+          />
+        </div>
         {hasNavigationBar && (
           <NavigationBarScrollContainer activeIndex={navigationItems.findIndex(el => el.props.active)}>
             <NavigationBar id='navigation-bar'>{navigationItems}</NavigationBar>

--- a/web/src/components/PoiFiltersOverlayButtons.tsx
+++ b/web/src/components/PoiFiltersOverlayButtons.tsx
@@ -28,26 +28,24 @@ const PoiFiltersOverlayButtons = ({
   return (
     <>
       <ChipButton
-        text={t('adjustFilters')}
-        icon={EditLocationOutlinedIcon}
+        label={t('adjustFilters')}
+        icon={<EditLocationOutlinedIcon />}
         onClick={() => setShowFilterSelection(!poiFiltersShown)}
       />
       {currentlyOpenFilter && (
         <ChipButton
-          text={t('opened')}
-          label={t('clearFilter', { filter: t('opened') })}
-          icon={AccessTimeIcon}
+          label={t('opened')}
+          icon={<AccessTimeIcon />}
           onClick={() => setCurrentlyOpenFilter(false)}
-          closeButton
+          onDelete={() => setCurrentlyOpenFilter(false)}
         />
       )}
       {!!poiCategory && (
         <ChipButton
-          text={poiCategory.name}
-          label={t('clearFilter', { filter: poiCategory.name })}
+          label={poiCategory.name}
           icon={poiCategory.icon}
           onClick={() => setPoiCategoryFilter(null)}
-          closeButton
+          onDelete={() => setPoiCategoryFilter(null)}
         />
       )}
     </>

--- a/web/src/components/base/ChipButton.tsx
+++ b/web/src/components/base/ChipButton.tsx
@@ -1,46 +1,126 @@
 import styled from '@emotion/styled'
-import CloseIcon from '@mui/icons-material/Close'
-import { SvgIconProps } from '@mui/material'
-import React, { ElementType, ReactElement } from 'react'
+import { Chip, ChipOwnProps, Theme, useTheme } from '@mui/material'
+import React, { ReactElement } from 'react'
 
-import Button from './Button'
 import Icon from './Icon'
 
-const StyledButton = styled(Button)`
-  display: flex;
-  height: 30px;
-  padding: 4px 8px;
-  align-items: center;
-  margin: 0 2px;
-  border-radius: 20px;
-  gap: 4px;
-  background-color: ${props => props.theme.colors.backgroundColor};
-  color: ${props => props.theme.colors.textSecondaryColor};
-  font-family: ${props => props.theme.fonts.web.contentFont};
-  font-size: 0.875rem;
+const sharedIconMargins = `
+  .MuiChip-icon {
+    margin-inline-start: 12px;
+  }
+
+  .MuiChip-deleteIcon {
+    margin-inline-end: 12px;
+  }
 `
 
-const StyledIcon = styled(Icon)`
-  color: ${props => props.theme.colors.textSecondaryColor};
-  height: 16px;
-  width: 16px;
+const ExtraSmallChip = styled(Chip)`
+  ${sharedIconMargins}
+  height: 20px;
+  font-size: 10px;
+
+  .MuiChip-icon,
+  .MuiChip-deleteIcon {
+    height: 10px;
+    width: 10px;
+  }
 `
 
-type ChipButtonProps = {
-  text: string
-  icon: string | ElementType<SvgIconProps>
-  onClick: () => void
-  label?: string
-  closeButton?: boolean
-  className?: string
+const SmallChip = styled(Chip)`
+  ${sharedIconMargins}
+  height: 24px;
+  font-size: 12px;
+
+  .MuiChip-icon,
+  .MuiChip-deleteIcon {
+    height: 12px;
+    width: 12px;
+  }
+`
+
+const MediumChip = styled(Chip)`
+  ${sharedIconMargins}
+  font-size: 14px;
+
+  .MuiChip-icon,
+  .MuiChip-deleteIcon {
+    height: 14px;
+    width: 14px;
+  }
+`
+
+const getIconElement = (IconProp: undefined | string | ReactElement): ReactElement | undefined => {
+  if (typeof IconProp === 'string') {
+    return <Icon src={IconProp} />
+  }
+  return IconProp
 }
 
-const ChipButton = ({ text, onClick, label, className, ...props }: ChipButtonProps): ReactElement => (
-  <StyledButton label={label ?? text} onClick={onClick} className={className}>
-    <StyledIcon src={props.icon} />
-    <div>{text}</div>
-    {props.closeButton && <StyledIcon src={CloseIcon} />}
-  </StyledButton>
-)
+const mapPropsToMuiChipProps = (props: ChipButtonProps, theme: Theme): ChipOwnProps => {
+  const { variant, icon, size, ...rest } = props
+  const iconElement = getIconElement(icon)
+  if (variant === 'outlined') {
+    return {
+      variant: 'outlined',
+      icon: iconElement,
+      sx: {
+        '.MuiChip-label': {
+          color: theme.palette.neutral[900],
+        },
+        '.MuiChip-icon, .MuiChip-deleteIcon': {
+          color: theme.palette.neutral[400],
+        },
+      },
+      ...rest,
+    }
+  }
+  if (variant === 'primary') {
+    return {
+      color: 'primary',
+      icon: iconElement,
+      sx: {
+        '.MuiChip-label, .MuiChip-icon, .MuiChip-deleteIcon': {
+          color: theme.palette.neutral[50],
+        },
+      },
+      ...rest,
+    }
+  }
+  return {
+    variant: 'filled',
+    icon: iconElement,
+    sx: {
+      '.MuiChip-label': {
+        color: theme.palette.neutral[900],
+      },
+      '.MuiChip-icon, .MuiChip-deleteIcon': {
+        color: theme.palette.neutral[600],
+      },
+    },
+    ...rest,
+  }
+}
+
+type ChipButtonProps = {
+  label: string
+  icon?: string | ReactElement
+  onClick?: () => void
+  onDelete?: () => void
+  closeButton?: boolean
+  size?: 'xs' | 'sm' | 'default'
+  variant?: 'outlined' | 'grey' | 'primary'
+}
+
+const ChipButton = (props: ChipButtonProps): ReactElement => {
+  const { size } = props
+  const theme = useTheme()
+  if (size === 'xs') {
+    return <ExtraSmallChip {...mapPropsToMuiChipProps(props, theme)} />
+  }
+  if (size === 'sm') {
+    return <SmallChip {...mapPropsToMuiChipProps(props, theme)} />
+  }
+  return <MediumChip {...mapPropsToMuiChipProps(props, theme)} />
+}
 
 export default ChipButton


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
This PR replaces our own chip button with the one from the design system: https://www.figma.com/design/o5p3ArtrrmOqG6lJggAQE5/%F0%9F%9F%A8-Designsystem-Integreat--MUI-?node-id=14-740&p=f&m=dev

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Added the neutral color palette to our styles because it's used for the chip buttons (https://www.figma.com/design/o5p3ArtrrmOqG6lJggAQE5/%F0%9F%9F%A8-Designsystem-Integreat--MUI-?node-id=0-1&p=f&m=dev)
- Replaced the chip button with the one from Mui: https://mui.com/material-ui/react-chip/
- Added some chips to the header for easier testing that I will remove before merging

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- The chip button on the map doesn't look great, but that will probably look different in the future anyway: https://www.figma.com/design/o5p3ArtrrmOqG6lJggAQE5/%F0%9F%9F%A8-Designsystem-Integreat--MUI-?node-id=3048-15002&m=dev

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Take a look at the chip buttons in the header, maybe add or remove a bit.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3311 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
