### PR TITLE
3364: Improve bottom sheet at POI

### DIFF
--- a/native/src/components/PoisBottomSheet.tsx
+++ b/native/src/components/PoisBottomSheet.tsx
@@ -30,7 +30,7 @@ const BottomSheetContent = styled.View`
 
 const BottomSpace = styled.View<{ bottomInset: number }>`
   width: 100%;
-  height: ${props => props.bottomInset + 'px'};
+  height: ${props => `${props.bottomInset}px`};
   background-color: ${props => props.theme.colors.backgroundColor};
 `
 

--- a/native/src/components/PoisBottomSheet.tsx
+++ b/native/src/components/PoisBottomSheet.tsx
@@ -6,6 +6,7 @@ import BottomSheet, {
 import React, { memo, ReactElement, Ref } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Platform } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import styled, { useTheme } from 'styled-components/native'
 
 import { LocationType } from 'shared'
@@ -25,6 +26,12 @@ const StyledBottomSheet = styled(BottomSheet)<{ isFullscreen: boolean }>`
 const BottomSheetContent = styled.View`
   flex: 1;
   margin: 0 24px;
+`
+
+const BottomSpace = styled.View<{ bottomInset: number }>`
+  width: 100%;
+  height: ${props => props.bottomInset + 'px'};
+  background-color: ${props => props.theme.colors.backgroundColor};
 `
 
 const Title = styled.Text`
@@ -66,6 +73,7 @@ const PoisBottomSheet = ({
   const { languageCode } = useCityAppContext()
   const { t } = useTranslation('pois')
   const theme = useTheme()
+  const insets = useSafeAreaInsets()
   // ios has scrolling issues if content panning gesture is not enabled
   const enableContentPanningGesture = Platform.OS === 'ios' || !isFullscreen
 
@@ -86,35 +94,39 @@ const PoisBottomSheet = ({
   )
 
   return (
-    <StyledBottomSheet
-      accessibilityLabel=''
-      index={snapPointIndex}
-      isFullscreen={isFullscreen}
-      snapPoints={snapPoints}
-      enableContentPanningGesture={enableContentPanningGesture}
-      enableDynamicSizing={false}
-      animateOnMount
-      backgroundStyle={{ backgroundColor: theme.colors.backgroundColor }}
-      handleComponent={BottomSheetHandle}
-      onChange={setSnapPointIndex}>
-      <BottomSheetContent>
-        {slug ? (
-          <BottomSheetScrollView showsVerticalScrollIndicator={false}>{PoiDetail}</BottomSheetScrollView>
-        ) : (
-          <BottomSheetFlatList
-            ref={poiListRef}
-            data={pois}
-            role='list'
-            accessibilityLabel={t('poisCount', { count: pois.length })}
-            renderItem={renderPoiListItem}
-            onMomentumScrollBegin={event => setScrollPosition(event.nativeEvent.contentOffset.y)}
-            showsVerticalScrollIndicator={false}
-            ListHeaderComponent={<Title>{t('listTitle')}</Title>}
-            ListEmptyComponent={<NoItemsMessage>{t('noPois')}</NoItemsMessage>}
-          />
-        )}
-      </BottomSheetContent>
-    </StyledBottomSheet>
+    <>
+      <StyledBottomSheet
+        accessibilityLabel=''
+        index={snapPointIndex}
+        isFullscreen={isFullscreen}
+        snapPoints={snapPoints}
+        enableContentPanningGesture={enableContentPanningGesture}
+        enableDynamicSizing={false}
+        animateOnMount
+        backgroundStyle={{ backgroundColor: theme.colors.backgroundColor }}
+        handleComponent={BottomSheetHandle}
+        bottomInset={insets.bottom}
+        onChange={setSnapPointIndex}>
+        <BottomSheetContent>
+          {slug ? (
+            <BottomSheetScrollView showsVerticalScrollIndicator={false}>{PoiDetail}</BottomSheetScrollView>
+          ) : (
+            <BottomSheetFlatList
+              ref={poiListRef}
+              data={pois}
+              role='list'
+              accessibilityLabel={t('poisCount', { count: pois.length })}
+              renderItem={renderPoiListItem}
+              onMomentumScrollBegin={event => setScrollPosition(event.nativeEvent.contentOffset.y)}
+              showsVerticalScrollIndicator={false}
+              ListHeaderComponent={<Title>{t('listTitle')}</Title>}
+              ListEmptyComponent={<NoItemsMessage>{t('noPois')}</NoItemsMessage>}
+            />
+          )}
+        </BottomSheetContent>
+      </StyledBottomSheet>
+      <BottomSpace bottomInset={insets.bottom} />
+    </>
   )
 }
 

--- a/native/src/components/__tests__/PoisBottomSheet.spec.tsx
+++ b/native/src/components/__tests__/PoisBottomSheet.spec.tsx
@@ -11,6 +11,9 @@ jest.mock('../../components/Page')
 jest.mock('@react-native-clipboard/clipboard', () => () => ({ setString: jest.fn() }))
 jest.mock('react-i18next')
 jest.mock('styled-components')
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => jest.fn(),
+}))
 jest.mock('@gorhom/bottom-sheet', () => ({
   __esModule: true,
   ...require('@gorhom/bottom-sheet/mock'),


### PR DESCRIPTION
### Short Description
when you pull the bottom sheet handle at Poi while using gesture system navigation (Android) its hard to pull without triggering the system nav.


### Proposed Changes

<!-- Describe this PR in more detail. -->

- Used useSafeAreaInsets to know the bottom safe area at `bottomInset`.
- After moving the bottom sheet above the safe area it will leave an empty space so I added `<BottomSpace/>` to fill the gap.

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

None.

### Testing

- You need to switch system navigation to gesture instead of 3 buttons (you can test both).
- Go to POI (Map) and test the bottom sheet.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3364 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
