### PR TITLE
3284: Replace react-native-blob-util

### DIFF
--- a/native/jest.config.ts
+++ b/native/jest.config.ts
@@ -6,7 +6,7 @@ const transformNodeModules = [
   '@react-native-community',
   '@react-navigation',
   'react-navigation-header-buttons',
-  'react-native-blob-util',
+  '@dr.pogodin/react-native-fs',
   'shared',
   'translations',
   '@sentry/react-native',

--- a/native/jest.setup.ts
+++ b/native/jest.setup.ts
@@ -15,6 +15,14 @@ jest.mock('react-native-permissions', () => require('react-native-permissions/mo
 require('react-native-gesture-handler/jestSetup')
 
 jest.mock('react-native-tts')
+jest.mock('@dr.pogodin/react-native-fs', () => require('./src/__mocks__/react-native-fs'))
+
+// Mock Sentry to prevent timer leaks in tests
+jest.mock('@sentry/react-native', () => ({
+  init: jest.fn(),
+  captureException: jest.fn(),
+  addBreadcrumb: jest.fn(),
+}))
 
 jest.mock('react-native-reanimated', () => {
   const Reanimated = require('react-native-reanimated/mock')
@@ -52,7 +60,6 @@ jest.doMock('react-native/Libraries/ReactNative/I18nManager', () => I18nManager)
 jest.doMock(`${rootPath}/constants/NativeConstants`)
 jest.doMock('build-config-name')
 jest.doMock(`${rootPath}/constants/buildConfig`)
-jest.doMock('react-native-blob-util')
 jest.doMock('path', () => path.posix)
 
 // See https://github.com/callstack/react-native-testing-library/issues/329#issuecomment-737307473

--- a/native/src/components/__tests__/TtsContainer.spec.tsx
+++ b/native/src/components/__tests__/TtsContainer.spec.tsx
@@ -14,6 +14,14 @@ import TextButton from '../base/TextButton'
 jest.mock('react-i18next')
 jest.mock('react-native-tts')
 jest.mock('../../hooks/useSnackbar')
+jest.mock('react-native-fs', () => ({
+  mkdir: jest.fn().mockResolvedValue(undefined),
+  exists: jest.fn().mockResolvedValue(false),
+  stat: jest.fn().mockRejectedValue(new Error('File does not exist')),
+  writeFile: jest.fn().mockResolvedValue(undefined),
+  readFile: jest.fn().mockResolvedValue('{}'),
+  unlink: jest.fn().mockResolvedValue(undefined),
+}))
 jest.mock('shared/api', () => ({
   useLoadAsync: jest.fn(() => ({
     data: [

--- a/native/src/utils/DefaultDataContainer.ts
+++ b/native/src/utils/DefaultDataContainer.ts
@@ -1,6 +1,6 @@
+import * as RNFS from '@dr.pogodin/react-native-fs'
 import { difference, flatMap, isEmpty, map, omitBy } from 'lodash'
 import { DateTime } from 'luxon'
-import BlobUtil from 'react-native-blob-util'
 
 import { CategoriesMapModel, CityModel, EventModel, LocalNewsModel, PoiModel } from 'shared/api'
 
@@ -213,7 +213,7 @@ class DefaultDataContainer implements DataContainer {
         const pathsToClean = difference(removedPaths, pathsOfOtherLanguages)
         log('Cleaning up the following resources:')
         log(pathsToClean.join(', '))
-        await Promise.all(pathsToClean.map(path => BlobUtil.fs.unlink(path)))
+        await Promise.all(pathsToClean.map(path => RNFS.unlink(path)))
       }
     }
 

--- a/native/src/utils/__tests__/DatabaseConnector.spec.ts
+++ b/native/src/utils/__tests__/DatabaseConnector.spec.ts
@@ -7,7 +7,7 @@ import CategoriesMapModelBuilder from 'shared/api/endpoints/testing/CategoriesMa
 import CityModelBuilder from 'shared/api/endpoints/testing/CityModelBuilder'
 import EventModelBuilder from 'shared/api/endpoints/testing/EventModelBuilder'
 
-import BlobUtil from '../../__mocks__/react-native-blob-util'
+import * as RNFS from '../../__mocks__/react-native-fs'
 import DatabaseContext from '../../models/DatabaseContext'
 import DatabaseConnector, {
   RESOURCE_CACHE_DIR_PATH,
@@ -20,7 +20,7 @@ jest.useFakeTimers({ now: now.toJSDate() })
 
 const databaseConnector = new DatabaseConnector()
 afterEach(() => {
-  BlobUtil.fs._reset()
+  RNFS._reset()
   jest.clearAllMocks()
 })
 
@@ -63,7 +63,7 @@ describe('DatabaseConnector', () => {
   describe('storeCities', () => {
     it('should store the json file in the correct path', async () => {
       await databaseConnector.storeCities(testCities)
-      expect(BlobUtil.fs.writeFile).toHaveBeenCalledWith(
+      expect(RNFS.writeFile).toHaveBeenCalledWith(
         expect.stringContaining('/cities.json'),
         expect.any(String),
         expect.any(String),
@@ -92,7 +92,7 @@ describe('DatabaseConnector', () => {
 
     it('should throw if persisted data is malformed for a given city-language pair', async () => {
       const context = new DatabaseContext('tcc', 'de')
-      BlobUtil.fs.writeFile(databaseConnector.getMetaCitiesPath(), '{ "i": "am": "malformed" } }', 'utf8')
+      RNFS.writeFile(databaseConnector.getMetaCitiesPath(), '{ "i": "am": "malformed" } }', 'utf8')
       await expect(databaseConnector.loadLastUpdate(context)).rejects.toThrow()
     })
 
@@ -149,7 +149,7 @@ describe('DatabaseConnector', () => {
       const date = DateTime.fromISO('2011-05-04T00:00:00.000Z')
       await databaseConnector.storeLastUsage(context)
       await databaseConnector.storeLastUpdate(date, context)
-      expect(BlobUtil.fs.writeFile).toHaveBeenCalledWith(
+      expect(RNFS.writeFile).toHaveBeenCalledWith(
         expect.stringContaining('cities-meta.json'),
         expect.any(String),
         expect.any(String),
@@ -176,7 +176,7 @@ describe('DatabaseConnector', () => {
     it('should store the json file in the correct path', async () => {
       const context = new DatabaseContext('tcc', 'de')
       await databaseConnector.storeCategories(testCategoriesMap, context)
-      expect(BlobUtil.fs.writeFile).toHaveBeenCalledWith(
+      expect(RNFS.writeFile).toHaveBeenCalledWith(
         expect.stringContaining('tcc/de/categories.json'),
         expect.any(String),
         expect.any(String),
@@ -217,7 +217,7 @@ describe('DatabaseConnector', () => {
     it('should store the json file in the correct path', async () => {
       const context = new DatabaseContext('tcc', 'de')
       await databaseConnector.storeEvents(testEvents, context)
-      expect(BlobUtil.fs.writeFile).toHaveBeenCalledWith(
+      expect(RNFS.writeFile).toHaveBeenCalledWith(
         expect.stringContaining('tcc/de/events.json'),
         expect.any(String),
         expect.any(String),
@@ -283,7 +283,7 @@ describe('DatabaseConnector', () => {
     it('should store the json file in the correct path', async () => {
       const context = new DatabaseContext('tcc', 'de')
       await databaseConnector.storeResourceCache(testResources, context)
-      expect(BlobUtil.fs.writeFile).toHaveBeenCalledWith(
+      expect(RNFS.writeFile).toHaveBeenCalledWith(
         expect.stringContaining('tcc/files.json'),
         expect.any(String),
         expect.any(String),
@@ -307,7 +307,7 @@ describe('DatabaseConnector', () => {
   })
 
   const expectExists = async (path: string, exists = true) => {
-    const doesExist = await BlobUtil.fs.exists(path)
+    const doesExist = await RNFS.exists(path)
     expect(doesExist).toBe(exists)
   }
 
@@ -329,7 +329,7 @@ describe('DatabaseConnector', () => {
     it('should store the usage of the passed city', async () => {
       const context = new DatabaseContext('augsburg')
       await databaseConnector.storeLastUsage(context)
-      expect(JSON.parse(await BlobUtil.fs.readFile(databaseConnector.getMetaCitiesPath(), ''))).toEqual({
+      expect(JSON.parse(await RNFS.readFile(databaseConnector.getMetaCitiesPath(), ''))).toEqual({
         augsburg: {
           last_usage: now.toISO(),
           languages: {},
@@ -343,7 +343,7 @@ describe('DatabaseConnector', () => {
       await populateCityContent('ansbach')
       await populateCityContent('regensburg')
       // We have to write this manually, since this is normally done in storeLastUsage, but it calls deleteOldFiles
-      await BlobUtil.fs.writeFile(
+      await RNFS.writeFile(
         databaseConnector.getMetaCitiesPath(),
         JSON.stringify({
           muenchen: {
@@ -366,7 +366,7 @@ describe('DatabaseConnector', () => {
       await expectCityFilesExist('dortmund')
       await expectCityFilesExist('ansbach')
       await expectCityFilesExist('regensburg')
-      expect(JSON.parse(await BlobUtil.fs.readFile(databaseConnector.getMetaCitiesPath(), ''))).toEqual({
+      expect(JSON.parse(await RNFS.readFile(databaseConnector.getMetaCitiesPath(), ''))).toEqual({
         ansbach: {
           languages: {},
           last_usage: '2012-05-04T00:00:00.000+02:00',
@@ -385,9 +385,9 @@ describe('DatabaseConnector', () => {
     it('should override if persisted data is malformed for a given city-language pair', async () => {
       const context = new DatabaseContext('tcc', 'de')
       const path = databaseConnector.getMetaCitiesPath()
-      BlobUtil.fs.writeFile(path, '{ "i": "am": "malformed" } }', 'utf8')
+      RNFS.writeFile(path, '{ "i": "am": "malformed" } }', 'utf8')
       await databaseConnector.storeLastUsage(context)
-      expect(JSON.parse(await BlobUtil.fs.readFile(path, 'utf8'))).toEqual({
+      expect(JSON.parse(await RNFS.readFile(path, 'utf8'))).toEqual({
         tcc: {
           languages: {},
           last_usage: '2024-05-02T11:45:43.443+02:00',
@@ -398,7 +398,7 @@ describe('DatabaseConnector', () => {
 
   describe('loadLastUsages', () => {
     it('should load last usages', async () => {
-      await BlobUtil.fs.writeFile(
+      await RNFS.writeFile(
         databaseConnector.getMetaCitiesPath(),
         JSON.stringify({
           muenchen: {
@@ -450,7 +450,7 @@ describe('DatabaseConnector', () => {
 
     it('should throw array if persisted data is malformed', async () => {
       const path = databaseConnector.getMetaCitiesPath()
-      BlobUtil.fs.writeFile(path, '{ "i": "am": "malformed" } }', 'utf8')
+      RNFS.writeFile(path, '{ "i": "am": "malformed" } }', 'utf8')
       await expect(databaseConnector.loadLastUsages()).rejects.toThrow()
     })
   })
@@ -463,7 +463,7 @@ describe('DatabaseConnector', () => {
       await populateCityContent('regensburg')
       await populateCityContent('augsburg')
       // We have to write this manually, since this is normally done in storeLastUsage, but it calls deleteOldFiles
-      await BlobUtil.fs.writeFile(
+      await RNFS.writeFile(
         databaseConnector.getMetaCitiesPath(),
         JSON.stringify({
           muenchen: {
@@ -495,7 +495,7 @@ describe('DatabaseConnector', () => {
       await expectCityFilesExist('ansbach')
       await expectCityFilesExist('regensburg')
       await expectCityFilesExist('augsburg')
-      expect(JSON.parse(await BlobUtil.fs.readFile(databaseConnector.getMetaCitiesPath(), ''))).toEqual({
+      expect(JSON.parse(await RNFS.readFile(databaseConnector.getMetaCitiesPath(), ''))).toEqual({
         ansbach: {
           languages: {},
           last_usage: '2012-05-04T00:00:00.000+02:00',
@@ -517,7 +517,7 @@ describe('DatabaseConnector', () => {
       await populateCityContent('ansbach')
       await populateCityContent('regensburg')
       // We have to write this manually, since this is normally done in storeLastUsage, but it calls deleteOldFiles
-      await BlobUtil.fs.writeFile(
+      await RNFS.writeFile(
         databaseConnector.getMetaCitiesPath(),
         JSON.stringify({
           augsburg: {
@@ -544,7 +544,7 @@ describe('DatabaseConnector', () => {
       await expectCityFilesExist('ansbach')
       await expectCityFilesExist('regensburg')
       await expectCityFilesExist('augsburg')
-      expect(JSON.parse(await BlobUtil.fs.readFile(databaseConnector.getMetaCitiesPath(), ''))).toEqual({
+      expect(JSON.parse(await RNFS.readFile(databaseConnector.getMetaCitiesPath(), ''))).toEqual({
         ansbach: {
           languages: {},
           last_usage: '2012-05-04T00:00:00.000+02:00',
@@ -565,48 +565,54 @@ describe('DatabaseConnector', () => {
     it('should correctly read file and parse json content', async () => {
       const content = ['this', 'is', 'my', 'custom', { content: 'CONTENT' }]
       const path = 'my-path'
-      await BlobUtil.fs.writeFile(path, JSON.stringify(content), 'utf8')
+      await RNFS.writeFile(path, JSON.stringify(content), 'utf8')
       const readContent = await databaseConnector.readFile(path, content => content)
       expect(readContent).toEqual(content)
     })
 
     it('should delete file if json is corrupted', async () => {
       const path = 'my-path'
-      await BlobUtil.fs.writeFile(path, '[', 'utf8')
+      await RNFS.writeFile(path, '[', 'utf8')
       await expect(databaseConnector.readFile(path, content => content)).rejects.toEqual(
         new SyntaxError('Unexpected end of JSON input'),
       )
-      expect(BlobUtil.fs.unlink).toHaveBeenCalledWith(path)
+      expect(RNFS.unlink).toHaveBeenCalledWith(path)
     })
 
     it('should delete file if json cannot be mapped', async () => {
       const path = 'my-path'
-      await BlobUtil.fs.writeFile(path, `[{ "_code": "de", "_name": "Deutsch" }]`, 'utf8')
+      await RNFS.writeFile(path, `[{ "_code": "de", "_name": "Deutsch" }]`, 'utf8')
       await expect(databaseConnector.readFile<string, string>(path, content => content.toLowerCase())).rejects.toEqual(
         new TypeError('content.toLowerCase is not a function'),
       )
-      expect(BlobUtil.fs.unlink).toHaveBeenCalledWith(path)
+      expect(RNFS.unlink).toHaveBeenCalledWith(path)
     })
   })
 
   describe('migration routine', () => {
     it('should delete old content dir if version is upgraded', async () => {
-      BlobUtil.fs.isDir.mockImplementation(async path => path === UNVERSIONED_CONTENT_DIR_PATH)
+      RNFS.stat.mockImplementation(async path =>
+        path === UNVERSIONED_CONTENT_DIR_PATH ? { isDirectory: () => true } : Promise.reject(new Error('not found')),
+      )
       const _ = new DatabaseConnector()
-      await waitFor(() => expect(BlobUtil.fs.unlink).toHaveBeenCalledWith(UNVERSIONED_CONTENT_DIR_PATH))
+      await waitFor(() => expect(RNFS.unlink).toHaveBeenCalledWith(UNVERSIONED_CONTENT_DIR_PATH))
     })
 
     it('should delete old resource cache dir if version is upgraded', async () => {
-      BlobUtil.fs.isDir.mockImplementation(async path => path === UNVERSIONED_RESOURCE_CACHE_DIR_PATH)
+      RNFS.stat.mockImplementation(async path =>
+        path === UNVERSIONED_RESOURCE_CACHE_DIR_PATH
+          ? { isDirectory: () => true }
+          : Promise.reject(new Error('not found')),
+      )
       const _ = new DatabaseConnector()
-      await waitFor(() => expect(BlobUtil.fs.unlink).toHaveBeenCalledWith(UNVERSIONED_RESOURCE_CACHE_DIR_PATH))
+      await waitFor(() => expect(RNFS.unlink).toHaveBeenCalledWith(UNVERSIONED_RESOURCE_CACHE_DIR_PATH))
     })
 
     it('should not delete current cache if new version exists', async () => {
-      BlobUtil.fs.isDir.mockImplementation(async () => true)
+      RNFS.stat.mockImplementation(async () => ({ isDirectory: () => true }))
       const _ = new DatabaseConnector()
-      await waitFor(() => expect(BlobUtil.fs.isDir).toHaveBeenCalledWith(RESOURCE_CACHE_DIR_PATH))
-      expect(BlobUtil.fs.unlink).not.toHaveBeenCalled()
+      await waitFor(() => expect(RNFS.stat).toHaveBeenCalledWith(RESOURCE_CACHE_DIR_PATH))
+      expect(RNFS.unlink).not.toHaveBeenCalled()
     })
   })
 })

--- a/native/src/utils/__tests__/DefaultDataContainer.spec.ts
+++ b/native/src/utils/__tests__/DefaultDataContainer.spec.ts
@@ -5,7 +5,7 @@ import CityModelBuilder from 'shared/api/endpoints/testing/CityModelBuilder'
 import EventModelBuilder from 'shared/api/endpoints/testing/EventModelBuilder'
 import PoiModelBuilder from 'shared/api/endpoints/testing/PoiModelBuilder'
 
-import BlobUtil from '../../__mocks__/react-native-blob-util'
+import * as RNFS from '../../__mocks__/react-native-fs'
 import DatabaseContext from '../../models/DatabaseContext'
 import DatabaseConnector from '../DatabaseConnector'
 import defaultDataContainer from '../DefaultDataContainer'
@@ -37,7 +37,7 @@ const anotherTestResources = {
 
 describe('DefaultDataContainer', () => {
   beforeEach(() => {
-    BlobUtil.fs._reset()
+    RNFS._reset()
     jest.clearAllMocks()
     defaultDataContainer.clearInMemoryCache()
   })
@@ -136,14 +136,14 @@ describe('DefaultDataContainer', () => {
   describe('setResourceCache', () => {
     it('should not delete any data if there are no previous resources available', async () => {
       await defaultDataContainer.setResourceCache('testCity', 'de', testResources)
-      expect(BlobUtil.fs.unlink).not.toHaveBeenCalled()
+      expect(RNFS.unlink).not.toHaveBeenCalled()
     })
     it('should unlink the outdated resources if there are new resources available', async () => {
       await defaultDataContainer.setResourceCache('testCity', 'de', previousResources)
       // Add mock file, normally this is done in the NativeFetcherModule.fetchAsync
-      await BlobUtil.fs.writeFile('/local/path/to/resource/b4b5dca65e423.png', '', 'UTF-8')
+      await RNFS.writeFile('/local/path/to/resource/b4b5dca65e423.png', '', 'UTF-8')
       await defaultDataContainer.setResourceCache('testCity', 'de', testResources)
-      expect(BlobUtil.fs.unlink).toHaveBeenCalledWith('/local/path/to/resource/b4b5dca65e423.png')
+      expect(RNFS.unlink).toHaveBeenCalledWith('/local/path/to/resource/b4b5dca65e423.png')
     })
   })
   describe('citiesAvailable', () => {

--- a/native/src/utils/__tests__/sentry.spec.ts
+++ b/native/src/utils/__tests__/sentry.spec.ts
@@ -7,7 +7,6 @@ import buildConfig from '../../constants/buildConfig'
 import { initSentry, log, reportError } from '../sentry'
 
 jest.mock('@sentry/react-native', () => ({
-  ...jest.requireActual('@sentry/react-native'),
   captureException: jest.fn(),
   addBreadcrumb: jest.fn(),
   init: jest.fn(),

--- a/native/src/utils/helpers.ts
+++ b/native/src/utils/helpers.ts
@@ -1,5 +1,5 @@
+import * as RNFS from '@dr.pogodin/react-native-fs'
 import { last } from 'lodash'
-import BlobUtil from 'react-native-blob-util'
 import Url from 'url-parse'
 
 import buildConfig from '../constants/buildConfig'
@@ -9,8 +9,8 @@ import { log } from './sentry'
 // Android throws an error if attempting to delete non existing directories/files
 // https://github.com/joltup/rn-fetch-blob/issues/333
 export const deleteIfExists = async (path: string): Promise<void> => {
-  if (await BlobUtil.fs.exists(path)) {
-    await BlobUtil.fs.unlink(path)
+  if (await RNFS.exists(path)) {
+    await RNFS.unlink(path)
   } else {
     log(`File or directory ${path} does not exist and was therefore not deleted.`, 'warning')
   }


### PR DESCRIPTION
### Short Description

We should check if we can replace react-native-blob-util with @dr.pogodin/react-native-fs to have one less dependency.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Replaced `BlobUtil.fs` with `RNFS` and what is equivalent at `react-native-fs`.
- Replaced the old mock `react-native-blob-util.ts` with the new one `react-native-fs.ts`.
- writeFile needs to check if there is a directory to write file to it otherwise it wont work.
- Found an issue while fixing the tests that says
```
A worker process has failed to exit gracefully and has been force exited. This is likely caused by tests leaking due to improper teardown. Try running with --detectOpenHandles to find leaks. Active timers can also cause this, ensure that .unref() was called on them.
```
So I found that it's coming from sentry. to solve it I had to remove `...jest.requireActual('@sentry/react-native'),`at `sentry.spec.ts` and added a simple mock at `jest.setup.ts` this will save about 1 or 1.5 second when you do `yarn test` .
- :warning: I can't remove  `react-native-blob-util.ts` from package.json because it's used by `react-native-pdf` check this: https://www.npmjs.com/package/react-native-pdf.

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Anything could be affected.

### Testing

- Test the app thoroughly.
- Check 3rd leaf content is loading.
- Check if content can be accessed offline.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3284 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
