### PR TITLE
Use correct height for headroom

### DIFF
--- a/web/jest.setup.ts
+++ b/web/jest.setup.ts
@@ -13,6 +13,10 @@ window.ResizeObserver = jest.fn().mockImplementation(() => ({
 global.fetch = require('jest-fetch-mock')
 
 console.error = () => undefined
+
+// structuredClone is still not available in JSDOM, so we hack around it... https://github.com/jsdom/jsdom/issues/3363
+global.structuredClone = <T>(it: T): T => JSON.parse(JSON.stringify(it))
+
 Element.prototype.scrollIntoView = jest.fn()
 
 const walkDir = (dir: string, callback: (dir: string) => void) => {

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -42,7 +42,7 @@ const Row = styled.div`
   display: flex;
   flex: 1;
   max-width: 100%;
-  align-items: stretch;
+  align-items: center;
   min-height: ${dimensions.headerHeightLarge}px;
   flex-direction: row;
   justify-content: space-between;
@@ -53,7 +53,6 @@ const Row = styled.div`
     flex-wrap: wrap;
     min-height: ${dimensions.headerHeightSmall}px;
     overflow-x: auto;
-    padding: 8px 0;
   }
 `
 

--- a/web/src/components/HeaderLogo.tsx
+++ b/web/src/components/HeaderLogo.tsx
@@ -4,7 +4,6 @@ import React, { ReactElement } from 'react'
 
 import buildConfig from '../constants/buildConfig'
 import dimensions from '../constants/dimensions'
-import Icon from './base/Icon'
 import Link from './base/Link'
 
 type HeaderLogoProps = {
@@ -29,17 +28,17 @@ const LogoContainer = styled.div`
   }
 `
 
-const StyledLogoIcon = styled(Icon)<{ small: boolean }>`
+const StyledLogo = styled.img<{ $small: boolean }>`
   color: ${props => props.theme.colors.textColor};
   height: 100%;
   width: 200px;
 
   @media ${dimensions.mediumLargeViewport} {
-    ${props => (props.small ? 'display: none;' : '')}
+    ${props => (props.$small ? 'display: none;' : '')}
   }
 
   @media ${dimensions.smallViewport} {
-    ${props => (!props.small ? 'display: none;' : '')}
+    ${props => (!props.$small ? 'display: none;' : '')}
     width: 100%;
   }
 `
@@ -59,8 +58,9 @@ export const HeaderLogo = ({ link }: HeaderLogoProps): ReactElement => {
   return (
     <LogoContainer>
       <Link to={link}>
-        <StyledLogoIcon small src={srcMobile} title={appName} />
-        <StyledLogoIcon small={false} src={src} title={appName} />
+        {/* Using `loading="lazy"` makes the browser only fetch the image that is actually visible */}
+        <StyledLogo $small src={srcMobile} alt={appName} loading='lazy' />
+        <StyledLogo $small={false} src={src} alt={appName} loading='lazy' />
       </Link>
     </LogoContainer>
   )

--- a/web/src/components/HeaderLogo.tsx
+++ b/web/src/components/HeaderLogo.tsx
@@ -4,7 +4,6 @@ import React, { ReactElement } from 'react'
 
 import buildConfig from '../constants/buildConfig'
 import dimensions from '../constants/dimensions'
-import useWindowDimensions from '../hooks/useWindowDimensions'
 import Icon from './base/Icon'
 import Link from './base/Link'
 
@@ -14,37 +13,34 @@ type HeaderLogoProps = {
 
 const LogoContainer = styled.div`
   box-sizing: border-box;
-  height: ${dimensions.headerHeightLarge}px;
   padding: 0 10px;
-  display: flex;
-  justify-content: start;
-  align-items: center;
   flex: initial;
   order: 1;
 
   & a {
+    display: block;
     width: 100%;
     height: 60%;
-  }
 
-  @media ${dimensions.smallViewport} {
-    height: ${dimensions.headerHeightSmall}px;
-    max-width: ${dimensions.headerHeightSmall}px;
-    flex: 1 1 0%; /* The % unit is necessary for IE11 */
-    & a {
-      max-height: 75%;
+    @media ${dimensions.smallViewport} {
+      height: 42px;
+      width: 42px;
     }
   }
 `
 
-const StyledLogoIcon = styled(Icon)`
+const StyledLogoIcon = styled(Icon)<{ small: boolean }>`
   color: ${props => props.theme.colors.textColor};
   height: 100%;
   width: 200px;
-  max-width: 200px;
+
+  @media ${dimensions.mediumLargeViewport} {
+    ${props => (props.small ? 'display: none;' : '')}
+  }
 
   @media ${dimensions.smallViewport} {
-    max-width: 44px;
+    ${props => (!props.small ? 'display: none;' : '')}
+    width: 100%;
   }
 `
 
@@ -52,7 +48,6 @@ const StyledLogoIcon = styled(Icon)`
  * A logo component designed for the Header.
  */
 export const HeaderLogo = ({ link }: HeaderLogoProps): ReactElement => {
-  const { viewportSmall } = useWindowDimensions()
   const { campaign, appName, icons } = buildConfig()
 
   const currentDate = DateTime.now()
@@ -64,7 +59,8 @@ export const HeaderLogo = ({ link }: HeaderLogoProps): ReactElement => {
   return (
     <LogoContainer>
       <Link to={link}>
-        <StyledLogoIcon src={viewportSmall ? srcMobile : src} title={appName} />
+        <StyledLogoIcon small src={srcMobile} title={appName} />
+        <StyledLogoIcon small={false} src={src} title={appName} />
       </Link>
     </LogoContainer>
   )

--- a/web/src/components/KebabMenu.tsx
+++ b/web/src/components/KebabMenu.tsx
@@ -62,6 +62,7 @@ const Heading = styled.div`
   background-color: ${props => props.theme.colors.backgroundAccentColor};
   box-shadow: -3px 3px 3px 0 rgb(0 0 0 / 13%);
   min-height: ${dimensions.headerHeightSmall}px;
+  box-sizing: border-box;
   padding: 8px;
 `
 

--- a/web/src/components/NavigationBarScrollContainer.tsx
+++ b/web/src/components/NavigationBarScrollContainer.tsx
@@ -31,6 +31,7 @@ const ScrollContainer = styled.div<{ showArrowContainer: boolean }>`
   flex: 1;
   max-width: 100%;
   align-items: stretch;
+  box-sizing: border-box;
   min-height: ${dimensions.headerHeightLarge}px;
   flex-direction: row;
 

--- a/web/src/components/__tests__/HeaderLogo.spec.tsx
+++ b/web/src/components/__tests__/HeaderLogo.spec.tsx
@@ -4,14 +4,13 @@ import buildConfig from '../../constants/buildConfig'
 import { renderWithRouterAndTheme } from '../../testing/render'
 import HeaderLogo from '../HeaderLogo'
 
-jest.mock('../base/Icon', () => ({
+jest.mock('../../constants/buildConfig', () => ({
   __esModule: true,
-  default: ({ src, title, id }: { src: string; title?: string; id?: string }) => (
-    <div data-testid={id || 'header-logo'} data-src={src} data-title={title} />
-  ),
+  default: jest.fn(() => __BUILD_CONFIG__),
 }))
 
 jest.useFakeTimers()
+
 describe('HeaderLogo', () => {
   const womensDayCampaign = {
     campaignAppLogo: '/campaign-app-logo.png',
@@ -19,54 +18,57 @@ describe('HeaderLogo', () => {
     startDate: '2021-03-08T00:00:00.000Z',
     endDate: '2021-03-15T00:00:00.000Z',
   }
-  const previousConfig = buildConfig()
-  let config = previousConfig
 
-  afterEach(() => {
-    config = previousConfig
+  let config = __BUILD_CONFIG__
+
+  beforeEach(() => {
+    config = structuredClone(__BUILD_CONFIG__)
+    const mock = buildConfig as ReturnType<typeof jest.fn>
+    mock.mockReturnValue(config)
   })
 
   it('should show the regular header app icon if there is no campaign', () => {
     jest.setSystemTime(1615374110000) // Wed Mar 10 2021 11:01:50 GMT+0000
     config.campaign = undefined
     config.icons.appLogo = '/my-regular-logo'
-    const { getByTestId } = renderWithRouterAndTheme(<HeaderLogo link='https://example.com' />)
-    const logo = getByTestId('header-logo')
+    const { getAllByRole } = renderWithRouterAndTheme(<HeaderLogo link='https://example.com' />)
+    const logos = getAllByRole('img')
 
-    expect(logo).toBeInTheDocument()
-    expect(logo.getAttribute('data-src')).toBe(config.icons.appLogo)
-    expect(logo.getAttribute('data-title')).toBe('IntegreatTestCms')
+    expect(logos[0]!.getAttribute('src')).toBe(config.icons.appLogoMobile)
+    expect(logos[1]!.getAttribute('src')).toBe(config.icons.appLogo)
+    logos.forEach(it => expect(it.getAttribute('alt')).toBe('IntegreatTestCms'))
   })
 
   it('should show the campaign logo if the current date is between start and end date', () => {
     jest.setSystemTime(1615374110000) // Wed Mar 10 2021 11:01:50 GMT+0000
     config.campaign = womensDayCampaign
     config.icons.appLogo = '/my-regular-logo'
-    const { getByTestId } = renderWithRouterAndTheme(<HeaderLogo link='https://example.com' />)
-    const logo = getByTestId('header-logo')
+    const { getAllByRole } = renderWithRouterAndTheme(<HeaderLogo link='https://example.com' />)
+    const logos = getAllByRole('img')
 
-    expect(logo).toBeInTheDocument()
-    expect(logo.getAttribute('data-src')).toBe(womensDayCampaign.campaignAppLogo)
-    expect(logo.getAttribute('data-title')).toBe('IntegreatTestCms')
+    expect(logos[0]!.getAttribute('src')).toBe(womensDayCampaign.campaignAppLogoMobile)
+    expect(logos[1]!.getAttribute('src')).toBe(womensDayCampaign.campaignAppLogo)
   })
 
   it('should show the regular logo if the current date is before the start date', () => {
     jest.setSystemTime(1614942686000) // Fri Mar 05 2021 11:11:26
     config.campaign = womensDayCampaign
     config.icons.appLogo = '/my-regular-logo'
-    const { getByTestId } = renderWithRouterAndTheme(<HeaderLogo link='https://example.com' />)
-    const logo = getByTestId('header-logo')
+    const { getAllByRole } = renderWithRouterAndTheme(<HeaderLogo link='https://example.com' />)
+    const logos = getAllByRole('img')
 
-    expect(logo.getAttribute('data-src')).toBe(config.icons.appLogo)
+    expect(logos[0]!.getAttribute('src')).toBe(config.icons.appLogoMobile)
+    expect(logos[1]!.getAttribute('src')).toBe(config.icons.appLogo)
   })
 
   it('should show the regular logo if the current date is after the end date', () => {
     jest.setSystemTime(1615806686000) // Mon Mar 15 2021 11:11:26
     config.campaign = womensDayCampaign
     config.icons.appLogo = '/my-regular-logo'
-    const { getByTestId } = renderWithRouterAndTheme(<HeaderLogo link='https://example.com' />)
-    const logo = getByTestId('header-logo')
+    const { getAllByRole } = renderWithRouterAndTheme(<HeaderLogo link='https://example.com' />)
+    const logos = getAllByRole('img')
 
-    expect(logo.getAttribute('data-src')).toBe(config.icons.appLogo)
+    expect(logos[0]!.getAttribute('src')).toBe(config.icons.appLogoMobile)
+    expect(logos[1]!.getAttribute('src')).toBe(config.icons.appLogo)
   })
 })

--- a/web/src/constants/dimensions.ts
+++ b/web/src/constants/dimensions.ts
@@ -30,7 +30,7 @@ const dimensions: DimensionsType = {
   ttsPlayerHeight: 90,
   maxTtsPlayerWidth: 576,
   headerHeightLarge: 90,
-  headerHeightSmall: 70,
+  headerHeightSmall: 86,
   navigationMenuHeight: 90,
   poiDesktopPanelWidth: 332,
   mainContainerHorizontalPadding: 10,

--- a/web/src/constants/dimensions.ts
+++ b/web/src/constants/dimensions.ts
@@ -19,10 +19,10 @@ export type DimensionsType = {
 
 const dimensions: DimensionsType = {
   maxWidthViewportSmall: 768,
-  smallViewport: '(max-width: 768px)',
-  mediumViewport: '(min-width: 769px) and (max-width: 1100px)',
-  mediumLargeViewport: '(min-width: 769px)',
-  minMaxWidth: '(min-width: 1101px)',
+  smallViewport: '(width <= 768px)',
+  mediumViewport: '(width > 768px) and (width <= 1100px)',
+  mediumLargeViewport: '(width > 768px)',
+  minMaxWidth: '(width > 1100px)',
   maxWidth: 1100,
   toolbarWidth: 200,
   poiDetailNavigation: 42,


### PR DESCRIPTION
### Short Description

Fix a small visual glitch related to Headroom; more specifically, on mobile, Headroom does hides less than expected of the Header when scrolling down.

### Proposed Changes

* The height passed to Headroom was incorrect (since some padding was introduced at some point, which is not reflected in `dimensions.headerHeightX`).
This fixes this, and simplifies some of the Header related rendering / CSS.

* I also removed JS-based viewport-specific behavior, to avoid any flickering when the viewport changes.

### Side Effects

Some slight changes in the layout (some slight horizontal shifts in the logo area)
In my view theses are improvements :D

### Testing

* Check that exactly half of the header is hidden when scrolling down, on a mobile viewport.
* Check that the header works as expected also in larger viewport.
* Check that all whitelabeled' apps' logos work as expected.

### Related

It seems there is an issue to redesign the header #3375.

