### PR TITLE
3387: Fix back navigation in search content

### DIFF
--- a/web/src/routes/SearchPage.tsx
+++ b/web/src/routes/SearchPage.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import React, { ReactElement, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useSearchParams } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 
 import {
   parseHTML,
@@ -42,15 +42,17 @@ const SearchCounter = styled.p`
 `
 
 const SearchPage = ({ city, cityCode, languageCode }: CityRouteProps): ReactElement | null => {
-  const [queryParams, setQueryParams] = useSearchParams()
+  const [queryParams] = useSearchParams()
+  const navigate = useNavigate()
   const [query, setQuery] = useState(queryParams.get(SEARCH_QUERY_KEY) ?? '')
   const { t } = useTranslation('search')
   const fallbackLanguage = config.sourceLanguage
   const debouncedQuery = useDebounce(query)
 
   useEffect(() => {
-    setQueryParams(debouncedQuery.length > 0 ? { query: debouncedQuery } : undefined)
-  }, [debouncedQuery, setQueryParams])
+    const search = debouncedQuery ? `?${SEARCH_QUERY_KEY}=${debouncedQuery}` : ''
+    navigate({ search }, { replace: false })
+  }, [debouncedQuery, navigate])
 
   const {
     data: contentLanguageDocuments,

--- a/web/src/routes/__tests__/SearchPage.spec.tsx
+++ b/web/src/routes/__tests__/SearchPage.spec.tsx
@@ -132,6 +132,22 @@ describe('SearchPage', () => {
     await waitFor(() => expect(router.state.location.search).toMatch(/\?query=ChangeToThis/))
   })
 
+  it('should go back to previous url when using back navigation', async () => {
+    const { getByPlaceholderText, router } = renderRoute(searchPage, { pathname, routePattern })
+
+    fireEvent.change(getByPlaceholderText('search:searchPlaceholder'), { target: { value: 'firstQuery' } })
+    await waitFor(() => expect(router.state.location.search).toMatch(/\?query=firstQuery/))
+
+    fireEvent.change(getByPlaceholderText('search:searchPlaceholder'), { target: { value: 'secondQuery' } })
+    await waitFor(() => expect(router.state.location.search).toMatch(/\?query=secondQuery/))
+
+    router.navigate(-1)
+
+    await waitFor(() => {
+      expect(router.state.location.search).toMatch(/\?query=firstQuery/)
+    })
+  })
+
   it('should remove ?query= when filteredText is empty', () => {
     const query = '?query=RemoveThis'
 


### PR DESCRIPTION
### Short Description

This PR fixes back navigation being broken in search content when there is a search param in url

### Proposed Changes

<!-- Describe this PR in more detail. -->

- use useNavigate() hook to update the url with push state
- add test case for it

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- should be none

### Testing

- Go to 'Search'
- Look for something
- Try to use back button to go back to the previous state

### Resolved Issues

Fixes: #3387 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
