### PR TITLE
Update ReleaseNoteTemplate to remove web platform

### DIFF
--- a/release-notes/ReleaseNoteTemplate.yml
+++ b/release-notes/ReleaseNoteTemplate.yml
@@ -1,6 +1,6 @@
-issue_key: <github issue number> # e.g. #1234
+issue_key: <github issue number> # e.g. 1234
 show_in_stores: <boolean> # whether this note should be shown in the stores, either true or false
-platforms: # relevant platforms, possible values: web, android and ios
+platforms: # relevant platforms, possible values are android and ios
   - <platform1>
   - <platform2>
 en: <your note> # english version of the note


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
This just updates our template for the release notes to not include web as a platform anymore since we don't create release notes for them anymore. I also took the opportunity to remove `#` from the example GitHub issue (`1234` instead of `#1234`) that we don't use because it would turn the issue key into a comment.