### PR TITLE
Exclude iOS folder from IntelliJ search

### DIFF
--- a/.idea/integreat-app.iml
+++ b/.idea/integreat-app.iml
@@ -20,6 +20,7 @@
       <excludeFolder url="file://$MODULE_DIR$/native/ios/vendor" />
       <excludeFolder url="file://$MODULE_DIR$/native/vendor" />
       <excludeFolder url="file://$MODULE_DIR$/native/ios/Pods" />
+      <excludeFolder url="file://$MODULE_DIR$/native/ios/DerivedData" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Search results from the folder cluttered the search in IntelliJ, therefore mark it excluded.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Mark folder `native/ios/DerivedData` as excluded in IntelliJ

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
N/A

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: N/A

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
