### PR TITLE
Show PRs with maintenance label in maintenance section of release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -9,6 +9,8 @@ changelog:
       exclude:
         labels:
           - not-testable
+          - maintenance
     - title: Maintenance 🛠
       labels:
         - not-testable
+        - maintenance


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
There are cases where a PR is definitely a maintenance PR and should appear in the corresponding category in the release notes, but should still be tested, for example bigger dependency upgrades/replacements like #3393 or #3158.

I therefore added a new label `maintenance` whose PRs are also shown in the maintenance release notes section.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Show PRs with `maintenance` label in corresponding section in the release notes

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

Not sure if there are cases where a PR has the `not-testable` but not the `maintenance` label and in which category it should then be displayed 🤔 Perhaps we should not care about the `not-testable` label in the template at all.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
N/A

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: N/A

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
