### PR TITLE
3373: Mui divider

### DIFF
--- a/web/src/components/BottomActionSheet.tsx
+++ b/web/src/components/BottomActionSheet.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled'
+import Divider from '@mui/material/Divider'
 import React, { ReactElement, ReactNode, RefObject, useImperativeHandle, useRef, useState } from 'react'
 import { BottomSheet, BottomSheetRef } from 'react-spring-bottom-sheet'
 import 'react-spring-bottom-sheet/dist/style.css'
@@ -6,7 +7,6 @@ import { SpringEvent } from 'react-spring-bottom-sheet/dist/types'
 
 import { getSnapPoints } from '../utils/getSnapPoints'
 import { RichLayout } from './Layout'
-import Spacer from './Spacer'
 
 const Title = styled.h1`
   font-size: 1.25rem;
@@ -21,7 +21,7 @@ const ToolbarContainer = styled.div`
   margin-top: 16px;
 `
 
-const StyledSpacer = styled(Spacer)`
+const StyledSpacer = styled(Divider)`
   margin: 12px 30px;
 `
 

--- a/web/src/components/BottomActionSheet.tsx
+++ b/web/src/components/BottomActionSheet.tsx
@@ -1,4 +1,3 @@
-import { useTheme } from '@emotion/react'
 import styled from '@emotion/styled'
 import React, { ReactElement, ReactNode, RefObject, useImperativeHandle, useRef, useState } from 'react'
 import { BottomSheet, BottomSheetRef } from 'react-spring-bottom-sheet'
@@ -57,7 +56,6 @@ const BottomActionSheet = ({
   setBottomActionSheetHeight,
   ref,
 }: BottomActionSheetProps): ReactElement => {
-  const theme = useTheme()
   const [scrollElement, setScrollElement] = useState<HTMLElement | null>(null)
   const bottomSheetRef = useRef<BottomSheetRef>(null)
   useImperativeHandle(
@@ -92,7 +90,7 @@ const BottomActionSheet = ({
       <StyledLayout>
         {children}
         <ToolbarContainer>
-          <StyledSpacer borderColor={theme.colors.borderColor} />
+          <StyledSpacer />
           {toolbar}
         </ToolbarContainer>
       </StyledLayout>

--- a/web/src/components/CategoryListItem.tsx
+++ b/web/src/components/CategoryListItem.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled'
+import { Divider } from '@mui/material'
 import React, { ReactElement } from 'react'
 import { Link } from 'react-router-dom'
 
@@ -49,7 +50,6 @@ const StyledLink = styled(Link)`
   align-items: center;
   margin: 0 auto;
   width: inherit;
-  border-bottom: 1px solid ${props => props.theme.colors.themeColor};
 
   &:hover {
     color: inherit;
@@ -65,12 +65,13 @@ type CategoryListItemProps = {
 }
 
 const CategoryListItem = ({ category, subCategories }: CategoryListItemProps): ReactElement => {
-  const SubCategories = subCategories.map(subCategory => (
+  const SubCategories = subCategories.map((subCategory, index) => (
     <SubCategory key={subCategory.path} dir='auto'>
       <StyledLink to={subCategory.path}>
         {!!subCategory.thumbnail && <CategoryThumbnail alt='' src={subCategory.thumbnail} />}
         <SubCategoryCaption>{subCategory.title}</SubCategoryCaption>
       </StyledLink>
+      {index < subCategories.length - 1 && <Divider />}
     </SubCategory>
   ))
 
@@ -80,6 +81,7 @@ const CategoryListItem = ({ category, subCategories }: CategoryListItemProps): R
         {!!category.thumbnail && <CategoryThumbnail alt='' src={category.thumbnail} />}
         <CategoryItemCaption>{category.title}</CategoryItemCaption>
       </StyledLink>
+      <Divider />
       <SubCategoriesContainer>{SubCategories}</SubCategoriesContainer>
     </Row>
   )

--- a/web/src/components/CategoryListItem.tsx
+++ b/web/src/components/CategoryListItem.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import { Divider } from '@mui/material'
+import Divider from '@mui/material/Divider'
 import React, { ReactElement } from 'react'
 import { Link } from 'react-router-dom'
 
@@ -65,13 +65,13 @@ type CategoryListItemProps = {
 }
 
 const CategoryListItem = ({ category, subCategories }: CategoryListItemProps): ReactElement => {
-  const SubCategories = subCategories.map((subCategory, index) => (
+  const SubCategories = subCategories.map(subCategory => (
     <SubCategory key={subCategory.path} dir='auto'>
       <StyledLink to={subCategory.path}>
         {!!subCategory.thumbnail && <CategoryThumbnail alt='' src={subCategory.thumbnail} />}
         <SubCategoryCaption>{subCategory.title}</SubCategoryCaption>
       </StyledLink>
-      {index < subCategories.length - 1 && <Divider />}
+      <Divider />
     </SubCategory>
   ))
 

--- a/web/src/components/CityContentFooter.tsx
+++ b/web/src/components/CityContentFooter.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import { Divider } from '@mui/material'
+import Divider from '@mui/material/Divider'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 

--- a/web/src/components/CityContentFooter.tsx
+++ b/web/src/components/CityContentFooter.tsx
@@ -15,7 +15,7 @@ const SidebarFooterContainer = styled.div`
   margin-top: -10px; /* to counteract the padding-top of the normal footer */
   padding: 0 27px;
 
-  > *:not(hr) {
+  > a {
     color: ${props => props.theme.colors.textColor};
     padding: 16px 0;
     display: flex;

--- a/web/src/components/CityContentFooter.tsx
+++ b/web/src/components/CityContentFooter.tsx
@@ -1,10 +1,12 @@
 import styled from '@emotion/styled'
+import { Divider } from '@mui/material'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { DISCLAIMER_ROUTE, LICENSES_ROUTE, pathnameFromRouteInformation } from 'shared'
 
 import buildConfig from '../constants/buildConfig'
+import useWindowDimensions from '../hooks/useWindowDimensions'
 import Footer from './Footer'
 import Link from './base/Link'
 
@@ -13,17 +15,12 @@ const SidebarFooterContainer = styled.div`
   margin-top: -10px; /* to counteract the padding-top of the normal footer */
   padding: 0 27px;
 
-  > * {
+  > *:not(hr) {
     color: ${props => props.theme.colors.textColor};
     padding: 16px 0;
     display: flex;
     align-items: center;
     justify-content: center;
-    border-bottom: 1px solid ${props => props.theme.colors.footerLineColor};
-
-    &:last-child {
-      border-bottom: none;
-    }
   }
 `
 
@@ -34,6 +31,7 @@ type CityContentFooterProps = {
 }
 
 const CityContentFooter = ({ city, language, mode = 'normal' }: CityContentFooterProps): ReactElement => {
+  const { viewportSmall } = useWindowDimensions()
   const { aboutUrls, privacyUrls, accessibilityUrls } = buildConfig()
   const { t } = useTranslation(['layout', 'settings'])
   const aboutUrl = aboutUrls[language] || aboutUrls.default
@@ -48,13 +46,21 @@ const CityContentFooter = ({ city, language, mode = 'normal' }: CityContentFoote
     route: LICENSES_ROUTE,
   })
 
+  const linkItems = [
+    { to: disclaimerPath, text: t('imprintAndContact') },
+    { to: aboutUrl, text: t('settings:about', { appName: buildConfig().appName }) },
+    { to: privacyUrl, text: t('privacy') },
+    { to: licensesPath, text: t('settings:openSourceLicenses') },
+    ...(accessibilityUrl ? [{ to: accessibilityUrl, text: t('accessibility') }] : []),
+  ]
   const Links = (
     <>
-      <Link to={disclaimerPath}>{t('imprintAndContact')}</Link>
-      <Link to={aboutUrl}>{t('settings:about', { appName: buildConfig().appName })}</Link>
-      <Link to={privacyUrl}>{t('privacy')}</Link>
-      <Link to={licensesPath}>{t('settings:openSourceLicenses')}</Link>
-      {!!accessibilityUrl && <Link to={accessibilityUrl}>{t('accessibility')}</Link>}
+      {linkItems.map((item, index) => (
+        <React.Fragment key={item.to}>
+          <Link to={item.to}>{item.text}</Link>
+          {viewportSmall && index < linkItems.length - 1 && <Divider />}
+        </React.Fragment>
+      ))}
     </>
   )
 

--- a/web/src/components/CityContentHeader.tsx
+++ b/web/src/components/CityContentHeader.tsx
@@ -4,6 +4,7 @@ import MapOutlinedIcon from '@mui/icons-material/MapOutlined'
 import NewspaperOutlinedIcon from '@mui/icons-material/NewspaperOutlined'
 import SearchOutlinedIcon from '@mui/icons-material/SearchOutlined'
 import SignpostOutlinedIcon from '@mui/icons-material/SignpostOutlined'
+import { Divider } from '@mui/material'
 import React, { ReactElement, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -29,6 +30,13 @@ import HeaderNavigationItem, { HeaderNavigationItemProps } from './HeaderNavigat
 import KebabActionItem from './KebabActionItem'
 import LanguageSelector from './LanguageSelector'
 import Link from './base/Link'
+
+const KebabItemDivider = ({ children }: { children: ReactElement }): ReactElement => (
+  <>
+    {children}
+    <Divider />
+  </>
+)
 
 type CityContentHeaderProps = {
   cityModel: CityModel
@@ -85,17 +93,20 @@ const CityContentHeader = ({
       ]
 
   const kebabItems = [
-    <Link key='location' to={landingPath}>
-      <KebabActionItem text={t('changeLocation')} iconSrc={LocationOnOutlinedIcon} />
-    </Link>,
-    <LanguageSelector
-      key='language'
-      languageChangePaths={languageChangePaths}
-      isHeaderActionItem
-      languageCode={languageCode}
-      inKebabMenu
-      closeSidebar={() => setIsSidebarOpen(false)}
-    />,
+    <KebabItemDivider key='location'>
+      <Link to={landingPath}>
+        <KebabActionItem text={t('changeLocation')} iconSrc={LocationOnOutlinedIcon} />
+      </Link>
+    </KebabItemDivider>,
+    <KebabItemDivider key='language'>
+      <LanguageSelector
+        languageChangePaths={languageChangePaths}
+        isHeaderActionItem
+        languageCode={languageCode}
+        inKebabMenu
+        closeSidebar={() => setIsSidebarOpen(false)}
+      />
+    </KebabItemDivider>,
     <ContrastThemeToggle key='contrastTheme' />,
   ]
 

--- a/web/src/components/CityContentHeader.tsx
+++ b/web/src/components/CityContentHeader.tsx
@@ -4,7 +4,6 @@ import MapOutlinedIcon from '@mui/icons-material/MapOutlined'
 import NewspaperOutlinedIcon from '@mui/icons-material/NewspaperOutlined'
 import SearchOutlinedIcon from '@mui/icons-material/SearchOutlined'
 import SignpostOutlinedIcon from '@mui/icons-material/SignpostOutlined'
-import { Divider } from '@mui/material'
 import React, { ReactElement, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -30,13 +29,6 @@ import HeaderNavigationItem, { HeaderNavigationItemProps } from './HeaderNavigat
 import KebabActionItem from './KebabActionItem'
 import LanguageSelector from './LanguageSelector'
 import Link from './base/Link'
-
-const KebabItemDivider = ({ children }: { children: ReactElement }): ReactElement => (
-  <>
-    {children}
-    <Divider />
-  </>
-)
 
 type CityContentHeaderProps = {
   cityModel: CityModel
@@ -93,20 +85,17 @@ const CityContentHeader = ({
       ]
 
   const kebabItems = [
-    <KebabItemDivider key='location'>
-      <Link to={landingPath}>
-        <KebabActionItem text={t('changeLocation')} iconSrc={LocationOnOutlinedIcon} />
-      </Link>
-    </KebabItemDivider>,
-    <KebabItemDivider key='language'>
-      <LanguageSelector
-        languageChangePaths={languageChangePaths}
-        isHeaderActionItem
-        languageCode={languageCode}
-        inKebabMenu
-        closeSidebar={() => setIsSidebarOpen(false)}
-      />
-    </KebabItemDivider>,
+    <Link key='location' to={landingPath}>
+      <KebabActionItem text={t('changeLocation')} iconSrc={LocationOnOutlinedIcon} />
+    </Link>,
+    <LanguageSelector
+      key='language'
+      languageChangePaths={languageChangePaths}
+      isHeaderActionItem
+      languageCode={languageCode}
+      inKebabMenu
+      closeSidebar={() => setIsSidebarOpen(false)}
+    />,
     <ContrastThemeToggle key='contrastTheme' />,
   ]
 

--- a/web/src/components/CityNotCooperatingFooter.tsx
+++ b/web/src/components/CityNotCooperatingFooter.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled'
+import { Divider } from '@mui/material'
 import Button from '@mui/material/Button'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -15,7 +16,6 @@ const FooterContainer = styled.div`
   flex-direction: column;
   align-items: center;
   padding: 20px;
-  border-bottom: 2px solid ${props => props.theme.colors.footerLineColor};
 `
 
 const StyledIcon = styled(Icon)`
@@ -50,6 +50,7 @@ const CityNotCooperatingFooter = ({ languageCode }: CityNotCooperatingFooterProp
           {t('suggestToRegion', { appName: buildConfig().appName })}
         </Link>
       </Button>
+      <Divider />
     </FooterContainer>
   )
 }

--- a/web/src/components/CityNotCooperatingFooter.tsx
+++ b/web/src/components/CityNotCooperatingFooter.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
-import { Divider } from '@mui/material'
 import Button from '@mui/material/Button'
+import Divider from '@mui/material/Divider'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 

--- a/web/src/components/CitySelector.tsx
+++ b/web/src/components/CitySelector.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled'
+import { Divider, Typography } from '@mui/material'
 import React, { ReactElement, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -16,7 +17,7 @@ const Container = styled.div`
   padding-top: 22px;
 `
 
-export const CityListParent = styled.div<{ stickyTop: number }>`
+export const CityListParent = styled(Typography)<{ stickyTop: number }>`
   position: sticky;
   top: ${props => props.stickyTop}px;
   height: 30px;
@@ -24,7 +25,6 @@ export const CityListParent = styled.div<{ stickyTop: number }>`
   line-height: 30px;
   transition: top 0.2s ease-out;
   background-color: ${props => props.theme.colors.backgroundColor};
-  border-bottom: 1px solid ${props => props.theme.colors.themeColor};
 `
 
 const SearchCounter = styled.p`
@@ -49,7 +49,10 @@ const CitySelector = ({ cities, language }: CitySelectorProps): ReactElement => 
       {resultCities
         .filter(it => it.sortCategory === group)
         .map(city => (
-          <CityEntry key={city.code} city={city} language={language} filterText={filterText} />
+          <>
+            <Divider />
+            <CityEntry key={city.code} city={city} language={language} filterText={filterText} />
+          </>
         ))}
     </div>
   ))

--- a/web/src/components/CitySelector.tsx
+++ b/web/src/components/CitySelector.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled'
-import { Divider, Typography } from '@mui/material'
+import Divider from '@mui/material/Divider'
+import Typography from '@mui/material/Typography'
 import React, { ReactElement, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 

--- a/web/src/components/CitySelector.tsx
+++ b/web/src/components/CitySelector.tsx
@@ -71,6 +71,7 @@ const CitySelector = ({ cities, language }: CitySelectorProps): ReactElement => 
           {t('search:searchResultsCount', { count: resultCities.length })}
         </SearchCounter>
         <NearbyCities stickyTop={stickyTop} cities={cities} language={language} filterText={filterText} />
+        <Divider />
         {resultCities.length === 0 ? <Failure errorMessage='search:nothingFound' /> : groups}
       </ScrollingSearchBox>
     </Container>

--- a/web/src/components/CitySelector.tsx
+++ b/web/src/components/CitySelector.tsx
@@ -50,10 +50,10 @@ const CitySelector = ({ cities, language }: CitySelectorProps): ReactElement => 
       {resultCities
         .filter(it => it.sortCategory === group)
         .map(city => (
-          <>
+          <React.Fragment key={city.code}>
             <Divider />
-            <CityEntry key={city.code} city={city} language={language} filterText={filterText} />
-          </>
+            <CityEntry city={city} language={language} filterText={filterText} />
+          </React.Fragment>
         ))}
     </div>
   ))

--- a/web/src/components/Collapsible.tsx
+++ b/web/src/components/Collapsible.tsx
@@ -26,6 +26,7 @@ const Title = styled.div`
   font-weight: 700;
   justify-content: space-between;
   ${helpers.adaptiveFontSize}
+  align-items: center;
 `
 
 const CollapseIcon = styled(Icon)`

--- a/web/src/components/ConsentSection.tsx
+++ b/web/src/components/ConsentSection.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled'
+import { Divider } from '@mui/material'
 import React, { ReactElement } from 'react'
 
 import Checkbox from './base/Checkbox'
@@ -6,13 +7,6 @@ import Checkbox from './base/Checkbox'
 const Container = styled.div`
   flex-direction: row;
   padding: 16px 0;
-`
-
-const Divider = styled.hr`
-  background-color: ${props => props.theme.colors.borderColor};
-  height: 1px;
-  border: none;
-  margin: 0;
 `
 
 type ConsentSectionProps = {

--- a/web/src/components/ConsentSection.tsx
+++ b/web/src/components/ConsentSection.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import { Divider } from '@mui/material'
+import Divider from '@mui/material/Divider'
 import React, { ReactElement } from 'react'
 
 import Checkbox from './base/Checkbox'

--- a/web/src/components/Contact.tsx
+++ b/web/src/components/Contact.tsx
@@ -1,4 +1,3 @@
-import { useTheme } from '@emotion/react'
 import styled from '@emotion/styled'
 import MailOutlinedIcon from '@mui/icons-material/MailOutlined'
 import OpenInNewIcon from '@mui/icons-material/OpenInNew'
@@ -26,7 +25,6 @@ const Contact = ({
   isLastContact?: boolean
 }): ReactElement => {
   const { t } = useTranslation('pois')
-  const theme = useTheme()
 
   return (
     <>
@@ -59,7 +57,7 @@ const Contact = ({
       {!!email && (
         <ContactItem iconSource={MailOutlinedIcon} iconAlt={t('eMail')} link={`mailto:${email}`} content={email} />
       )}
-      {!isLastContact && <Spacer borderColor={theme.colors.borderColor} />}
+      {!isLastContact && <Spacer />}
     </>
   )
 }

--- a/web/src/components/Contact.tsx
+++ b/web/src/components/Contact.tsx
@@ -3,6 +3,7 @@ import MailOutlinedIcon from '@mui/icons-material/MailOutlined'
 import OpenInNewIcon from '@mui/icons-material/OpenInNew'
 import PhoneOutlinedIcon from '@mui/icons-material/PhoneOutlined'
 import PublicOutlinedIcon from '@mui/icons-material/PublicOutlined'
+import Divider from '@mui/material/Divider'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -10,7 +11,6 @@ import { ContactModel } from 'shared/api'
 
 import { helpers } from '../constants/theme'
 import ContactItem from './ContactItem'
-import Spacer from './Spacer'
 
 const StyledContactHeader = styled.div`
   margin-bottom: 6px;
@@ -57,7 +57,7 @@ const Contact = ({
       {!!email && (
         <ContactItem iconSource={MailOutlinedIcon} iconAlt={t('eMail')} link={`mailto:${email}`} content={email} />
       )}
-      {!isLastContact && <Spacer />}
+      {!isLastContact && <Divider style={{ margin: '12px 0' }} />}
     </>
   )
 }

--- a/web/src/components/Contact.tsx
+++ b/web/src/components/Contact.tsx
@@ -17,6 +17,10 @@ const StyledContactHeader = styled.div`
   ${helpers.adaptiveFontSize};
 `
 
+const StyledDivider = styled(Divider)`
+  margin: 12px 0;
+`
+
 const Contact = ({
   contact: { headline, website, phoneNumber, email, mobilePhoneNumber },
   isLastContact,
@@ -57,7 +61,7 @@ const Contact = ({
       {!!email && (
         <ContactItem iconSource={MailOutlinedIcon} iconAlt={t('eMail')} link={`mailto:${email}`} content={email} />
       )}
-      {!isLastContact && <Divider style={{ margin: '12px 0' }} />}
+      {!isLastContact && <StyledDivider />}
     </>
   )
 }

--- a/web/src/components/GoBack.tsx
+++ b/web/src/components/GoBack.tsx
@@ -43,6 +43,10 @@ const StyledIcon = styled(Icon)`
   width: 24px;
 `
 
+const StyledDivider = styled(Divider)`
+  margin: 12px 0;
+`
+
 type GoBackProps = {
   text: string
   goBack: () => void
@@ -55,7 +59,7 @@ const GoBack = ({ goBack, viewportSmall = false, text }: GoBackProps): ReactElem
       <StyledIcon src={ArrowBackIcon} directionDependent />
       <DetailsHeaderTitle>{text}</DetailsHeaderTitle>
     </StyledButton>
-    <Divider style={{ margin: '12px 0' }} />
+    <StyledDivider />
   </>
 )
 

--- a/web/src/components/GoBack.tsx
+++ b/web/src/components/GoBack.tsx
@@ -1,4 +1,4 @@
-import { css, useTheme } from '@emotion/react'
+import { css } from '@emotion/react'
 import styled from '@emotion/styled'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import React, { memo, ReactElement } from 'react'
@@ -49,17 +49,14 @@ type GoBackProps = {
   viewportSmall?: boolean
 }
 
-const GoBack = ({ goBack, viewportSmall = false, text }: GoBackProps): ReactElement => {
-  const theme = useTheme()
-  return (
-    <>
-      <StyledButton onClick={goBack} label={text} tabIndex={0} viewportSmall={viewportSmall}>
-        <StyledIcon src={ArrowBackIcon} directionDependent />
-        <DetailsHeaderTitle>{text}</DetailsHeaderTitle>
-      </StyledButton>
-      <Spacer borderColor={theme.colors.borderColor} />
-    </>
-  )
-}
+const GoBack = ({ goBack, viewportSmall = false, text }: GoBackProps): ReactElement => (
+  <>
+    <StyledButton onClick={goBack} label={text} tabIndex={0} viewportSmall={viewportSmall}>
+      <StyledIcon src={ArrowBackIcon} directionDependent />
+      <DetailsHeaderTitle>{text}</DetailsHeaderTitle>
+    </StyledButton>
+    <Spacer />
+  </>
+)
 
 export default memo(GoBack)

--- a/web/src/components/GoBack.tsx
+++ b/web/src/components/GoBack.tsx
@@ -1,10 +1,10 @@
 import { css } from '@emotion/react'
 import styled from '@emotion/styled'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
+import Divider from '@mui/material/Divider'
 import React, { memo, ReactElement } from 'react'
 
 import { helpers } from '../constants/theme'
-import Spacer from './Spacer'
 import Button from './base/Button'
 import Icon from './base/Icon'
 
@@ -55,7 +55,7 @@ const GoBack = ({ goBack, viewportSmall = false, text }: GoBackProps): ReactElem
       <StyledIcon src={ArrowBackIcon} directionDependent />
       <DetailsHeaderTitle>{text}</DetailsHeaderTitle>
     </StyledButton>
-    <Spacer />
+    <Divider style={{ margin: '12px 0' }} />
   </>
 )
 

--- a/web/src/components/KebabActionItem.tsx
+++ b/web/src/components/KebabActionItem.tsx
@@ -9,7 +9,6 @@ const Container = styled.span`
   flex: 1;
   text-decoration: none;
   padding: 24px 0;
-  border-bottom: 1px solid ${props => props.theme.colors.themeColor};
 
   & > span {
     padding: 0 28px;

--- a/web/src/components/KebabMenu.tsx
+++ b/web/src/components/KebabMenu.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled'
 import CloseIcon from '@mui/icons-material/Close'
 import MoreVertIcon from '@mui/icons-material/MoreVert'
+import Divider from '@mui/material/Divider'
 import IconButton from '@mui/material/IconButton'
 import React, { ReactElement, ReactNode, useLayoutEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -114,7 +115,14 @@ const KebabMenu = ({ items, show, setShow, Footer }: KebabMenuProps): ReactEleme
               </IconButton>
             </ActionBar>
           </Heading>
-          <Content>{items}</Content>
+          <Content>
+            {items.map((item, index) => (
+              <React.Fragment key={`menu-item-${index + 1}`}>
+                {item}
+                {index < items.length - 1 && <Divider />}
+              </React.Fragment>
+            ))}
+          </Content>
           {Footer}
         </List>
       </Portal>

--- a/web/src/components/List.tsx
+++ b/web/src/components/List.tsx
@@ -1,9 +1,6 @@
 import styled from '@emotion/styled'
+import { Divider } from '@mui/material'
 import React, { ReactNode } from 'react'
-
-const StyledList = styled.div<{ borderless: boolean }>`
-  border-top: 2px solid ${props => (props.borderless ? 'transparent' : props.theme.colors.themeColor)};
-`
 
 const NoItemsMessage = styled.div`
   padding-top: 25px;
@@ -24,7 +21,12 @@ class List<T> extends React.PureComponent<ListProps<T>> {
       return <NoItemsMessage>{noItemsMessage}</NoItemsMessage>
     }
 
-    return <StyledList borderless={borderless}>{items.map(renderItem)}</StyledList>
+    return (
+      <div>
+        {!borderless && <Divider />}
+        {items.map(renderItem)}
+      </div>
+    )
   }
 }
 

--- a/web/src/components/List.tsx
+++ b/web/src/components/List.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import { Divider } from '@mui/material'
+import Divider from '@mui/material/Divider'
 import React, { ReactNode } from 'react'
 
 const NoItemsMessage = styled.div`

--- a/web/src/components/ListItem.tsx
+++ b/web/src/components/ListItem.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import { Divider } from '@mui/material'
+import Divider from '@mui/material/Divider'
 import React, { ReactElement, ReactNode } from 'react'
 
 import Link from './base/Link'

--- a/web/src/components/ListItem.tsx
+++ b/web/src/components/ListItem.tsx
@@ -1,10 +1,10 @@
 import styled from '@emotion/styled'
+import { Divider } from '@mui/material'
 import React, { ReactElement, ReactNode } from 'react'
 
 import Link from './base/Link'
 
 const ListItemContainer = styled.article`
-  border-bottom: 2px solid ${props => props.theme.colors.themeColor};
   display: flex;
 `
 
@@ -53,18 +53,21 @@ type ListItemProps = {
 }
 
 const ListItem = ({ path, title, thumbnail, thumbnailSize, children, Icon }: ListItemProps): ReactElement => (
-  <ListItemContainer dir='auto'>
-    <FullWidthLink to={path}>
-      {!!thumbnail && <Thumbnail alt='' src={thumbnail} thumbnailSize={thumbnailSize} />}
-      <Description>
-        <TitleRow>
-          <Title>{title}</Title>
-          {Icon}
-        </TitleRow>
-        {children}
-      </Description>
-    </FullWidthLink>
-  </ListItemContainer>
+  <>
+    <ListItemContainer dir='auto'>
+      <FullWidthLink to={path}>
+        {!!thumbnail && <Thumbnail alt='' src={thumbnail} thumbnailSize={thumbnailSize} />}
+        <Description>
+          <TitleRow>
+            <Title>{title}</Title>
+            {Icon}
+          </TitleRow>
+          {children}
+        </Description>
+      </FullWidthLink>
+    </ListItemContainer>
+    <Divider />
+  </>
 )
 
 export default ListItem

--- a/web/src/components/NearbyCities.tsx
+++ b/web/src/components/NearbyCities.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import RefreshIcon from '@mui/icons-material/Refresh'
-import { Divider } from '@mui/material'
+import Divider from '@mui/material/Divider'
 import IconButton from '@mui/material/IconButton'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'

--- a/web/src/components/NearbyCities.tsx
+++ b/web/src/components/NearbyCities.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled'
 import RefreshIcon from '@mui/icons-material/Refresh'
+import { Divider } from '@mui/material'
 import IconButton from '@mui/material/IconButton'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -46,7 +47,12 @@ const NearbyCities = ({ cities, language, filterText, stickyTop }: NearbyCitiesP
     <div>
       <CityListParent stickyTop={stickyTop}>{t('nearbyCities')}</CityListParent>
       {nearbyCities.length > 0 ? (
-        nearbyCities.map(city => <CityEntry key={city.code} city={city} language={language} filterText={filterText} />)
+        nearbyCities.map(city => (
+          <>
+            <Divider />
+            <CityEntry key={city.code} city={city} language={language} filterText={filterText} />
+          </>
+        ))
       ) : (
         <NearbyMessageContainer>
           <NearbyMessage>{userLocation ? t('noNearbyCities') : t('locationError')}</NearbyMessage>

--- a/web/src/components/NearbyCities.tsx
+++ b/web/src/components/NearbyCities.tsx
@@ -48,10 +48,10 @@ const NearbyCities = ({ cities, language, filterText, stickyTop }: NearbyCitiesP
       <CityListParent stickyTop={stickyTop}>{t('nearbyCities')}</CityListParent>
       {nearbyCities.length > 0 ? (
         nearbyCities.map(city => (
-          <>
+          <React.Fragment key={city.code}>
             <Divider />
             <CityEntry key={city.code} city={city} language={language} filterText={filterText} />
-          </>
+          </React.Fragment>
         ))
       ) : (
         <NearbyMessageContainer>

--- a/web/src/components/NewsListItem.tsx
+++ b/web/src/components/NewsListItem.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import { Divider } from '@mui/material'
+import Divider from '@mui/material/Divider'
 import { TFunction } from 'i18next'
 import { DateTime } from 'luxon'
 import React, { ReactElement } from 'react'

--- a/web/src/components/NewsListItem.tsx
+++ b/web/src/components/NewsListItem.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled'
+import { Divider } from '@mui/material'
 import { TFunction } from 'i18next'
 import { DateTime } from 'luxon'
 import React, { ReactElement } from 'react'
@@ -36,7 +37,6 @@ const Body = styled.p`
 
 const StyledNewsListItem = styled.article`
   padding-bottom: 2px;
-  border-bottom: 1px solid ${({ theme }) => theme.colors.textSecondaryColor};
 `
 
 const StyledContainer = styled.div`
@@ -70,6 +70,7 @@ const NewsListItem = ({ title, content, timestamp, t, type, link }: NewsListItem
           </StyledContainer>
         </Description>
       </StyledLink>
+      <Divider />
     </StyledNewsListItem>
   )
 }

--- a/web/src/components/PoiDetails.tsx
+++ b/web/src/components/PoiDetails.tsx
@@ -1,4 +1,3 @@
-import { useTheme } from '@emotion/react'
 import styled from '@emotion/styled'
 import LocationOnOutlinedIcon from '@mui/icons-material/LocationOnOutlined'
 import OpenInNewIcon from '@mui/icons-material/OpenInNew'
@@ -129,7 +128,6 @@ type PoiDetailsProps = {
 
 const PoiDetails = ({ poi, distance, toolbar }: PoiDetailsProps): ReactElement => {
   const { viewportSmall } = useWindowDimensions()
-  const theme = useTheme()
   const { t } = useTranslation('pois')
   const { content, location, contacts, isCurrentlyOpen, openingHours, temporarilyClosed, appointmentUrl } = poi
 
@@ -145,7 +143,7 @@ const PoiDetails = ({ poi, distance, toolbar }: PoiDetailsProps): ReactElement =
         {distance !== null && <Distance>{t('distanceKilometre', { distance: distance.toFixed(1) })}</Distance>}
         <PoiChips poi={poi} />
       </HeadingSection>
-      <Spacer borderColor={theme.colors.borderColor} />
+      <Spacer />
       {!viewportSmall && <Subheading>{t('detailsAddress')}</Subheading>}
       <DetailSection>
         <AddressContentWrapper>
@@ -164,7 +162,7 @@ const PoiDetails = ({ poi, distance, toolbar }: PoiDetailsProps): ReactElement =
       </DetailSection>
       {contacts.length > 0 && (
         <>
-          <Spacer borderColor={theme.colors.borderColor} />
+          <Spacer />
           <StyledCollapsible title={t('contacts')}>
             <StyledContactsContainer>
               {contacts.map((contact, index) => (
@@ -178,7 +176,7 @@ const PoiDetails = ({ poi, distance, toolbar }: PoiDetailsProps): ReactElement =
       )}
       {((openingHours && openingHours.length > 0) || temporarilyClosed || !!appointmentUrl) && (
         <>
-          <Spacer borderColor={theme.colors.borderColor} />
+          <Spacer />
           <OpeningHours
             openingHours={openingHours}
             isCurrentlyOpen={isCurrentlyOpen}
@@ -190,7 +188,7 @@ const PoiDetails = ({ poi, distance, toolbar }: PoiDetailsProps): ReactElement =
 
       {content.length > 0 && (
         <>
-          <Spacer borderColor={theme.colors.borderColor} />
+          <Spacer />
           <Collapsible title={t('detailsInformation')}>
             <RemoteContent html={content} smallText />
           </Collapsible>
@@ -198,7 +196,7 @@ const PoiDetails = ({ poi, distance, toolbar }: PoiDetailsProps): ReactElement =
       )}
       {toolbar && (
         <>
-          <Spacer borderColor={theme.colors.borderColor} />
+          <Spacer />
           <ToolbarWrapper>{toolbar}</ToolbarWrapper>
         </>
       )}

--- a/web/src/components/PoiDetails.tsx
+++ b/web/src/components/PoiDetails.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled'
 import LocationOnOutlinedIcon from '@mui/icons-material/LocationOnOutlined'
 import OpenInNewIcon from '@mui/icons-material/OpenInNew'
+import Divider from '@mui/material/Divider'
 import React, { Fragment, ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -15,9 +16,12 @@ import Contact from './Contact'
 import OpeningHours from './OpeningHours'
 import PoiChips from './PoiChips'
 import RemoteContent from './RemoteContent'
-import Spacer from './Spacer'
 import Icon from './base/Icon'
 import Link from './base/Link'
+
+const StyledDivider = styled(Divider)`
+  margin: 12px 0;
+`
 
 const DetailsContainer = styled.div`
   font-family: ${props => props.theme.fonts.web.contentFont};
@@ -143,7 +147,7 @@ const PoiDetails = ({ poi, distance, toolbar }: PoiDetailsProps): ReactElement =
         {distance !== null && <Distance>{t('distanceKilometre', { distance: distance.toFixed(1) })}</Distance>}
         <PoiChips poi={poi} />
       </HeadingSection>
-      <Spacer />
+      <StyledDivider />
       {!viewportSmall && <Subheading>{t('detailsAddress')}</Subheading>}
       <DetailSection>
         <AddressContentWrapper>
@@ -162,7 +166,7 @@ const PoiDetails = ({ poi, distance, toolbar }: PoiDetailsProps): ReactElement =
       </DetailSection>
       {contacts.length > 0 && (
         <>
-          <Spacer />
+          <StyledDivider />
           <StyledCollapsible title={t('contacts')}>
             <StyledContactsContainer>
               {contacts.map((contact, index) => (
@@ -176,7 +180,7 @@ const PoiDetails = ({ poi, distance, toolbar }: PoiDetailsProps): ReactElement =
       )}
       {((openingHours && openingHours.length > 0) || temporarilyClosed || !!appointmentUrl) && (
         <>
-          <Spacer />
+          <StyledDivider />
           <OpeningHours
             openingHours={openingHours}
             isCurrentlyOpen={isCurrentlyOpen}
@@ -188,7 +192,7 @@ const PoiDetails = ({ poi, distance, toolbar }: PoiDetailsProps): ReactElement =
 
       {content.length > 0 && (
         <>
-          <Spacer />
+          <StyledDivider />
           <Collapsible title={t('detailsInformation')}>
             <RemoteContent html={content} smallText />
           </Collapsible>
@@ -196,7 +200,7 @@ const PoiDetails = ({ poi, distance, toolbar }: PoiDetailsProps): ReactElement =
       )}
       {toolbar && (
         <>
-          <Spacer />
+          <StyledDivider />
           <ToolbarWrapper>{toolbar}</ToolbarWrapper>
         </>
       )}

--- a/web/src/components/PoiListItem.tsx
+++ b/web/src/components/PoiListItem.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled'
+import { Divider } from '@mui/material'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -12,14 +13,7 @@ const ListItemContainer = styled.ul`
   font-family: ${props => props.theme.fonts.web.contentFont};
   display: flex;
   padding: clamp(10px, 1vh, 20px) 0;
-  border-bottom: 1px solid ${props => props.theme.colors.borderColor};
   cursor: pointer;
-
-  ${props => props.theme.breakpoints.down('md')} {
-    &:last-child {
-      border-bottom: none;
-    }
-  }
 
   &:first-of-type {
     padding-top: 0;
@@ -79,16 +73,19 @@ const PoiListItem = ({ poi, distance, selectPoi }: PoiListItemProps): ReactEleme
   const { thumbnail, title, category, slug } = poi
 
   return (
-    <ListItemContainer id={slug}>
-      <LinkContainer onClick={selectPoi} tabIndex={0} label={title}>
-        <Thumbnail alt='' src={thumbnail || PoiThumbnailPlaceholder} />
-        <Description>
-          <Title>{title}</Title>
-          {distance !== null && <Distance>{t('distanceKilometre', { distance: distance.toFixed(1) })}</Distance>}
-          <Category>{category.name}</Category>
-        </Description>
-      </LinkContainer>
-    </ListItemContainer>
+    <>
+      <ListItemContainer id={slug}>
+        <LinkContainer onClick={selectPoi} tabIndex={0} label={title}>
+          <Thumbnail alt='' src={thumbnail || PoiThumbnailPlaceholder} />
+          <Description>
+            <Title>{title}</Title>
+            {distance !== null && <Distance>{t('distanceKilometre', { distance: distance.toFixed(1) })}</Distance>}
+            <Category>{category.name}</Category>
+          </Description>
+        </LinkContainer>
+      </ListItemContainer>
+      <Divider sx={{ '&:last-child': { display: 'none' } }} />
+    </>
   )
 }
 

--- a/web/src/components/PoiListItem.tsx
+++ b/web/src/components/PoiListItem.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import { Divider } from '@mui/material'
+import Divider from '@mui/material/Divider'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 

--- a/web/src/components/PoisDesktop.tsx
+++ b/web/src/components/PoisDesktop.tsx
@@ -46,7 +46,6 @@ const ListHeader = styled.div`
   font-family: ${props => props.theme.fonts.web.decorativeFont};
   line-height: ${props => props.theme.fonts.decorativeLineHeight};
   font-weight: 600;
-  border-bottom: 1px solid ${props => props.theme.colors.borderColor};
   margin-bottom: clamp(10px, 1vh, 20px);
 `
 

--- a/web/src/components/SearchListItem.tsx
+++ b/web/src/components/SearchListItem.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled'
+import { Divider } from '@mui/material'
 import React, { ReactElement } from 'react'
 import { Link } from 'react-router-dom'
 
@@ -45,7 +46,6 @@ const StyledLink = styled(Link)`
   display: inline-flex;
   margin: 0 auto;
   width: inherit;
-  border-bottom: 1px solid ${props => props.theme.colors.themeColor};
 
   &:hover {
     color: inherit;
@@ -79,6 +79,7 @@ const SearchListItem = ({ title, contentWithoutHtml, query, path, thumbnail }: S
           </div>
         </CategoryItemContainer>
       </StyledLink>
+      <Divider />
     </Row>
   )
 }

--- a/web/src/components/SearchListItem.tsx
+++ b/web/src/components/SearchListItem.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import { Divider } from '@mui/material'
+import Divider from '@mui/material/Divider'
 import React, { ReactElement } from 'react'
 import { Link } from 'react-router-dom'
 

--- a/web/src/components/Spacer.tsx
+++ b/web/src/components/Spacer.tsx
@@ -1,7 +1,8 @@
 import styled from '@emotion/styled'
+import { Divider } from '@mui/material'
 
-const Spacer = styled.hr<{ borderColor: string }>`
+const Spacer = styled(Divider)`
   margin: 12px 0;
-  border: 1px solid ${props => props.borderColor};
 `
+
 export default Spacer

--- a/web/src/components/Spacer.tsx
+++ b/web/src/components/Spacer.tsx
@@ -1,8 +1,0 @@
-import styled from '@emotion/styled'
-import { Divider } from '@mui/material'
-
-const Spacer = styled(Divider)`
-  margin: 12px 0;
-`
-
-export default Spacer

--- a/web/src/components/Toolbar.tsx
+++ b/web/src/components/Toolbar.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react'
 import styled from '@emotion/styled'
+import { Divider } from '@mui/material'
 import React, { ReactElement, ReactNode } from 'react'
 
 import useWindowDimensions from '../hooks/useWindowDimensions'
@@ -41,13 +42,6 @@ const ToolbarContainer = styled.div<{ direction: 'row' | 'column'; hasPadding: b
   }
 `
 
-const Divider = styled.hr`
-  margin: 12px 24px;
-  background-color: ${props => props.theme.colors.borderColor};
-  height: 1px;
-  border: none;
-`
-
 type ToolbarProps = {
   className?: string
   children?: ReactNode
@@ -65,7 +59,7 @@ const Toolbar: React.FC<ToolbarProps> = ({
   const hasPadding = iconDirection === 'column'
   return (
     <Container as={viewportSmall ? 'footer' : 'div'}>
-      {viewportSmall && !hideDivider && <Divider />}
+      {viewportSmall && !hideDivider && <Divider variant='middle' />}
       <ToolbarContainer className={className} direction={iconDirection} hasPadding={hasPadding}>
         {children}
       </ToolbarContainer>

--- a/web/src/components/Toolbar.tsx
+++ b/web/src/components/Toolbar.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react'
 import styled from '@emotion/styled'
-import { Divider } from '@mui/material'
+import Divider from '@mui/material/Divider'
 import React, { ReactElement, ReactNode } from 'react'
 
 import useWindowDimensions from '../hooks/useWindowDimensions'


### PR DESCRIPTION
### Short Description
We currently have a few places where we make a divider line (e.g. the Toolbar and the ConsentSection). Let's instead use the one that Mui offers out of the box


### Proposed Changes

- Replaced the following with Mui divider :
   - hr components.
   - Any `border-bottom` that used for creating a divider except the ones at `RemoteContentSandBox.tsx` and `SharingPopup.tsx`.
   - At Spacer.tsx.
- In some cases I had to wrap the whole components with fragment. (the divider is allergic to flex containers).
- At `CityContentHeader.tsx` I used `KebabItemDivider` it could sound unnecessary instead of remapping it again with divider.


### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- This could affect alot of lists and components check test section for what to test 👇️

### Testing
- Test the following components/pages:
   - Poi lists.
   - toolbar.
   - Contact details.
   - Consent section.
   - News
   - City selector page/list.
   - Nearby cities.
   - CityNotCooperatingFooter.
   - CityContentFooter.
   - Lists.
 You can open https://integreat.app to make comparisons and don't forget to check mobile screens.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3373

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
