### PR TITLE
Fix delivery by force clearing the yarn cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,14 +163,14 @@ commands:
         steps:
             - restore_cache:
                 keys:
-                    - 8-yarn-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum "package.json" }}-{{ checksum "native/package.json" }}-{{ checksum "web/package.json" }}
-                    - 8-yarn-{{ arch }}-
+                    - 9-yarn-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum "package.json" }}-{{ checksum "native/package.json" }}-{{ checksum "web/package.json" }}
+                    - 9-yarn-{{ arch }}-
                 name: Restore Yarn Package Cache
             - run:
                 command: yarn --frozen-lockfile --cache-folder ~/.cache/yarn
                 name: Yarn
             - save_cache:
-                key: 8-yarn-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum "package.json" }}-{{ checksum "native/package.json" }}-{{ checksum "web/package.json" }}
+                key: 9-yarn-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum "package.json" }}-{{ checksum "native/package.json" }}-{{ checksum "web/package.json" }}
                 name: Save Yarn Package Cache
                 paths:
                     - ~/.cache/yarn

--- a/.circleci/src/commands/restore_yarn_cache.yml
+++ b/.circleci/src/commands/restore_yarn_cache.yml
@@ -3,14 +3,14 @@ steps:
   - restore_cache:
       name: Restore Yarn Package Cache
       keys:
-        - 8-yarn-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum "package.json" }}-{{ checksum "native/package.json" }}-{{ checksum "web/package.json" }}
-        - 8-yarn-{{ arch }}-
+        - 9-yarn-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum "package.json" }}-{{ checksum "native/package.json" }}-{{ checksum "web/package.json" }}
+        - 9-yarn-{{ arch }}-
   - run:
       name: Yarn
       command: yarn --frozen-lockfile --cache-folder ~/.cache/yarn
   - save_cache:
       name: Save Yarn Package Cache
-      key: 8-yarn-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum "package.json" }}-{{ checksum "native/package.json" }}-{{ checksum "web/package.json" }}
+      key: 9-yarn-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum "package.json" }}-{{ checksum "native/package.json" }}-{{ checksum "web/package.json" }}
       paths:
         - ~/.cache/yarn
         - node_modules


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
The delivery is failing and my guess is that it's because of some caching issue, especially since this is the first delivery since the RN-upgrade was merged.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Force clean the yarn cache

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Run another delivery after this is merged

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
