### PR TITLE
3423: Fix safe area for absolute elements

### DIFF
--- a/native/src/components/SnackbarContainer.tsx
+++ b/native/src/components/SnackbarContainer.tsx
@@ -1,11 +1,13 @@
 import React, { createContext, ReactElement, useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Animated, View, LayoutChangeEvent } from 'react-native'
+import { Animated, LayoutChangeEvent } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 import styled from 'styled-components/native'
 
 import Snackbar, { SnackbarActionType } from '../components/Snackbar'
 
-const Container = styled(View)`
+const Container = styled(SafeAreaView)`
+  background-color: ${props => props.theme.colors.textSecondaryColor};
   position: absolute;
   bottom: 0;
   left: 0;
@@ -83,6 +85,7 @@ const SnackbarContainer = ({ children }: SnackbarContainerProps): ReactElement |
       {displayedSnackbar ? (
         <AnimatedContainer
           onLayout={onLayout}
+          edges={['bottom']}
           style={{
             transform: [
               {

--- a/native/src/components/TtsPlayer.tsx
+++ b/native/src/components/TtsPlayer.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import styled, { css } from 'styled-components/native'
 
 import { CloseIcon, PauseIcon, PlaybackIcon, PlayIcon } from '../assets'
@@ -16,7 +17,8 @@ const elevatedStyle = css`
   elevation: 5;
 `
 
-const StyledTtsPlayer = styled.View<{ $isPlaying: boolean }>`
+const extraBottomMargin = 8
+const StyledTtsPlayer = styled.View<{ $isPlaying: boolean; bottom: number }>`
   background-color: ${props => props.theme.colors.ttsPlayerBackground};
   border-radius: 28px;
   width: ${props => (props.$isPlaying ? '90%' : '80%')};
@@ -26,9 +28,10 @@ const StyledTtsPlayer = styled.View<{ $isPlaying: boolean }>`
   align-items: center;
   align-self: center;
   position: absolute;
-  bottom: 5px;
-  min-height: 93px;
+  bottom: ${props => props.bottom + extraBottomMargin}px;
+  min-height: 112px;
   gap: ${props => (props.$isPlaying ? '0px;' : '20px')};
+  padding: 8px;
   ${elevatedStyle}
 `
 
@@ -118,9 +121,10 @@ const TtsPlayer = ({
   title,
   disabled,
 }: TtsPlayerProps): ReactElement => {
+  const { bottom } = useSafeAreaInsets()
   const { t } = useTranslation('layout')
   return (
-    <StyledTtsPlayer $isPlaying={isPlaying}>
+    <StyledTtsPlayer $isPlaying={isPlaying} bottom={bottom}>
       <StyledPanel $isPlaying={isPlaying}>
         {isPlaying && (
           <StyledBackForthButton role='button' accessibilityLabel={t('previous')} onPress={playPrevious}>

--- a/native/src/components/__tests__/SnackbarContainer.spec.tsx
+++ b/native/src/components/__tests__/SnackbarContainer.spec.tsx
@@ -1,10 +1,13 @@
-import { act, render } from '@testing-library/react-native'
+import { act } from '@testing-library/react-native'
 import React, { useContext } from 'react'
+import mockSafeAreaContext from 'react-native-safe-area-context/jest/mock'
 
+import renderWithTheme from '../../testing/render'
 import SnackbarContainer, { SnackbarContext } from '../SnackbarContainer'
 
 jest.useFakeTimers()
 
+jest.mock('react-native-safe-area-context', () => mockSafeAreaContext)
 jest.mock('react-i18next')
 jest.mock('../../components/Snackbar', () => {
   const { Text } = require('react-native')
@@ -34,7 +37,7 @@ describe('SnackbarContainer', () => {
   it('should show a snackbar if included in the state', () => {
     const snackbarText1 = 'snackbarText1'
     const snackbarText2 = 'snackbarText2'
-    const { update, queryByText } = render(<MockComponentWithSnackbar />)
+    const { update, queryByText } = renderWithTheme(<MockComponentWithSnackbar />, false)
     expect(queryByText(snackbarText1)).toBeFalsy()
     expect(queryByText(snackbarText2)).toBeFalsy()
 

--- a/native/src/components/__tests__/TtsContainer.spec.tsx
+++ b/native/src/components/__tests__/TtsContainer.spec.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, RenderAPI, waitFor } from '@testing-library/react-native'
 import { mocked } from 'jest-mock'
 import React, { useContext } from 'react'
+import mockSafeAreaContext from 'react-native-safe-area-context/jest/mock'
 import Tts from 'react-native-tts'
 
 import buildConfig from '../../constants/buildConfig'
@@ -11,6 +12,7 @@ import TtsContainer, { TtsContext } from '../TtsContainer'
 import Text from '../base/Text'
 import TextButton from '../base/TextButton'
 
+jest.mock('react-native-safe-area-context', () => mockSafeAreaContext)
 jest.mock('react-i18next')
 jest.mock('react-native-tts')
 jest.mock('../../hooks/useSnackbar')


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Fix safe area for absolute elements.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Fix the safe area view for snackbar
- Fix the safe area view for tts player

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Check the tts player and the snackbar on different devices.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3423 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
