### PR TITLE
Remove deprecated ts-jest config option

### DIFF
--- a/native/jest.config.ts
+++ b/native/jest.config.ts
@@ -28,7 +28,7 @@ export default {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   transform: {
     '^.+\\.jsx?$': ['babel-jest', { rootMode: 'upward' }],
-    '^.+\\.tsx?$': ['ts-jest', { isolatedModules: true }],
+    '^.+\\.tsx?$': ['ts-jest', {}],
   },
   transformIgnorePatterns: [`node_modules/(?!${transformNodeModules.join('|')}/)`],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],

--- a/shared/jest.config.ts
+++ b/shared/jest.config.ts
@@ -7,7 +7,7 @@ export default {
   testEnvironment: 'jsdom',
   testPathIgnorePatterns: ['<rootDir>/dist/', '<rootDir>/node_modules/'],
   transform: {
-    '^.+\\.(j|t)sx?$': ['ts-jest', { isolatedModules: true }],
+    '^.+\\.(j|t)sx?$': ['ts-jest', {}],
   },
   maxWorkers: '50%',
 }

--- a/translations/jest.config.ts
+++ b/translations/jest.config.ts
@@ -5,6 +5,6 @@ export default {
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
   maxWorkers: '50%',
   transform: {
-    '^.+\\.(j|t)sx?$': ['ts-jest', { isolatedModules: true }],
+    '^.+\\.(j|t)sx?$': ['ts-jest', {}],
   },
 }

--- a/web/jest.config.ts
+++ b/web/jest.config.ts
@@ -20,7 +20,7 @@ const config: JestConfigWithTsJest = {
   maxWorkers: '50%',
   workerIdleMemoryLimit: process.env.CI ? '500MB' : undefined,
   transform: {
-    '^.+\\.(j|t)sx?$': ['ts-jest', { isolatedModules: true }],
+    '^.+\\.(j|t)sx?$': ['ts-jest', {}],
   },
   testEnvironment: 'jsdom',
   globals: {


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
We had lots of warnings in our tests due to the option `isolatedModules` being deprecated:
```
ts-jest[config] (WARN) 
    The "ts-jest" config option "isolatedModules" is deprecated and will be removed in v30.0.0. Please use "isolatedModules: true" in /Users/st/digitalfabrik/integreat-app/native/tsconfig.json instead, see https://www.typescriptlang.org/tsconfig/#isolatedModules
```

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Remove deprecated `isolatedModules` options

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
N/A

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: N/A

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
