### PR TITLE
Move apple-app-site-association to recommended .well-known directory

### DIFF
--- a/web/tools/webpack.config.ts
+++ b/web/tools/webpack.config.ts
@@ -253,7 +253,7 @@ const createConfig = (
                 },
                 {
                   from: appleAppSiteAssociationPreset,
-                  to: distDirectory,
+                  to: wellKnownDirectory,
                   transform: () => generateAppleAppSiteAssociation(buildConfig),
                 },
               ]


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Move apple-app-site-association to recommended .well-known directory.
https://developer.apple.com/documentation/xcode/supporting-associated-domains

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Move apple-app-site-association to recommended .well-known directory.

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

On iOS, deep linking only works for clicking links. Contrary to Android, opening the URL in the browser does NOT open the app.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Build the app and check that the `apple-app-site-association` is in the correct directory.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: N/A

### Additional Information

Discussed here: https://chat.tuerantuer.org/digitalfabrik/pl/8a7qwdxbo7do8rdacor7k7u7ha

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
