### PR TITLE
3446: Fix sentry tests

### DIFF
--- a/native/jest.setup.ts
+++ b/native/jest.setup.ts
@@ -16,6 +16,12 @@ require('react-native-gesture-handler/jestSetup')
 
 jest.mock('react-native-tts')
 
+jest.mock('@sentry/react-native', () => ({
+  init: jest.fn(),
+  captureException: jest.fn(),
+  addBreadcrumb: jest.fn(),
+}))
+
 jest.mock('react-native-reanimated', () => {
   const Reanimated = require('react-native-reanimated/mock')
 

--- a/native/src/utils/__tests__/sentry.spec.ts
+++ b/native/src/utils/__tests__/sentry.spec.ts
@@ -6,13 +6,6 @@ import { FetchError, NotFoundError } from 'shared/api'
 import buildConfig from '../../constants/buildConfig'
 import { initSentry, log, reportError } from '../sentry'
 
-jest.mock('@sentry/react-native', () => ({
-  ...jest.requireActual('@sentry/react-native'),
-  captureException: jest.fn(),
-  addBreadcrumb: jest.fn(),
-  init: jest.fn(),
-}))
-
 beforeEach(() => {
   jest.clearAllMocks()
 })


### PR DESCRIPTION
### Short Description
When you do `yarn test` it will say at the end `A worker process has failed to exit gracefully and has been force exited...` so the issue was sentry's mock.


### Proposed Changes

<!-- Describe this PR in more detail. -->

- Moved sentry mock to jest setup file.
- Removed requireActual() no need for it.

### Side Effects

None.

### Testing

Test `yarn test`

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3446

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
