### PR TITLE
3451: Change Poi chip border color

### DIFF
--- a/web/src/components/PoiChips.tsx
+++ b/web/src/components/PoiChips.tsx
@@ -24,7 +24,7 @@ const Chip = styled.div`
   align-items: center;
   gap: 6px;
   border-radius: 12px;
-  border: 1px solid rgb(0 0 0 / 38%);
+  border: 1px solid ${props => props.theme.colors.textSecondaryColor};
   height: 24px;
   font-size: 12px;
 `


### PR DESCRIPTION
### Short Description

The border for `PoiChips` is in black while the contrast mode is activated.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Just change the border color to `textSecondaryColor` like we did at native. 

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

None.

### Testing

- Go to map (Poi) and go to any location.
- Check that the border looks good when the contrast mode is enabled.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3451 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
