### PR TITLE
3450: Fix size and color of header logo

### DIFF
--- a/web/src/components/HeaderLogo.tsx
+++ b/web/src/components/HeaderLogo.tsx
@@ -1,9 +1,11 @@
 import styled from '@emotion/styled'
 import { DateTime } from 'luxon'
 import React, { ReactElement } from 'react'
+import SVG from 'react-inlinesvg'
 
 import buildConfig from '../constants/buildConfig'
 import dimensions from '../constants/dimensions'
+import useWindowDimensions from '../hooks/useWindowDimensions'
 import Link from './base/Link'
 
 type HeaderLogoProps = {
@@ -27,17 +29,12 @@ const LogoContainer = styled.div`
   }
 `
 
-const StyledLogo = styled.img<{ $small: boolean }>`
+const StyledLogo = styled(SVG)`
   color: ${props => props.theme.colors.textColor};
   height: 100%;
   width: 200px;
 
-  @media ${dimensions.mediumLargeViewport} {
-    ${props => (props.$small ? 'display: none;' : '')}
-  }
-
   @media ${dimensions.smallViewport} {
-    ${props => (!props.$small ? 'display: none;' : '')}
     width: 100%;
   }
 `
@@ -53,13 +50,12 @@ export const HeaderLogo = ({ link }: HeaderLogoProps): ReactElement => {
     campaign && currentDate > DateTime.fromISO(campaign.startDate) && currentDate < DateTime.fromISO(campaign.endDate)
   const src = showCampaignLogo ? campaign.campaignAppLogo : icons.appLogo
   const srcMobile = showCampaignLogo ? campaign.campaignAppLogoMobile : icons.appLogoMobile
+  const { viewportSmall } = useWindowDimensions()
 
   return (
     <LogoContainer>
       <Link to={link}>
-        {/* Using `loading="lazy"` makes the browser only fetch the image that is actually visible */}
-        <StyledLogo $small src={srcMobile} alt={appName} loading='lazy' />
-        <StyledLogo $small={false} src={src} alt={appName} loading='lazy' />
+        <StyledLogo src={viewportSmall ? srcMobile : src} title={appName} />
       </Link>
     </LogoContainer>
   )

--- a/web/src/components/__tests__/HeaderLogo.spec.tsx
+++ b/web/src/components/__tests__/HeaderLogo.spec.tsx
@@ -4,11 +4,11 @@ import buildConfig from '../../constants/buildConfig'
 import { renderWithRouterAndTheme } from '../../testing/render'
 import HeaderLogo from '../HeaderLogo'
 
+jest.mock('react-inlinesvg')
 jest.mock('../../constants/buildConfig', () => ({
   __esModule: true,
   default: jest.fn(() => __BUILD_CONFIG__),
 }))
-
 jest.useFakeTimers()
 
 describe('HeaderLogo', () => {
@@ -31,44 +31,39 @@ describe('HeaderLogo', () => {
     jest.setSystemTime(1615374110000) // Wed Mar 10 2021 11:01:50 GMT+0000
     config.campaign = undefined
     config.icons.appLogo = '/my-regular-logo'
-    const { getAllByRole } = renderWithRouterAndTheme(<HeaderLogo link='https://example.com' />)
-    const logos = getAllByRole('img')
+    const { getByRole } = renderWithRouterAndTheme(<HeaderLogo link='https://example.com' />)
+    const logo = getByRole('img')
 
-    expect(logos[0]!.getAttribute('src')).toBe(config.icons.appLogoMobile)
-    expect(logos[1]!.getAttribute('src')).toBe(config.icons.appLogo)
-    logos.forEach(it => expect(it.getAttribute('alt')).toBe('IntegreatTestCms'))
+    expect(logo.getAttribute('id')).toBe(config.icons.appLogo)
   })
 
   it('should show the campaign logo if the current date is between start and end date', () => {
     jest.setSystemTime(1615374110000) // Wed Mar 10 2021 11:01:50 GMT+0000
     config.campaign = womensDayCampaign
     config.icons.appLogo = '/my-regular-logo'
-    const { getAllByRole } = renderWithRouterAndTheme(<HeaderLogo link='https://example.com' />)
-    const logos = getAllByRole('img')
+    const { getByRole } = renderWithRouterAndTheme(<HeaderLogo link='https://example.com' />)
+    const logo = getByRole('img')
 
-    expect(logos[0]!.getAttribute('src')).toBe(womensDayCampaign.campaignAppLogoMobile)
-    expect(logos[1]!.getAttribute('src')).toBe(womensDayCampaign.campaignAppLogo)
+    expect(logo.getAttribute('id')).toBe(womensDayCampaign.campaignAppLogo)
   })
 
   it('should show the regular logo if the current date is before the start date', () => {
     jest.setSystemTime(1614942686000) // Fri Mar 05 2021 11:11:26
     config.campaign = womensDayCampaign
     config.icons.appLogo = '/my-regular-logo'
-    const { getAllByRole } = renderWithRouterAndTheme(<HeaderLogo link='https://example.com' />)
-    const logos = getAllByRole('img')
+    const { getByRole } = renderWithRouterAndTheme(<HeaderLogo link='https://example.com' />)
+    const logo = getByRole('img')
 
-    expect(logos[0]!.getAttribute('src')).toBe(config.icons.appLogoMobile)
-    expect(logos[1]!.getAttribute('src')).toBe(config.icons.appLogo)
+    expect(logo.getAttribute('id')).toBe(config.icons.appLogo)
   })
 
   it('should show the regular logo if the current date is after the end date', () => {
     jest.setSystemTime(1615806686000) // Mon Mar 15 2021 11:11:26
     config.campaign = womensDayCampaign
     config.icons.appLogo = '/my-regular-logo'
-    const { getAllByRole } = renderWithRouterAndTheme(<HeaderLogo link='https://example.com' />)
-    const logos = getAllByRole('img')
+    const { getByRole } = renderWithRouterAndTheme(<HeaderLogo link='https://example.com' />)
+    const logo = getByRole('img')
 
-    expect(logos[0]!.getAttribute('src')).toBe(config.icons.appLogoMobile)
-    expect(logos[1]!.getAttribute('src')).toBe(config.icons.appLogo)
+    expect(logo.getAttribute('id')).toBe(config.icons.appLogo)
   })
 })


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
This PR fixes the size of the header app logo for malte and aschaffenburg and the color of the icons in the contrast mode.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Fix the height to `48px`
- Use an Svg again to fix the color in the high contrast mode

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- The height of 48 px is slightly smaller than on production (54 px)

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Test integreat, malte, aschaffenburg and obdach in both small and big viewports as well as both light and high contrast mode.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3450

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
