### PR TITLE
3416: Headroom z-index fix

### DIFF
--- a/web/src/components/BottomActionSheet.tsx
+++ b/web/src/components/BottomActionSheet.tsx
@@ -28,6 +28,7 @@ const StyledSpacer = styled(Spacer)`
 
 const StyledBottomSheet = styled(BottomSheet)`
   direction: ${props => props.theme.contentDirection};
+  z-index: 3;
 `
 
 const StyledLayout = styled(RichLayout)`

--- a/web/src/components/BottomActionSheet.tsx
+++ b/web/src/components/BottomActionSheet.tsx
@@ -28,7 +28,7 @@ const StyledSpacer = styled(Spacer)`
 
 const StyledBottomSheet = styled(BottomSheet)`
   direction: ${props => props.theme.contentDirection};
-  z-index: 3;
+  z-index: 2;
 `
 
 const StyledLayout = styled(RichLayout)`

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -115,7 +115,7 @@ export const Header = ({
   const scrollHeight = viewportSmall ? headerHeightSmall : headerHeightLarge
 
   return (
-    <Headroom scrollHeight={scrollHeight} height={height}>
+    <Headroom scrollHeight={scrollHeight} height={height} zIndex={3}>
       <HeaderContainer>
         <Row>
           <HeaderLogo link={logoHref} />

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -115,7 +115,7 @@ export const Header = ({
   const scrollHeight = viewportSmall ? headerHeightSmall : headerHeightLarge
 
   return (
-    <Headroom scrollHeight={scrollHeight} height={height} zIndex={10}>
+    <Headroom scrollHeight={scrollHeight} height={height}>
       <HeaderContainer>
         <Row>
           <HeaderLogo link={logoHref} />

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -115,7 +115,7 @@ export const Header = ({
   const scrollHeight = viewportSmall ? headerHeightSmall : headerHeightLarge
 
   return (
-    <Headroom scrollHeight={scrollHeight} height={height} zIndex={3}>
+    <Headroom scrollHeight={scrollHeight} height={height} zIndex={2}>
       <HeaderContainer>
         <Row>
           <HeaderLogo link={logoHref} />

--- a/web/src/components/base/Input.tsx
+++ b/web/src/components/base/Input.tsx
@@ -1,5 +1,12 @@
+import styled from '@emotion/styled'
 import TextField from '@mui/material/TextField'
 import React, { ChangeEvent, ReactElement } from 'react'
+
+const StyledTextField = styled(TextField)`
+  .MuiInputLabel-root {
+    z-index: 0;
+  }
+`
 
 export type InputProps = {
   id: string
@@ -42,7 +49,7 @@ const Input = ({
   }
 
   return (
-    <TextField
+    <StyledTextField
       id={id}
       onClick={onClick}
       onChange={onInputChange}

--- a/web/src/components/base/Input.tsx
+++ b/web/src/components/base/Input.tsx
@@ -1,9 +1,10 @@
 import styled from '@emotion/styled'
+import { inputLabelClasses } from '@mui/material/InputLabel'
 import TextField from '@mui/material/TextField'
 import React, { ChangeEvent, ReactElement } from 'react'
 
 const StyledTextField = styled(TextField)`
-  .MuiInputLabel-root {
+  .${inputLabelClasses.root} {
     z-index: 0;
   }
 `

--- a/web/src/components/base/Input.tsx
+++ b/web/src/components/base/Input.tsx
@@ -1,17 +1,6 @@
-import styled from '@emotion/styled'
-import { inputLabelClasses } from '@mui/material/InputLabel'
 import TextField from '@mui/material/TextField'
 import React, { ChangeEvent, ReactElement } from 'react'
 
-const StyledTextField = styled(TextField)`
-  .${inputLabelClasses.root} {
-    z-index: 0;
-  }
-
-  input:autofill {
-    transition-delay: calc(infinity * 1s);
-  }
-`
 export type InputProps = {
   id: string
   value: string
@@ -53,7 +42,7 @@ const Input = ({
   }
 
   return (
-    <StyledTextField
+    <TextField
       id={id}
       onClick={onClick}
       onChange={onInputChange}

--- a/web/src/components/base/Input.tsx
+++ b/web/src/components/base/Input.tsx
@@ -7,8 +7,11 @@ const StyledTextField = styled(TextField)`
   .${inputLabelClasses.root} {
     z-index: 0;
   }
-`
 
+  input:autofill {
+    transition-delay: calc(infinity * 1s);
+  }
+`
 export type InputProps = {
   id: string
   value: string


### PR DESCRIPTION
### Short Description

This problem located at 3231-design-system-web about the bottom sheet getting under the headroom on smallViewport.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Removed the z-index at the headroom.
- Changed the MuiInputLabel zindex to 0.

### Side Effects

Hope none.

### Testing

- Go to http://localhost:9000/testumgebung/de/kontaktformular (Malte).
- scroll down and look if the input labels are above the headroom (header).
- Test the POI bottom sheet.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3416

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
