### PR TITLE
3455: Fix infinite loop of opening deep link

### DIFF
--- a/native/ios/Integreat/AppDelegate.swift
+++ b/native/ios/Integreat/AppDelegate.swift
@@ -30,4 +30,10 @@ class AppDelegate: RCTAppDelegate {
       Bundle.main.url(forResource: "main", withExtension: "jsbundle")
     #endif
   }
+
+  override func application(
+    _ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]
+  ) -> Bool {
+    return RCTLinkingManager.application(app, open: url, options: options)
+  }
 }

--- a/native/src/components/RedirectContainer.tsx
+++ b/native/src/components/RedirectContainer.tsx
@@ -8,7 +8,7 @@ import useNavigateToDeepLink from '../hooks/useNavigateToDeepLink'
 import Layout from './Layout'
 
 const TIMEOUT = 10
-const INTERVAL_TIMEOUT = 500
+const INTERVAL_TIMEOUT = 1000
 
 type RedirectContainerProps = {
   route: RouteProps<RedirectRouteType>
@@ -16,7 +16,7 @@ type RedirectContainerProps = {
 }
 
 const RedirectContainer = ({ route, navigation }: RedirectContainerProps): ReactElement => {
-  const navigateToDeepLink = useNavigateToDeepLink()
+  const navigateToDeepLink = useNavigateToDeepLink({ redirect: true })
   const { url } = route.params
 
   useEffect(() => {

--- a/native/src/hooks/useNavigate.ts
+++ b/native/src/hooks/useNavigate.ts
@@ -32,6 +32,7 @@ const navigate = <T extends RoutesType>(
   appCityCode: string | null,
   appLanguageCode: string,
   showSnackbar: (snackbar: SnackbarType) => void,
+  redirect: boolean,
 ): void => {
   if (!routeInformation) {
     return
@@ -44,26 +45,27 @@ const navigate = <T extends RoutesType>(
       url,
     },
   })
+  const navigate = redirect ? navigation.replace : navigation.push
 
   if (routeInformation.route === LICENSES_ROUTE) {
-    navigation.push(LICENSES_ROUTE)
+    navigate(LICENSES_ROUTE)
     return
   }
   if (routeInformation.route === CONSENT_ROUTE) {
-    navigation.push(CONSENT_ROUTE)
+    navigate(CONSENT_ROUTE)
     return
   }
   if (routeInformation.route === LANDING_ROUTE) {
-    navigation.push(LANDING_ROUTE)
+    navigate(LANDING_ROUTE)
     return
   }
   if (routeInformation.route === CITY_NOT_COOPERATING_ROUTE) {
-    navigation.push(CITY_NOT_COOPERATING_ROUTE)
+    navigate(CITY_NOT_COOPERATING_ROUTE)
     return
   }
   if (routeInformation.route === JPAL_TRACKING_ROUTE) {
     if (buildConfig().featureFlags.jpalTracking) {
-      navigation.push(JPAL_TRACKING_ROUTE)
+      navigate(JPAL_TRACKING_ROUTE)
     }
     return
   }
@@ -83,15 +85,15 @@ const navigate = <T extends RoutesType>(
 
   switch (routeInformation.route) {
     case CATEGORIES_ROUTE:
-      navigation.push(CATEGORIES_ROUTE, { path: routeInformation.cityContentPath })
+      navigate(CATEGORIES_ROUTE, { path: routeInformation.cityContentPath })
       return
 
     case DISCLAIMER_ROUTE:
-      navigation.push(DISCLAIMER_ROUTE)
+      navigate(DISCLAIMER_ROUTE)
       return
 
     case EVENTS_ROUTE:
-      navigation.push(EVENTS_ROUTE, { slug: routeInformation.slug })
+      navigate(EVENTS_ROUTE, { slug: routeInformation.slug })
       return
 
     case NEWS_ROUTE:
@@ -99,7 +101,7 @@ const navigate = <T extends RoutesType>(
         break
       }
 
-      navigation.push(NEWS_ROUTE, {
+      navigate(NEWS_ROUTE, {
         ...params,
         newsType: routeInformation.newsType,
         newsId: routeInformation.newsId ?? null,
@@ -110,7 +112,7 @@ const navigate = <T extends RoutesType>(
       if (!buildConfig().featureFlags.pois) {
         break
       }
-      navigation.push(POIS_ROUTE, {
+      navigate(POIS_ROUTE, {
         slug: routeInformation.slug,
         multipoi: routeInformation.multipoi,
         zoom: routeInformation.zoom,
@@ -119,7 +121,7 @@ const navigate = <T extends RoutesType>(
       return
 
     case SEARCH_ROUTE:
-      navigation.push(SEARCH_ROUTE, { searchText: routeInformation.searchText })
+      navigate(SEARCH_ROUTE, { searchText: routeInformation.searchText })
   }
 }
 
@@ -128,15 +130,15 @@ type UseNavigateReturn = {
   navigation: NavigationProps<RoutesType>
 }
 
-const useNavigate = (): UseNavigateReturn => {
+const useNavigate = ({ redirect } = { redirect: false }): UseNavigateReturn => {
   const navigation = useNavigation<NavigationProps<RoutesType>>()
   const { cityCode, languageCode } = useContext(AppContext)
   const showSnackbar = useSnackbar()
 
   const navigateTo = useCallback(
     (routeInformation: RouteInformationType) =>
-      navigate(routeInformation, navigation, cityCode, languageCode, showSnackbar),
-    [navigation, cityCode, languageCode, showSnackbar],
+      navigate(routeInformation, navigation, cityCode, languageCode, showSnackbar, redirect),
+    [navigation, cityCode, languageCode, showSnackbar, redirect],
   )
 
   return { navigateTo, navigation }

--- a/native/src/hooks/useNavigateToDeepLink.ts
+++ b/native/src/hooks/useNavigateToDeepLink.ts
@@ -106,10 +106,10 @@ const navigateToDeepLink = <T extends RoutesType>({
   navigateTo(routeInformation)
 }
 
-const useNavigateToDeepLink = (): ((url: string) => void) => {
+const useNavigateToDeepLink = ({ redirect } = { redirect: false }): ((url: string) => void) => {
   const showSnackbar = useSnackbar()
   const appContext = useAppContext()
-  const { navigation, navigateTo } = useNavigate()
+  const { navigation, navigateTo } = useNavigate({ redirect })
 
   return useCallback(
     (url: string) => navigateToDeepLink({ url, navigation, navigateTo, appContext, showSnackbar }),


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Fix infinite loop of opening deep link by actually replacing instead of pushing the route.
The changed behavior of the infinite loop when opening a deep link in the same city/same language seem to be due to the redirect container still being mounted even after navigating to some other route (or at least the interval in RedirectContainer still fires). I worked around it by actually replacing the route instead of just pushing a new route which unmounts the redirect route and therefore prevents the infinite interval.

I am not sure where exactly the changed behavior is coming from, but there might have been some breaking changes in react-navigation v7:
https://reactnavigation.org/docs/upgrading-from-6.x/#the-navigate-method-no-longer-goes-back-use-popto-instead

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Replace the current route instead of just pushing for deep links

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

I did yet not have enough time to properly test different edge cases, e.g.
- deep linking with a cold app start (i.e. opening a link when the app is closed)
- behavior on old/slow devices

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
See issue description. Basically test deep links in the app.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3455

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
