### PR TITLE
3465: Use mui theme provider

### DIFF
--- a/web/src/@types/@emotion/react.d.ts
+++ b/web/src/@types/@emotion/react.d.ts
@@ -1,14 +1,7 @@
 import '@emotion/react'
 import { Theme as MuiTheme } from '@mui/material/styles'
 
-import { LegacyThemeType } from 'build-configs/LegacyThemeType'
-import { UiDirectionType } from 'translations'
-
 declare module '@emotion/react' {
   // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-  export interface Theme extends LegacyThemeType, MuiTheme {
-    contentDirection: UiDirectionType
-    isContrastTheme: boolean
-    toggleTheme: () => void
-  }
+  export interface Theme extends MuiTheme {}
 }

--- a/web/src/@types/mui-theme.d.ts
+++ b/web/src/@types/mui-theme.d.ts
@@ -4,6 +4,8 @@
 import { TypographyPropsVariantOverrides } from '@mui/material/Typography'
 import { PaletteColor, Palette, PaletteOptions } from '@mui/material/styles'
 
+import { LegacyThemeType } from 'build-configs'
+
 // Enable and disable typography variants according to our design system
 // docs: https://mui.com/material-ui/customization/typography/#adding-amp-disabling-variants
 declare module '@mui/material/Typography' {
@@ -33,6 +35,19 @@ declare module '@mui/material/Typography' {
 }
 
 declare module '@mui/material/styles' {
+  interface Theme {
+    legacy: LegacyThemeType
+    contentDirection: UiDirectionType
+    isContrastTheme: boolean
+    toggleTheme: () => void
+  }
+
+  interface ThemeOptions {
+    legacy: LegacyThemeType
+    contentDirection: UiDirectionType
+    isContrastTheme: boolean
+  }
+
   interface Palette {
     tertiary: PaletteColor
   }

--- a/web/src/components/BottomActionSheet.tsx
+++ b/web/src/components/BottomActionSheet.tsx
@@ -10,7 +10,7 @@ import { RichLayout } from './Layout'
 
 const Title = styled.h1`
   font-size: 1.25rem;
-  font-family: ${props => props.theme.fonts.web.contentFont};
+  font-family: ${props => props.theme.legacy.fonts.web.contentFont};
 `
 
 const ToolbarContainer = styled.div`

--- a/web/src/components/Breadcrumb.tsx
+++ b/web/src/components/Breadcrumb.tsx
@@ -16,7 +16,7 @@ const ListItem = styled.li<{ shrink: boolean }>`
 
   & * {
     ${helpers.removeLinkHighlighting}
-    color: ${props => props.theme.colors.textColor};
+    color: ${props => props.theme.legacy.colors.textColor};
     font-size: 16px;
     margin: 0 2px;
   }
@@ -24,7 +24,7 @@ const ListItem = styled.li<{ shrink: boolean }>`
 
 const Separator = styled.span`
   &::before {
-    color: ${props => props.theme.colors.textColor};
+    color: ${props => props.theme.legacy.colors.textColor};
     font-size: 19px;
     content: ' > ';
   }

--- a/web/src/components/CategoryListItem.tsx
+++ b/web/src/components/CategoryListItem.tsx
@@ -31,7 +31,7 @@ const CategoryItemCaption = styled.span`
   align-items: center;
   padding: 15px 5px;
   color: inherit;
-  font-size: ${props => props.theme.fonts.contentFontSize};
+  font-size: ${props => props.theme.legacy.fonts.contentFontSize};
   font-weight: bold;
   text-decoration: inherit;
   height: 100%;
@@ -55,7 +55,7 @@ const StyledLink = styled(Link)`
     color: inherit;
     text-decoration: inherit;
     transition: background-color 0.5s ease;
-    background-color: ${props => props.theme.colors.backgroundAccentColor};
+    background-color: ${props => props.theme.legacy.colors.backgroundAccentColor};
   }
 `
 

--- a/web/src/components/ChatContainer.tsx
+++ b/web/src/components/ChatContainer.tsx
@@ -35,17 +35,17 @@ const StyledIcon = styled(Icon)`
   height: 40px;
   align-self: center;
   justify-content: center;
-  color: ${props => props.theme.colors.backgroundColor};
+  color: ${props => props.theme.legacy.colors.backgroundColor};
 `
 
 const ChatTitle = styled.span`
   margin-top: 8px;
-  color: ${props => props.theme.colors.textColor};
+  color: ${props => props.theme.legacy.colors.textColor};
 `
 
 const ChatActionButton = styled(Fab)`
   &:hover {
-    background-color: ${props => props.theme.colors.themeColor};
+    background-color: ${props => props.theme.legacy.colors.themeColor};
   }
 `
 

--- a/web/src/components/ChatContentWrapper.tsx
+++ b/web/src/components/ChatContentWrapper.tsx
@@ -8,7 +8,7 @@ import ChatMenu from './ChatMenu'
 const Container = styled.div`
   display: flex;
   flex-direction: column;
-  font-family: ${props => props.theme.fonts.web.decorativeFont};
+  font-family: ${props => props.theme.legacy.fonts.web.decorativeFont};
   border-radius: 5px;
   flex: 1;
   width: 400px;
@@ -23,10 +23,10 @@ const Header = styled.div<{ small: boolean }>`
   flex-direction: ${props => (props.small ? 'row-reverse' : 'row')};
   justify-content: space-between;
   ${helpers.adaptiveThemeTextColor}
-  font-size: ${props => props.theme.fonts.hintFontSize};
+  font-size: ${props => props.theme.legacy.fonts.hintFontSize};
   font-weight: bold;
   align-items: center;
-  background-color: ${props => props.theme.colors.themeColor};
+  background-color: ${props => props.theme.legacy.colors.themeColor};
   padding: 4px 8px;
 
   ${props => props.theme.breakpoints.up('md')} {

--- a/web/src/components/ChatConversation.tsx
+++ b/web/src/components/ChatConversation.tsx
@@ -7,7 +7,7 @@ import { ChatMessageModel } from 'shared/api'
 import ChatMessage, { InnerChatMessage } from './ChatMessage'
 
 const Container = styled.div`
-  font-size: ${props => props.theme.fonts.hintFontSize};
+  font-size: ${props => props.theme.legacy.fonts.hintFontSize};
   overflow: auto;
   padding: 0 12px;
 `
@@ -17,10 +17,10 @@ const InitialMessage = styled.div`
 `
 
 const ErrorSendingStatus = styled.div`
-  background-color: ${props => props.theme.colors.invalidInput};
+  background-color: ${props => props.theme.legacy.colors.invalidInput};
   border-radius: 5px;
   padding: 8px;
-  border: 1px solid ${props => props.theme.colors.textDecorationColor};
+  border: 1px solid ${props => props.theme.legacy.colors.textDecorationColor};
   margin: 16px;
 `
 

--- a/web/src/components/ChatMenu.tsx
+++ b/web/src/components/ChatMenu.tsx
@@ -10,7 +10,7 @@ import Button from './base/Button'
 import Icon from './base/Icon'
 
 const StyledButton = styled(Button)`
-  background-color: ${props => props.theme.colors.themeColor};
+  background-color: ${props => props.theme.legacy.colors.themeColor};
 `
 
 const StyledIcon = styled(Icon)`
@@ -18,7 +18,7 @@ const StyledIcon = styled(Icon)`
   height: 24px;
   align-self: center;
   display: flex;
-  color: ${props => props.theme.colors.backgroundColor};
+  color: ${props => props.theme.legacy.colors.backgroundColor};
 
   ${props => props.theme.breakpoints.down('md')} {
     ${helpers.adaptiveThemeTextColor}

--- a/web/src/components/ChatMessage.tsx
+++ b/web/src/components/ChatMessage.tsx
@@ -11,10 +11,10 @@ import RemoteContent from './RemoteContent'
 import Icon from './base/Icon'
 
 export const Message = styled.div`
-  color: ${props => props.theme.colors.textColor};
+  color: ${props => props.theme.legacy.colors.textColor};
   border-radius: 5px;
   padding: 8px;
-  border: 1px solid ${props => props.theme.colors.textDecorationColor};
+  border: 1px solid ${props => props.theme.legacy.colors.textDecorationColor};
   max-width: 70%;
   width: max-content;
 
@@ -23,7 +23,7 @@ export const Message = styled.div`
   }
 `
 const StyledChatIcon = styled(Icon)`
-  background-color: ${props => props.theme.colors.themeColor};
+  background-color: ${props => props.theme.legacy.colors.themeColor};
   color: black;
   border-radius: 4px;
 `
@@ -41,15 +41,15 @@ const IconContainer = styled.div<{ visible: boolean }>`
 
 const Circle = styled.div`
   display: flex;
-  background-color: ${props => props.theme.colors.textColor};
+  background-color: ${props => props.theme.legacy.colors.textColor};
   border-radius: 50%;
   height: 18px;
   width: 18px;
-  color: ${props => props.theme.colors.backgroundColor};
+  color: ${props => props.theme.legacy.colors.backgroundColor};
   justify-content: center;
   align-items: center;
   padding: 4px;
-  font-size: ${props => props.theme.fonts.decorativeFontSizeSmall};
+  font-size: ${props => props.theme.legacy.fonts.decorativeFontSizeSmall};
 `
 
 const getIcon = (userIsAuthor: boolean, isAutomaticAnswer: boolean, t: TFunction<'chat'>): ReactElement => {

--- a/web/src/components/ChatModal.tsx
+++ b/web/src/components/ChatModal.tsx
@@ -10,7 +10,7 @@ import Button from './base/Button'
 const Overlay = styled(Button)`
   position: absolute;
   inset: 0;
-  background-color: ${props => props.theme.colors.textSecondaryColor};
+  background-color: ${props => props.theme.legacy.colors.textSecondaryColor};
   opacity: 0.4;
   width: 100%;
   height: 100%;
@@ -33,7 +33,7 @@ const ModalContentContainer = styled.div`
   position: relative;
   display: flex;
   flex-direction: column;
-  background-color: ${props => props.theme.colors.backgroundColor};
+  background-color: ${props => props.theme.legacy.colors.backgroundColor};
   border-radius: 5px;
 
   ${props => props.theme.breakpoints.down('md')} {

--- a/web/src/components/ChatPrivacyInformation.tsx
+++ b/web/src/components/ChatPrivacyInformation.tsx
@@ -20,7 +20,7 @@ const PrivacyPolicyLink = styled(Link)`
 const SecurityIcon = styled(Icon)`
   width: 100%;
   height: 100%;
-  color: ${props => props.theme.colors.textSecondaryColor};
+  color: ${props => props.theme.legacy.colors.textSecondaryColor};
 `
 
 type ChatPrivacyInformationProps = {

--- a/web/src/components/CityContentFooter.tsx
+++ b/web/src/components/CityContentFooter.tsx
@@ -16,7 +16,7 @@ const SidebarFooterContainer = styled.div`
   padding: 0 27px;
 
   > a {
-    color: ${props => props.theme.colors.textColor};
+    color: ${props => props.theme.legacy.colors.textColor};
     padding: 16px 0;
     display: flex;
     align-items: center;

--- a/web/src/components/CityEntry.tsx
+++ b/web/src/components/CityEntry.tsx
@@ -20,7 +20,7 @@ const CityListItem = styled(Link)`
     color: inherit;
     text-decoration: inherit;
     transition: background-color 0.5s ease;
-    background-color: ${props => props.theme.colors.backgroundAccentColor};
+    background-color: ${props => props.theme.legacy.colors.backgroundAccentColor};
   }
 `
 

--- a/web/src/components/CityNotCooperatingFooter.tsx
+++ b/web/src/components/CityNotCooperatingFooter.tsx
@@ -11,7 +11,7 @@ import Icon from './base/Icon'
 import Link from './base/Link'
 
 const FooterContainer = styled.div`
-  background-color: ${props => props.theme.colors.backgroundAccentColor};
+  background-color: ${props => props.theme.legacy.colors.backgroundAccentColor};
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -25,7 +25,7 @@ const StyledIcon = styled(Icon)`
 `
 
 const Question = styled.p`
-  font: ${props => props.theme.fonts.web.decorativeFont};
+  font: ${props => props.theme.legacy.fonts.web.decorativeFont};
   font-weight: 400;
 `
 

--- a/web/src/components/CitySelector.tsx
+++ b/web/src/components/CitySelector.tsx
@@ -25,11 +25,11 @@ export const CityListParent = styled(Typography)<{ stickyTop: number }>`
   margin-top: 10px;
   line-height: 30px;
   transition: top 0.2s ease-out;
-  background-color: ${props => props.theme.colors.backgroundColor};
+  background-color: ${props => props.theme.legacy.colors.backgroundColor};
 `
 
 const SearchCounter = styled.p`
-  color: ${props => props.theme.colors.textSecondaryColor};
+  color: ${props => props.theme.legacy.colors.textSecondaryColor};
 `
 
 type CitySelectorProps = {

--- a/web/src/components/Collapsible.tsx
+++ b/web/src/components/Collapsible.tsx
@@ -17,7 +17,7 @@ const Container = styled.div`
 const CollapsibleHeader = styled(Button)`
   display: flex;
   justify-content: space-between;
-  color: ${props => props.theme.colors.textColor};
+  color: ${props => props.theme.legacy.colors.textColor};
 `
 
 const Title = styled.div`

--- a/web/src/components/ContactItem.tsx
+++ b/web/src/components/ContactItem.tsx
@@ -19,7 +19,7 @@ const StyledLink = styled(Link)`
   padding-top: 4px;
   gap: 8px;
   overflow-wrap: anywhere;
-  color: ${props => props.theme.colors.linkColor};
+  color: ${props => props.theme.legacy.colors.linkColor};
   ${helpers.adaptiveFontSize};
 `
 

--- a/web/src/components/ContrastThemeToggle.tsx
+++ b/web/src/components/ContrastThemeToggle.tsx
@@ -17,7 +17,7 @@ const ContrastButton = styled(Button)`
 
   & > span {
     padding: 0 28px;
-    color: ${props => props.theme.colors.textColor};
+    color: ${props => props.theme.legacy.colors.textColor};
   }
 `
 

--- a/web/src/components/CrashTestingIcon.tsx
+++ b/web/src/components/CrashTestingIcon.tsx
@@ -5,7 +5,7 @@ import React, { ReactElement, useState } from 'react'
 import Icon from './base/Icon'
 
 const StyledIcon = styled(Icon)`
-  color: ${props => props.theme.colors.themeColor};
+  color: ${props => props.theme.legacy.colors.themeColor};
   display: block;
   height: 64px;
   width: 96px;

--- a/web/src/components/DatePicker.tsx
+++ b/web/src/components/DatePicker.tsx
@@ -35,20 +35,20 @@ const StyledInput = styled(DatePickerWrapper)`
   height: ${INPUT_HEIGHT};
   padding: 0 16px;
   border-radius: 8px;
-  border-color: ${props => props.theme.colors.themeColorLight};
+  border-color: ${props => props.theme.legacy.colors.themeColorLight};
   border-width: 3px;
   border-style: solid;
 
   &&& {
     &:focus {
       outline: none;
-      border-color: ${props => props.theme.colors.themeColor};
+      border-color: ${props => props.theme.legacy.colors.themeColor};
     }
   }
 `
 
 const StyledTitle = styled.span`
-  background-color: ${props => props.theme.colors.backgroundColor};
+  background-color: ${props => props.theme.legacy.colors.backgroundColor};
   position: absolute;
   top: -12px;
   left: 12px;
@@ -59,7 +59,7 @@ const StyledTitle = styled.span`
 const StyledError = styled.div`
   font-size: 12px;
   font-weight: bold;
-  color: ${props => props.theme.colors.invalidInput};
+  color: ${props => props.theme.legacy.colors.invalidInput};
 `
 
 export type CustomDatePickerProps = {

--- a/web/src/components/DropDownContainer.tsx
+++ b/web/src/components/DropDownContainer.tsx
@@ -18,7 +18,7 @@ const DropDownContainer = styled.div<{ active: boolean }>`
     transform 0.2s,
     opacity 0.2s,
     visibility 0s ${props => (props.active ? '0s' : '0.2s')};
-  background-color: ${props => props.theme.colors.backgroundColor};
+  background-color: ${props => props.theme.legacy.colors.backgroundColor};
   visibility: ${props => (props.active ? 'visible' : 'hidden')};
 
   ${props => props.theme.breakpoints.down('md')} {

--- a/web/src/components/EventsDateFilter.tsx
+++ b/web/src/components/EventsDateFilter.tsx
@@ -22,7 +22,7 @@ const DateSection = styled.div`
   }
 `
 const Text = styled.span`
-  color: ${props => props.theme.colors.textColor};
+  color: ${props => props.theme.legacy.colors.textColor};
 `
 
 const StyledButton = styled(Button)`

--- a/web/src/components/Feedback.tsx
+++ b/web/src/components/Feedback.tsx
@@ -23,8 +23,8 @@ export const Container = styled.div<{ fullWidth?: boolean }>`
   justify-content: space-between;
   padding: 16px;
   border-radius: 10px;
-  border-color: ${props => props.theme.colors.textSecondaryColor};
-  font-size: ${props => props.theme.fonts.contentFontSize};
+  border-color: ${props => props.theme.legacy.colors.textSecondaryColor};
+  font-size: ${props => props.theme.legacy.fonts.contentFontSize};
   overflow: auto;
   align-self: center;
   gap: 16px;

--- a/web/src/components/FilterToggle.tsx
+++ b/web/src/components/FilterToggle.tsx
@@ -18,7 +18,7 @@ const StyledButton = styled(Button)`
 `
 
 const Text = styled.span`
-  color: ${props => props.theme.colors.textColor};
+  color: ${props => props.theme.legacy.colors.textColor};
 `
 
 const FilterToggle = ({

--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -14,13 +14,14 @@ const FooterContainer = styled.footer<{ overlay: boolean }>`
   justify-content: center;
   padding: ${props => (props.overlay ? '0 10px' : '15px 5px')};
   margin-top: auto;
-  background-color: ${props => (props.overlay ? `rgba(255, 255, 255, 0.5)` : props.theme.colors.backgroundAccentColor)};
+  background-color: ${props =>
+    props.overlay ? `rgba(255, 255, 255, 0.5)` : props.theme.legacy.colors.backgroundAccentColor};
   box-shadow: 0 2px 3px 3px rgb(0 0 0 / 10%);
 
   ${props => (props.overlay ? 'color: rgba(0, 0, 0, 0.75);' : '')}
   & > * {
     margin: ${props => (props.overlay ? 0 : '5px')};
-    color: ${props => props.theme.isContrastTheme && !props.overlay && props.theme.colors.textColor};
+    color: ${props => props.theme.isContrastTheme && !props.overlay && props.theme.legacy.colors.textColor};
   }
 
   & > *::after {

--- a/web/src/components/GoBack.tsx
+++ b/web/src/components/GoBack.tsx
@@ -30,12 +30,12 @@ const StyledButton = styled(Button)<{ viewportSmall: boolean }>`
 `
 
 const DetailsHeaderTitle = styled.span`
-  color: ${props => props.theme.colors.textColor};
+  color: ${props => props.theme.legacy.colors.textColor};
   align-self: center;
   white-space: pre;
   padding-inline-start: 8px;
   ${helpers.adaptiveFontSize};
-  font-family: ${props => props.theme.fonts.web.contentFont};
+  font-family: ${props => props.theme.legacy.fonts.web.contentFont};
 `
 
 const StyledIcon = styled(Icon)`

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -27,7 +27,7 @@ const HeaderContainer = styled.header`
   display: flex;
   width: 100%;
   box-sizing: border-box;
-  background-color: ${props => props.theme.colors.backgroundAccentColor};
+  background-color: ${props => props.theme.legacy.colors.backgroundAccentColor};
   user-select: none;
   flex-direction: column;
   overflow: visible;
@@ -49,7 +49,7 @@ const Row = styled.div`
   justify-content: space-between;
 
   ${props => props.theme.breakpoints.down('md')} {
-    background-color: ${props => props.theme.colors.backgroundAccentColor};
+    background-color: ${props => props.theme.legacy.colors.backgroundAccentColor};
     justify-content: space-between;
     flex-wrap: wrap;
     min-height: ${dimensions.headerHeightSmall}px;
@@ -62,7 +62,7 @@ const HeaderSeparator = styled.div`
   height: ${dimensions.headerHeightLarge / 2}px;
   width: 2px;
   margin: 0 5px;
-  background-color: ${props => props.theme.colors.textDecorationColor};
+  background-color: ${props => props.theme.legacy.colors.textDecorationColor};
   order: 2;
 
   ${props => props.theme.breakpoints.down('md')} {

--- a/web/src/components/HeaderLogo.tsx
+++ b/web/src/components/HeaderLogo.tsx
@@ -29,7 +29,7 @@ const LogoContainer = styled.div`
 `
 
 const StyledLogo = styled(SVG)`
-  color: ${props => props.theme.colors.textColor};
+  color: ${props => props.theme.legacy.colors.textColor};
   height: 100%;
   width: 200px;
 

--- a/web/src/components/HeaderNavigationItem.tsx
+++ b/web/src/components/HeaderNavigationItem.tsx
@@ -13,8 +13,8 @@ const Container = styled.div`
 
 const StyledLink = styled(Link)<{ active: boolean }>`
   ${helpers.removeLinkHighlighting};
-  color: ${props => props.theme.colors.textSecondaryColor};
-  font-family: ${props => props.theme.fonts.web.contentFont};
+  color: ${props => props.theme.legacy.colors.textSecondaryColor};
+  font-family: ${props => props.theme.legacy.fonts.web.contentFont};
   font-size: 0.9em;
   font-weight: 800;
   text-align: center;
@@ -26,36 +26,37 @@ const StyledLink = styled(Link)<{ active: boolean }>`
   height: 100%;
 
   ${props => props.theme.breakpoints.down('md')} {
-    font-size: ${props => props.theme.fonts.decorativeFontSizeSmall};
+    font-size: ${props => props.theme.legacy.fonts.decorativeFontSizeSmall};
     font-weight: 400;
     min-width: 50px;
   }
 
   & > div > svg {
-    color: ${props => (props.active ? props.theme.colors.textColor : props.theme.colors.textSecondaryColor)};
+    color: ${props =>
+      props.active ? props.theme.legacy.colors.textColor : props.theme.legacy.colors.textSecondaryColor};
   }
 
   &:hover {
-    color: ${props => props.theme.colors.textColor};
+    color: ${props => props.theme.legacy.colors.textColor};
   }
 
   &:hover > div > svg {
-    color: ${props => props.theme.colors.textColor};
+    color: ${props => props.theme.legacy.colors.textColor};
   }
 
   &:hover > div:first-of-type {
     box-shadow: 0 0 0 0 rgb(0 0 0 / 30%);
-    border-color: ${props => props.theme.colors.themeColor};
+    border-color: ${props => props.theme.legacy.colors.themeColor};
   }
 
   ${props =>
     props.active &&
     css`
-      color: ${props.theme.colors.textColor};
+      color: ${props.theme.legacy.colors.textColor};
 
       & > div:first-of-type {
         box-shadow: 0 0 0 0 rgb(0 0 0 / 30%);
-        border-color: ${props.theme.colors.themeColor};
+        border-color: ${props.theme.legacy.colors.themeColor};
       }
     `}
 `
@@ -73,7 +74,7 @@ const Circle = styled.div`
   align-items: center;
 
   ${props => props.theme.breakpoints.up('md')} {
-    background-color: ${props => props.theme.colors.backgroundColor};
+    background-color: ${props => props.theme.legacy.colors.backgroundColor};
     box-sizing: border-box;
     border-radius: 100%;
     height: ${ICON_SIZE_LARGE}px;
@@ -82,7 +83,7 @@ const Circle = styled.div`
     transition:
       box-shadow 0.2s,
       border 0.2s;
-    border: ${props => props.theme.colors.backgroundColor} 2px solid;
+    border: ${props => props.theme.legacy.colors.backgroundColor} 2px solid;
   }
 
   ${props => props.theme.breakpoints.down('md')} {

--- a/web/src/components/HeaderTitle.tsx
+++ b/web/src/components/HeaderTitle.tsx
@@ -22,8 +22,8 @@ const HeaderTitleContainer = styled.div<{ long: boolean }>`
   }
 
   ${props => props.theme.breakpoints.down('md')} {
-    font-family: ${props => props.theme.fonts.web.decorativeFont};
-    font-size: ${props => props.theme.fonts.decorativeFontSize};
+    font-family: ${props => props.theme.legacy.fonts.web.decorativeFont};
+    font-size: ${props => props.theme.legacy.fonts.decorativeFontSize};
     height: ${HEADER_TITLE_HEIGHT}px;
     justify-content: start;
     padding: 0 10px;

--- a/web/src/components/HighlightBox.tsx
+++ b/web/src/components/HighlightBox.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 
 const HighlightBox = styled.div`
-  background-color: ${props => props.theme.colors.backgroundAccentColor};
+  background-color: ${props => props.theme.legacy.colors.backgroundAccentColor};
   border-radius: 4px;
   padding: 20px;
   box-shadow:

--- a/web/src/components/Highlighter.tsx
+++ b/web/src/components/Highlighter.tsx
@@ -22,9 +22,9 @@ const Highlighter = ({ search, text, className, dir }: HighlighterProps): ReactE
       sanitize={normalizeString}
       findChunks={findNormalizedMatches}
       highlightStyle={{
-        backgroundColor: theme.colors.backgroundColor,
+        backgroundColor: theme.legacy.colors.backgroundColor,
         fontWeight: 'bold',
-        color: theme.isContrastTheme ? theme.colors.themeColor : theme.colors.textColor,
+        color: theme.isContrastTheme ? theme.legacy.colors.themeColor : theme.legacy.colors.textColor,
       }}
       aria-label={text}
       autoEscape

--- a/web/src/components/KebabActionItem.tsx
+++ b/web/src/components/KebabActionItem.tsx
@@ -13,7 +13,7 @@ const Container = styled.span`
   & > span {
     padding: 0 28px;
     align-self: center;
-    color: ${props => props.theme.colors.textColor};
+    color: ${props => props.theme.legacy.colors.textColor};
   }
 `
 

--- a/web/src/components/KebabMenu.tsx
+++ b/web/src/components/KebabMenu.tsx
@@ -24,12 +24,12 @@ const ToggleContainer = styled.div`
 `
 
 const List = styled.div`
-  font-family: ${props => props.theme.fonts.web.decorativeFont};
+  font-family: ${props => props.theme.legacy.fonts.web.decorativeFont};
   position: fixed;
   top: 0;
   width: 80vw;
   height: 100vh;
-  background-color: ${props => props.theme.colors.backgroundColor};
+  background-color: ${props => props.theme.legacy.colors.backgroundColor};
   box-shadow: -3px 3px 3px 0 rgb(0 0 0 / 13%);
 
   /* to stop flickering of text in safari */
@@ -56,7 +56,7 @@ const Overlay = styled.div<{ show: boolean }>`
 const Heading = styled.div`
   display: flex;
   justify-content: flex-end;
-  background-color: ${props => props.theme.colors.backgroundAccentColor};
+  background-color: ${props => props.theme.legacy.colors.backgroundAccentColor};
   box-shadow: -3px 3px 3px 0 rgb(0 0 0 / 13%);
   min-height: ${dimensions.headerHeightSmall}px;
   box-sizing: border-box;

--- a/web/src/components/LastUpdateInfo.tsx
+++ b/web/src/components/LastUpdateInfo.tsx
@@ -4,9 +4,9 @@ import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
 const TimeStamp = styled.p`
-  color: ${props => props.theme.colors.textSecondaryColor};
-  font-family: ${props => props.theme.fonts.web.contentFont};
-  font-size: ${props => props.theme.fonts.contentFontSize};
+  color: ${props => props.theme.legacy.colors.textSecondaryColor};
+  font-family: ${props => props.theme.legacy.fonts.web.contentFont};
+  font-size: ${props => props.theme.legacy.fonts.contentFontSize};
 `
 
 type LastUpdateInfoProps = {

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -12,16 +12,16 @@ export const RichLayout = styled.div`
   min-height: 100vh;
   flex-direction: column;
   justify-content: space-between;
-  color: ${props => props.theme.colors.textColor};
-  font-family: ${props => props.theme.fonts.web.decorativeFont};
-  font-size-adjust: ${props => props.theme.fonts.fontSizeAdjust};
-  background-color: ${props => props.theme.colors.backgroundColor};
-  line-height: ${props => props.theme.fonts.decorativeLineHeight};
+  color: ${props => props.theme.legacy.colors.textColor};
+  font-family: ${props => props.theme.legacy.fonts.web.decorativeFont};
+  font-size-adjust: ${props => props.theme.legacy.fonts.fontSizeAdjust};
+  background-color: ${props => props.theme.legacy.colors.backgroundColor};
+  line-height: ${props => props.theme.legacy.fonts.decorativeLineHeight};
 
   & a,
   button {
     &:focus-visible {
-      outline: 2px solid ${props => props.theme.colors.textSecondaryColor};
+      outline: 2px solid ${props => props.theme.legacy.colors.textSecondaryColor};
     }
 
     cursor: pointer;
@@ -33,7 +33,7 @@ const Body = styled.div<{ fullWidth: boolean; disableScrollingSafari: boolean }>
   box-sizing: border-box;
   margin: 0 auto;
   flex-grow: 1;
-  background-color: ${props => props.theme.colors.backgroundColor};
+  background-color: ${props => props.theme.legacy.colors.backgroundColor};
   word-wrap: break-word;
   min-height: 100%;
   display: flex;
@@ -72,7 +72,7 @@ const Main = styled.main<{ fullWidth: boolean }>`
   word-wrap: break-word;
 
   & p {
-    margin: ${props => props.theme.fonts.standardParagraphMargin} 0;
+    margin: ${props => props.theme.legacy.fonts.standardParagraphMargin} 0;
   }
 
   ${props => props.theme.breakpoints.down('md')} {

--- a/web/src/components/LoadingSpinner.tsx
+++ b/web/src/components/LoadingSpinner.tsx
@@ -23,7 +23,7 @@ const Spinner = styled.div`
   animation-name: ${lineScaleParty};
 
   > div {
-    background-color: ${props => props.theme.colors.textSecondaryColor};
+    background-color: ${props => props.theme.legacy.colors.textSecondaryColor};
     width: 4px;
     height: 35px;
     border-radius: 2px;

--- a/web/src/components/LocalNewsList.tsx
+++ b/web/src/components/LocalNewsList.tsx
@@ -13,7 +13,7 @@ const StyledList = styled.div`
   padding-top: 1px;
 `
 const Wrapper = styled.div`
-  background-color: ${({ theme }) => theme.colors.backgroundColor};
+  background-color: ${({ theme }) => theme.legacy.colors.backgroundColor};
 `
 
 type LocalNewsListProps = {

--- a/web/src/components/MalteHelpForm.tsx
+++ b/web/src/components/MalteHelpForm.tsx
@@ -43,11 +43,11 @@ const Form = styled.form`
 
 const SubmitErrorHeading = styled.h5`
   margin: 0;
-  font-size: ${props => props.theme.fonts.subTitleFontSize};
+  font-size: ${props => props.theme.legacy.fonts.subTitleFontSize};
 `
 
 const ErrorSendingStatus = styled.div`
-  background-color: ${props => props.theme.colors.invalidInput}35;
+  background-color: ${props => props.theme.legacy.colors.invalidInput}35;
   padding: 20px 10px;
   margin: 10px 0;
 `

--- a/web/src/components/MapAttribution.tsx
+++ b/web/src/components/MapAttribution.tsx
@@ -22,13 +22,13 @@ const StyledButton = styled(Button)<{ expanded: boolean }>`
   inset-inline-end: 0;
   justify-content: flex-end;
   font-size: ${props =>
-    props.expanded ? props.theme.fonts.decorativeFontSizeSmall : props.theme.fonts.contentFontSize};
+    props.expanded ? props.theme.legacy.fonts.decorativeFontSizeSmall : props.theme.legacy.fonts.contentFontSize};
   font-weight: ${props => (props.expanded ? 'normal' : 'bold')};
 `
 
 const OpenStreetMapsLink = styled(Link)`
   text-decoration: underline;
-  color: ${props => props.theme.colors.linkColor};
+  color: ${props => props.theme.legacy.colors.linkColor};
 `
 
 const Label = styled.span`

--- a/web/src/components/MobileBanner.tsx
+++ b/web/src/components/MobileBanner.tsx
@@ -12,7 +12,7 @@ import Icon from './base/Icon'
 const StyledBanner = styled.div<{ isInstalled: boolean }>`
   display: none;
   justify-content: space-between;
-  background-color: ${props => props.theme.colors.themeColor};
+  background-color: ${props => props.theme.legacy.colors.themeColor};
   padding: 15px;
   align-items: center;
   transition: all 2s ease-out;
@@ -50,20 +50,21 @@ const StyledDivText = styled.div`
 const StyledAppName = styled.span`
   font-weight: bold;
   font-size: 12px;
-  color: ${props => props.theme.colors.themeContrast};
+  color: ${props => props.theme.legacy.colors.themeContrast};
 `
 
 const smallScreenSize = 400
 
 const StyledDescription = styled.span<{ screenSize: number }>`
-  color: ${props => props.theme.colors.themeContrast};
+  color: ${props => props.theme.legacy.colors.themeContrast};
   white-space: nowrap;
   font-size: ${props => (props.screenSize <= smallScreenSize ? '10px' : '12px')};
 `
 
 const StyledButton = styled.button<{ isInstalled: boolean }>`
-  background-color: ${props => (!props.isInstalled ? 'transparent' : props.theme.colors.textColor)};
-  color: ${props => (!props.isInstalled ? props.theme.colors.themeContrast : props.theme.colors.themeColor)};
+  background-color: ${props => (!props.isInstalled ? 'transparent' : props.theme.legacy.colors.textColor)};
+  color: ${props =>
+    !props.isInstalled ? props.theme.legacy.colors.themeContrast : props.theme.legacy.colors.themeColor};
   border: ${props => !props.isInstalled && 'none'};
   border-radius: 40px;
   padding: 6px 12px;

--- a/web/src/components/Modal.tsx
+++ b/web/src/components/Modal.tsx
@@ -16,7 +16,9 @@ const Overlay = styled(Button)`
   position: absolute;
   inset: 0;
   background-color: ${props =>
-    props.theme.isContrastTheme ? props.theme.colors.backgroundAccentColor : props.theme.colors.textSecondaryColor};
+    props.theme.isContrastTheme
+      ? props.theme.legacy.colors.backgroundAccentColor
+      : props.theme.legacy.colors.textSecondaryColor};
   opacity: 0.9;
   width: 100%;
   height: 100%;

--- a/web/src/components/ModalContent.tsx
+++ b/web/src/components/ModalContent.tsx
@@ -9,8 +9,8 @@ import { useTranslation } from 'react-i18next'
 const Container = styled.div`
   display: flex;
   flex-direction: column;
-  background-color: ${props => props.theme.colors.backgroundColor};
-  font-family: ${props => props.theme.fonts.web.decorativeFont};
+  background-color: ${props => props.theme.legacy.colors.backgroundColor};
+  font-family: ${props => props.theme.legacy.fonts.web.decorativeFont};
 `
 
 const Header = styled.div<{ small: boolean }>`
@@ -18,7 +18,7 @@ const Header = styled.div<{ small: boolean }>`
   padding: 16px;
   flex-direction: ${props => (props.small ? 'row-reverse' : 'row')};
   justify-content: space-between;
-  font-size: ${props => props.theme.fonts.subTitleFontSize};
+  font-size: ${props => props.theme.legacy.fonts.subTitleFontSize};
   font-weight: bold;
   align-items: center;
 
@@ -36,7 +36,7 @@ const TitleContainer = styled.div`
   justify-content: center;
   align-items: center;
   gap: 12px;
-  color: ${props => props.theme.colors.textColor};
+  color: ${props => props.theme.legacy.colors.textColor};
 `
 
 type ModalProps = {

--- a/web/src/components/NavigationBarScrollContainer.tsx
+++ b/web/src/components/NavigationBarScrollContainer.tsx
@@ -36,7 +36,7 @@ const ScrollContainer = styled.div<{ showArrowContainer: boolean }>`
   flex-direction: row;
 
   ${props => props.theme.breakpoints.down('md')} {
-    background-color: ${props => props.theme.colors.backgroundAccentColor};
+    background-color: ${props => props.theme.legacy.colors.backgroundAccentColor};
     justify-content: space-between;
     flex-wrap: wrap;
     min-height: ${dimensions.headerHeightSmall}px;

--- a/web/src/components/NearbyCities.tsx
+++ b/web/src/components/NearbyCities.tsx
@@ -20,8 +20,8 @@ const NearbyMessageContainer = styled.div`
 `
 
 const NearbyMessage = styled.span`
-  color: ${props => props.theme.colors.textColor};
-  font-family: ${props => props.theme.fonts.web.decorativeFont};
+  color: ${props => props.theme.legacy.colors.textColor};
+  font-family: ${props => props.theme.legacy.fonts.web.decorativeFont};
   align-self: center;
 `
 

--- a/web/src/components/NewsListItem.tsx
+++ b/web/src/components/NewsListItem.tsx
@@ -13,19 +13,21 @@ import Link from './base/Link'
 
 const StyledLink = styled(Link)`
   display: flex;
-  background-color: ${({ theme }) => theme.colors.backgroundColor};
+  background-color: ${({ theme }) => theme.legacy.colors.backgroundColor};
 `
 const ReadMore = styled.div<{ newsType: NewsType }>`
   align-self: flex-end;
   color: ${({ theme, newsType }) =>
-    theme.isContrastTheme || newsType === LOCAL_NEWS_TYPE ? theme.colors.themeColor : theme.colors.tunewsThemeColor};
+    theme.isContrastTheme || newsType === LOCAL_NEWS_TYPE
+      ? theme.legacy.colors.themeColor
+      : theme.legacy.colors.tunewsThemeColor};
   font-weight: 600;
 `
 
 const Title = styled.h3`
   margin-bottom: 0;
-  font-family: ${props => props.theme.fonts.web.decorativeFont};
-  font-size: ${props => props.theme.fonts.subTitleFontSize};
+  font-family: ${props => props.theme.legacy.fonts.web.decorativeFont};
+  font-size: ${props => props.theme.legacy.fonts.subTitleFontSize};
   font-weight: 700;
 `
 

--- a/web/src/components/NewsTab.tsx
+++ b/web/src/components/NewsTab.tsx
@@ -18,12 +18,12 @@ const StyledTab = styled(Link, { shouldForwardProp })<{ tabSelected: boolean }>`
   justify-content: center;
   cursor: pointer;
   padding: 13px 15px;
-  color: ${({ theme }) => theme.colors.backgroundColor};
+  color: ${({ theme }) => theme.legacy.colors.backgroundColor};
   object-fit: contain;
   background-color: ${({ tabSelected, theme }) =>
-    tabSelected ? theme.colors.themeColor : theme.colors.textDisabledColor};
+    tabSelected ? theme.legacy.colors.themeColor : theme.legacy.colors.textDisabledColor};
   border-radius: 11px;
-  font-size: ${props => props.theme.fonts.subTitleFontSize};
+  font-size: ${props => props.theme.legacy.fonts.subTitleFontSize};
   font-weight: 700;
   text-decoration: none;
 
@@ -35,7 +35,7 @@ const StyledTab = styled(Link, { shouldForwardProp })<{ tabSelected: boolean }>`
 const TuStyledTab = styled(StyledTab)`
   background-image: ${({ tabSelected }) => (tabSelected ? `url(${TuNewsActiveIcon})` : `url(${TuNewsInactiveIcon})`)};
   background-color: ${({ tabSelected, theme }) =>
-    tabSelected ? theme.colors.tunewsThemeColor : theme.colors.textDisabledColor};
+    tabSelected ? theme.legacy.colors.tunewsThemeColor : theme.legacy.colors.textDisabledColor};
   background-size: cover;
   background-position: center center;
 `

--- a/web/src/components/Note.tsx
+++ b/web/src/components/Note.tsx
@@ -7,19 +7,19 @@ import Icon from './base/Icon'
 
 const NoteContainer = styled.div`
   display: flex;
-  background-color: ${props => props.theme.colors.warningColor};
+  background-color: ${props => props.theme.legacy.colors.warningColor};
   padding: 12px;
   gap: 12px;
   align-items: center;
 `
 
 const NoteText = styled.span`
-  font-size: ${props => props.theme.fonts.decorativeFontSizeSmall};
+  font-size: ${props => props.theme.legacy.fonts.decorativeFontSizeSmall};
   ${helpers.adaptiveThemeTextColor}
 `
 
 const StyledIcon = styled(Icon)`
-  color: ${props => props.theme.isContrastTheme && props.theme.colors.backgroundColor};
+  color: ${props => props.theme.isContrastTheme && props.theme.legacy.colors.backgroundColor};
 `
 
 type NoteProps = {

--- a/web/src/components/OpeningHours.tsx
+++ b/web/src/components/OpeningHours.tsx
@@ -14,7 +14,8 @@ import Icon from './base/Icon'
 import Link from './base/Link'
 
 const OpeningLabel = styled.span<{ isOpen: boolean }>`
-  color: ${props => (props.isOpen ? props.theme.colors.positiveHighlight : props.theme.colors.negativeHighlight)};
+  color: ${props =>
+    props.isOpen ? props.theme.legacy.colors.positiveHighlight : props.theme.legacy.colors.negativeHighlight};
   padding-inline-end: 12px;
 `
 
@@ -46,7 +47,7 @@ const StyledLink = styled(Link)`
 `
 
 const LinkLabel = styled.span`
-  color: ${props => props.theme.colors.linkColor};
+  color: ${props => props.theme.legacy.colors.linkColor};
   ${helpers.adaptiveFontSize};
   align-self: flex-end;
 `
@@ -57,7 +58,7 @@ const StyledExternalLinkIcon = styled(Icon)`
   align-self: center;
   width: 16px;
   height: 16px;
-  color: ${props => props.theme.colors.linkColor};
+  color: ${props => props.theme.legacy.colors.linkColor};
 `
 
 type OpeningHoursTitleProps = {

--- a/web/src/components/OrganizationContentInfo.tsx
+++ b/web/src/components/OrganizationContentInfo.tsx
@@ -22,7 +22,7 @@ const ThumbnailSizer = styled.div`
 const Box = styled(HighlightBox)<{ viewportSmall: boolean }>`
   display: flex;
   place-content: space-evenly space-evenly;
-  font-family: ${props => props.theme.fonts.web.decorativeFont};
+  font-family: ${props => props.theme.legacy.fonts.web.decorativeFont};
   font-size: 14px;
   flex-direction: ${props => (props.viewportSmall ? 'column' : 'row')};
   gap: 20px;

--- a/web/src/components/PoiChips.tsx
+++ b/web/src/components/PoiChips.tsx
@@ -19,13 +19,13 @@ const ChipsContainer = styled.div`
 `
 
 const Chip = styled.div`
-  color: ${props => props.theme.colors.textSecondaryColor};
+  color: ${props => props.theme.legacy.colors.textSecondaryColor};
   display: flex;
   padding-inline: 12px;
   align-items: center;
   gap: 6px;
   border-radius: 12px;
-  border: 1px solid ${props => props.theme.colors.textSecondaryColor};
+  border: 1px solid ${props => props.theme.legacy.colors.textSecondaryColor};
   height: 24px;
   font-size: 12px;
 `

--- a/web/src/components/PoiDetails.tsx
+++ b/web/src/components/PoiDetails.tsx
@@ -24,7 +24,7 @@ const StyledDivider = styled(Divider)`
 `
 
 const DetailsContainer = styled.div`
-  font-family: ${props => props.theme.fonts.web.contentFont};
+  font-family: ${props => props.theme.legacy.fonts.web.contentFont};
 `
 
 const StyledIcon = styled(Icon)`
@@ -36,7 +36,7 @@ const StyledIcon = styled(Icon)`
 const StyledExternalLinkIcon = styled(StyledIcon)`
   width: 16px;
   height: 16px;
-  color: ${props => props.theme.colors.linkColor};
+  color: ${props => props.theme.legacy.colors.linkColor};
 `
 
 const Thumbnail = styled.img`
@@ -91,7 +91,7 @@ const StyledLink = styled(Link)`
 `
 
 const LinkLabel = styled.span`
-  color: ${props => props.theme.colors.linkColor};
+  color: ${props => props.theme.legacy.colors.linkColor};
   ${helpers.adaptiveFontSize};
   align-self: flex-end;
 `

--- a/web/src/components/PoiFilters.tsx
+++ b/web/src/components/PoiFilters.tsx
@@ -24,8 +24,8 @@ const Container = styled.div`
 
 const SubTitle = styled.div`
   font-size: 0.875rem;
-  color: ${props => props.theme.colors.textColor};
-  font-family: ${props => props.theme.fonts.web.decorativeFont};
+  color: ${props => props.theme.legacy.colors.textColor};
+  font-family: ${props => props.theme.legacy.fonts.web.decorativeFont};
   font-weight: bold;
 `
 
@@ -45,8 +45,8 @@ const Row = styled.div`
 const SortingHint = styled.div`
   align-self: flex-end;
   font-size: 0.75rem;
-  color: ${props => props.theme.colors.textColor};
-  font-family: ${props => props.theme.fonts.web.decorativeFont};
+  color: ${props => props.theme.legacy.colors.textColor};
+  font-family: ${props => props.theme.legacy.fonts.web.decorativeFont};
   padding: 0 4px;
 `
 

--- a/web/src/components/PoiListItem.tsx
+++ b/web/src/components/PoiListItem.tsx
@@ -10,7 +10,7 @@ import { helpers } from '../constants/theme'
 import Button from './base/Button'
 
 const ListItemContainer = styled.ul`
-  font-family: ${props => props.theme.fonts.web.contentFont};
+  font-family: ${props => props.theme.legacy.fonts.web.contentFont};
   display: flex;
   padding: clamp(10px, 1vh, 20px) 0;
   cursor: pointer;
@@ -35,7 +35,7 @@ const Distance = styled.div`
 
 const Category = styled.div`
   ${helpers.adaptiveFontSize};
-  color: ${props => props.theme.colors.textSecondaryColor};
+  color: ${props => props.theme.legacy.colors.textSecondaryColor};
 `
 
 export const Description = styled.div`
@@ -46,7 +46,7 @@ export const Description = styled.div`
   flex-direction: column;
   flex-grow: 1;
   padding: 0 22px;
-  color: ${props => props.theme.colors.textColor};
+  color: ${props => props.theme.legacy.colors.textColor};
   align-self: center;
   word-break: break-word;
   hyphens: auto;

--- a/web/src/components/PoiPanelNavigation.tsx
+++ b/web/src/components/PoiPanelNavigation.tsx
@@ -15,7 +15,7 @@ const NavigationContainer = styled.div`
 
 const StyledButton = styled(Button)`
   display: flex;
-  color: ${props => props.theme.colors.textColor};
+  color: ${props => props.theme.legacy.colors.textColor};
 `
 
 const Label = styled.span`

--- a/web/src/components/PoisDesktop.tsx
+++ b/web/src/components/PoisDesktop.tsx
@@ -34,7 +34,7 @@ const ListViewWrapper = styled.div<{ panelHeights: number; bottomBarHeight: numb
 const ToolbarContainer = styled.div`
   display: flex;
   justify-content: center;
-  background-color: ${props => props.theme.colors.backgroundColor};
+  background-color: ${props => props.theme.legacy.colors.backgroundColor};
   box-shadow: 1px 0 4px 0 rgb(0 0 0 / 20%);
 `
 
@@ -42,9 +42,9 @@ const ListHeader = styled.div`
   padding-top: clamp(16px, 1.4vh, 32px);
   padding-bottom: clamp(10px, 1vh, 20px);
   text-align: center;
-  font-size: ${props => props.theme.fonts.subTitleFontSize};
-  font-family: ${props => props.theme.fonts.web.decorativeFont};
-  line-height: ${props => props.theme.fonts.decorativeLineHeight};
+  font-size: ${props => props.theme.legacy.fonts.subTitleFontSize};
+  font-family: ${props => props.theme.legacy.fonts.web.decorativeFont};
+  line-height: ${props => props.theme.legacy.fonts.decorativeLineHeight};
   font-weight: 600;
   margin-bottom: clamp(10px, 1vh, 20px);
 `

--- a/web/src/components/RemoteContentSandBox.ts
+++ b/web/src/components/RemoteContentSandBox.ts
@@ -4,9 +4,9 @@ import { ExternalLinkIcon, PersonIcon } from '../assets'
 import { helpers } from '../constants/theme'
 
 const RemoteContentSandBox = styled.div<{ centered: boolean; smallText: boolean }>`
-  font-family: ${props => props.theme.fonts.web.contentFont};
-  font-size: ${props => (props.smallText ? helpers.adaptiveFontSize : props.theme.fonts.contentFontSize)};
-  line-height: ${props => props.theme.fonts.contentLineHeight};
+  font-family: ${props => props.theme.legacy.fonts.web.contentFont};
+  font-size: ${props => (props.smallText ? helpers.adaptiveFontSize : props.theme.legacy.fonts.contentFontSize)};
+  line-height: ${props => props.theme.legacy.fonts.contentLineHeight};
   display: flow-root; /* clearfix for the img floats */
 
   ${props => (props.centered ? 'text-align: center;' : '')}
@@ -41,7 +41,7 @@ const RemoteContentSandBox = styled.div<{ centered: boolean; smallText: boolean 
   }
 
   figcaption {
-    font-size: ${props => props.theme.fonts.hintFontSize};
+    font-size: ${props => props.theme.legacy.fonts.hintFontSize};
     font-style: italic;
     padding: 0 15px;
   }
@@ -65,12 +65,12 @@ const RemoteContentSandBox = styled.div<{ centered: boolean; smallText: boolean 
   thead,
   th,
   td {
-    border: 1px solid ${props => props.theme.colors.backgroundAccentColor};
+    border: 1px solid ${props => props.theme.legacy.colors.backgroundAccentColor};
   }
 
   a {
     overflow-wrap: break-word;
-    color: ${props => props.theme.colors.linkColor};
+    color: ${props => props.theme.legacy.colors.linkColor};
   }
 
   details > * {
@@ -89,11 +89,11 @@ const RemoteContentSandBox = styled.div<{ centered: boolean; smallText: boolean 
     content: '';
     display: inline-block;
     background-image: url('${ExternalLinkIcon}');
-    width: ${props => props.theme.fonts.contentFontSize};
-    height: ${props => props.theme.fonts.contentFontSize};
+    width: ${props => props.theme.legacy.fonts.contentFontSize};
+    height: ${props => props.theme.legacy.fonts.contentFontSize};
     ${props => props.smallText && helpers.adaptiveHeight}
     ${props => props.smallText && helpers.adaptiveWidth}
-    color: ${props => props.theme.colors.linkColor};
+    color: ${props => props.theme.legacy.colors.linkColor};
     background-size: contain;
     background-repeat: no-repeat;
     vertical-align: middle;
@@ -102,7 +102,7 @@ const RemoteContentSandBox = styled.div<{ centered: boolean; smallText: boolean 
 
   iframe {
     border: none;
-    border-bottom: 1px solid ${props => props.theme.colors.borderColor};
+    border-bottom: 1px solid ${props => props.theme.legacy.colors.borderColor};
 
     ${props => props.theme.breakpoints.down('md')} {
       max-width: 100%;
@@ -113,7 +113,7 @@ const RemoteContentSandBox = styled.div<{ centered: boolean; smallText: boolean 
     display: flex;
     padding: 4px;
     flex-direction: column;
-    border: 1px solid ${props => props.theme.colors.borderColor};
+    border: 1px solid ${props => props.theme.legacy.colors.borderColor};
     border-radius: 4px;
     box-shadow:
       0 1px 3px rgb(0 0 0 / 10%),
@@ -124,7 +124,7 @@ const RemoteContentSandBox = styled.div<{ centered: boolean; smallText: boolean 
     display: flex;
     padding: 12px;
     justify-content: space-between;
-    font-size: ${props => props.theme.fonts.decorativeFontSizeSmall};
+    font-size: ${props => props.theme.legacy.fonts.decorativeFontSizeSmall};
   }
 
   .iframe-info-text > input {
@@ -148,9 +148,9 @@ const RemoteContentSandBox = styled.div<{ centered: boolean; smallText: boolean 
     border-radius: 4px;
     background-repeat: no-repeat;
     background-color: ${props =>
-      props.theme.isContrastTheme ? `${props.theme.colors.textColor}10` : 'rgb(127 127 127 / 15%)'};
+      props.theme.isContrastTheme ? `${props.theme.legacy.colors.textColor}10` : 'rgb(127 127 127 / 15%)'};
     background-image:
-      linear-gradient(to right, ${props => props.theme.colors.backgroundColor}F0 0 100%), url(${PersonIcon});
+      linear-gradient(to right, ${props => props.theme.legacy.colors.backgroundColor}F0 0 100%), url(${PersonIcon});
     background-blend-mode: difference;
     background-position:
       calc(100% + 32px) 100%,
@@ -170,7 +170,7 @@ const RemoteContentSandBox = styled.div<{ centered: boolean; smallText: boolean 
     }
 
     img {
-      color: ${props => props.theme.colors.textColor};
+      color: ${props => props.theme.legacy.colors.textColor};
       margin-inline-end: 8px;
     }
 

--- a/web/src/components/SearchInput.tsx
+++ b/web/src/components/SearchInput.tsx
@@ -20,7 +20,7 @@ const Wrapper = styled.div`
   width: 100%;
   box-sizing: border-box;
   padding: 10px 10%;
-  background-color: ${props => props.theme.colors.backgroundColor};
+  background-color: ${props => props.theme.legacy.colors.backgroundColor};
   display: flex;
   align-items: center;
 

--- a/web/src/components/SearchListItem.tsx
+++ b/web/src/components/SearchListItem.tsx
@@ -51,7 +51,7 @@ const StyledLink = styled(Link)`
     color: inherit;
     text-decoration: inherit;
     transition: background-color 0.5s ease;
-    background-color: ${props => props.theme.colors.backgroundAccentColor};
+    background-color: ${props => props.theme.legacy.colors.backgroundAccentColor};
   }
 `
 

--- a/web/src/components/Selector.tsx
+++ b/web/src/components/Selector.tsx
@@ -32,7 +32,7 @@ const selectorItemStyle = ({ theme }: { theme: Theme }) => css`
 
 const SelectorItem = styled(Link)<{ selected: boolean }>`
   ${selectorItemStyle};
-  color: ${props => props.theme.colors.textColor};
+  color: ${props => props.theme.legacy.colors.textColor};
   ${props =>
     props.selected
       ? 'font-weight: 700;'
@@ -44,7 +44,7 @@ const SelectorItem = styled(Link)<{ selected: boolean }>`
 
 const DisabledSelectorItem = styled.div`
   ${selectorItemStyle};
-  color: ${props => props.theme.colors.textDisabledColor};
+  color: ${props => props.theme.legacy.colors.textDisabledColor};
 `
 
 const BoldSpacer = styled.div`
@@ -59,7 +59,7 @@ const Wrapper = styled.div<{ vertical: boolean }>`
   width: 100%;
   flex-flow: ${props => (props.vertical ? 'column' : 'row wrap')};
   justify-content: space-evenly;
-  color: ${props => props.theme.colors.textColor};
+  color: ${props => props.theme.legacy.colors.textColor};
 `
 
 type SelectorProps = {

--- a/web/src/components/SharingPopup.tsx
+++ b/web/src/components/SharingPopup.tsx
@@ -30,9 +30,9 @@ const TooltipContainer = styled.div<{
   tooltipFlow: 'vertical' | 'horizontal'
   optionsVisible: boolean
 }>`
-  background-color: ${props => props.theme.colors.backgroundColor};
+  background-color: ${props => props.theme.legacy.colors.backgroundColor};
   padding: 8px;
-  border: 2px solid ${props => props.theme.colors.textDecorationColor};
+  border: 2px solid ${props => props.theme.legacy.colors.textDecorationColor};
   width: max-content;
   position: absolute;
   display: flex;
@@ -67,7 +67,7 @@ const TooltipContainer = styled.div<{
 
   &::before {
     z-index: 2000;
-    border-bottom: 10px solid ${props => props.theme.colors.backgroundColor};
+    border-bottom: 10px solid ${props => props.theme.legacy.colors.backgroundColor};
     border-inline-start: 10px solid transparent;
     border-inline-end: 10px solid transparent;
 
@@ -95,7 +95,7 @@ const TooltipContainer = styled.div<{
 
   &::after {
     z-index: 1000;
-    border-bottom: 11px solid ${props => props.theme.colors.textDecorationColor};
+    border-bottom: 11px solid ${props => props.theme.legacy.colors.textDecorationColor};
     border-inline-start: 11px solid transparent;
     border-inline-end: 11px solid transparent;
 

--- a/web/src/components/ThemeContainer.tsx
+++ b/web/src/components/ThemeContainer.tsx
@@ -45,10 +45,6 @@ const createTheme = (
       values: BREAKPOINTS,
     },
     direction: contentDirection,
-    colorSchemes: {
-      light: buildConfig().lightTheme,
-      dark: buildConfig().darkTheme,
-    },
     shadows: muiShadowCreator(themeType),
     typography: buildConfig().typography,
     palette: isContrast ? buildConfig().darkTheme.palette : buildConfig().lightTheme.palette,

--- a/web/src/components/ThemeContainer.tsx
+++ b/web/src/components/ThemeContainer.tsx
@@ -1,6 +1,6 @@
 import createCache from '@emotion/cache'
-import { CacheProvider, Global, Theme, ThemeProvider } from '@emotion/react'
-import { createTheme as createMuiTheme } from '@mui/material/styles'
+import { CacheProvider, Global } from '@emotion/react'
+import { createTheme as createMuiTheme, Theme, ThemeProvider } from '@mui/material/styles'
 import rtlPlugin from '@mui/stylis-plugin-rtl'
 import React, { ReactElement, ReactNode, useMemo } from 'react'
 import { prefixer } from 'stylis'
@@ -37,24 +37,22 @@ const createTheme = (
 ): Omit<Theme, 'toggleTheme'> => {
   const isContrast = themeType === 'contrast'
 
-  return {
-    ...(isContrast ? buildConfig().legacyContrastTheme : buildConfig().legacyLightTheme),
+  return createMuiTheme({
+    legacy: isContrast ? buildConfig().legacyContrastTheme : buildConfig().legacyLightTheme,
     contentDirection,
     isContrastTheme: isContrast,
-    ...createMuiTheme({
-      breakpoints: {
-        values: BREAKPOINTS,
-      },
-      direction: contentDirection,
-      colorSchemes: {
-        light: buildConfig().lightTheme,
-        dark: buildConfig().darkTheme,
-      },
-      shadows: muiShadowCreator(themeType),
-      typography: buildConfig().typography,
-      palette: isContrast ? buildConfig().darkTheme.palette : buildConfig().lightTheme.palette,
-    }),
-  }
+    breakpoints: {
+      values: BREAKPOINTS,
+    },
+    direction: contentDirection,
+    colorSchemes: {
+      light: buildConfig().lightTheme,
+      dark: buildConfig().darkTheme,
+    },
+    shadows: muiShadowCreator(themeType),
+    typography: buildConfig().typography,
+    palette: isContrast ? buildConfig().darkTheme.palette : buildConfig().lightTheme.palette,
+  })
 }
 
 type ThemeContainerProps = {
@@ -75,7 +73,7 @@ const ThemeContainer = ({ children, contentDirection }: ThemeContainerProps): Re
     }
 
     const theme = createTheme(themeType, contentDirection)
-    document.body.style.backgroundColor = theme.colors.backgroundAccentColor
+    document.body.style.backgroundColor = theme.legacy.colors.backgroundAccentColor
     return { ...theme, toggleTheme }
   }, [themeType, setThemeType, contentDirection])
 

--- a/web/src/components/Tile.tsx
+++ b/web/src/components/Tile.tsx
@@ -33,7 +33,7 @@ const ThumbnailSizer = styled.div`
     ${props =>
       props.theme.isContrastTheme &&
       `
-        outline: 8px solid ${props.theme.colors.themeColor};
+        outline: 8px solid ${props.theme.legacy.colors.themeColor};
         border-radius: 24px;
       `}
   }
@@ -41,7 +41,7 @@ const ThumbnailSizer = styled.div`
 
 const TileTitle = styled.div`
   margin: 5px 0;
-  color: ${props => props.theme.colors.textColor};
+  color: ${props => props.theme.legacy.colors.textColor};
   text-align: center;
 `
 
@@ -54,7 +54,7 @@ const TileContainer = styled.div`
     max-width: 160px;
     margin: 0 auto;
     padding: 0;
-    background-color: ${props => props.theme.colors.backgroundColor};
+    background-color: ${props => props.theme.legacy.colors.backgroundColor};
     border: none;
     box-shadow: none;
     cursor: pointer;

--- a/web/src/components/Toolbar.tsx
+++ b/web/src/components/Toolbar.tsx
@@ -14,7 +14,7 @@ const ToolbarContainer = styled.div<{ direction: 'row' | 'column'; hasPadding: b
   box-sizing: border-box;
   flex-direction: ${props => props.direction};
   align-items: center;
-  font-family: ${props => props.theme.fonts.web.contentFont};
+  font-family: ${props => props.theme.legacy.fonts.web.contentFont};
 
   ${props =>
     props.direction === 'column' &&

--- a/web/src/components/ToolbarItem.tsx
+++ b/web/src/components/ToolbarItem.tsx
@@ -16,7 +16,7 @@ const toolbarItemStyle = ({ theme }: { theme: Theme }): SerializedStyles => css`
   display: inline-block;
   padding: 8px;
   border: none;
-  color: ${theme.colors.textColor};
+  color: ${theme.legacy.colors.textColor};
   background-color: transparent;
   text-align: center;
 
@@ -34,12 +34,13 @@ const ToolbarItemButton = styled(Button)`
 
 const DisabledToolbarItem = styled('div')`
   ${toolbarItemStyle};
-  color: ${props => props.theme.colors.textDisabledColor};
+  color: ${props => props.theme.legacy.colors.textDisabledColor};
   cursor: default;
 `
 
 const StyledIcon = styled(Icon)<{ disabled?: boolean }>`
-  color: ${props => (props.disabled ? props.theme.colors.textDisabledColor : props.theme.colors.textSecondaryColor)};
+  color: ${props =>
+    props.disabled ? props.theme.legacy.colors.textDisabledColor : props.theme.legacy.colors.textSecondaryColor};
 `
 
 const StyledTooltip = styled(Tooltip)`

--- a/web/src/components/TtsHelpModal.tsx
+++ b/web/src/components/TtsHelpModal.tsx
@@ -24,26 +24,26 @@ const ModalContent = styled(Container)`
 `
 
 const StyledWarningText = styled.div`
-  font-family: ${props => props.theme.fonts.web.contentFont};
+  font-family: ${props => props.theme.legacy.fonts.web.contentFont};
   font-size: 16px;
-  color: ${props => props.theme.colors.textColor};
+  color: ${props => props.theme.legacy.colors.textColor};
 `
 
 const StyledWarningIcon = styled(Icon)`
-  color: ${props => props.theme.colors.ttsPlayerWarningColor};
+  color: ${props => props.theme.legacy.colors.ttsPlayerWarningColor};
 `
 
 const StyledList = styled.div`
   display: flex;
   flex-direction: column;
   gap: 8px;
-  color: ${props => props.theme.colors.textColor};
+  color: ${props => props.theme.legacy.colors.textColor};
 `
 
 const StyledExternalIcon = styled(Icon)`
   height: 12px;
   width: 12px;
-  color: ${props => props.theme.colors.linkColor};
+  color: ${props => props.theme.legacy.colors.linkColor};
 `
 
 const StyledBookIcon = styled(Icon)`
@@ -90,7 +90,9 @@ const TtsHelpModal = ({ closeModal }: { closeModal: () => void }): ReactElement 
     <Modal
       contentStyle={{
         borderRadius: 5,
-        backgroundColor: theme.isContrastTheme ? theme.colors.backgroundColor : theme.colors.ttsPlayerWarningBackground,
+        backgroundColor: theme.isContrastTheme
+          ? theme.legacy.colors.backgroundColor
+          : theme.legacy.colors.ttsPlayerWarningBackground,
       }}
       title={t('voiceUnavailable')}
       icon={<StyledWarningIcon src={WarningAmberOutlinedIcon} />}

--- a/web/src/components/TtsPlayer.tsx
+++ b/web/src/components/TtsPlayer.tsx
@@ -14,8 +14,10 @@ import useWindowDimensions from '../hooks/useWindowDimensions'
 
 const StyledTtsPlayer = styled.dialog<{ footerHeight: number }>`
   background-color: ${props =>
-    props.theme.isContrastTheme ? props.theme.colors.backgroundAccentColor : props.theme.colors.ttsPlayerBackground};
-  color: ${props => props.theme.colors.textColor};
+    props.theme.isContrastTheme
+      ? props.theme.legacy.colors.backgroundAccentColor
+      : props.theme.legacy.colors.ttsPlayerBackground};
+  color: ${props => props.theme.legacy.colors.textColor};
   border-radius: 8px;
   width: 300px;
   display: flex;

--- a/web/src/components/__tests__/NewsTab.spec.tsx
+++ b/web/src/components/__tests__/NewsTab.spec.tsx
@@ -1,12 +1,9 @@
-import { ThemeProvider } from '@emotion/react'
 import { TFunction } from 'i18next'
 import React from 'react'
 
 import { LOCAL_NEWS_TYPE, TU_NEWS_TYPE } from 'shared'
-import { UiDirectionType } from 'translations'
 
-import buildConfig from '../../constants/buildConfig'
-import { renderWithRouter } from '../../testing/render'
+import { renderWithRouterAndTheme } from '../../testing/render'
 import NewsTab from '../NewsTab'
 
 jest.mock('react-inlinesvg')
@@ -16,23 +13,18 @@ describe('NewsTab', () => {
   const active = true
   const destination = '/testcity/en/news/local'
   const t = ((key: string) => key) as TFunction
-  const theme = { ...buildConfig().legacyLightTheme, contentDirection: 'ltr' as UiDirectionType }
 
   it('should render the local news tab', () => {
-    const { getByText, queryByLabelText } = renderWithRouter(
-      <ThemeProvider theme={theme}>
-        <NewsTab type={LOCAL_NEWS_TYPE} active={active} destination={destination} t={t} />
-      </ThemeProvider>,
+    const { getByText, queryByLabelText } = renderWithRouterAndTheme(
+      <NewsTab type={LOCAL_NEWS_TYPE} active={active} destination={destination} t={t} />,
     )
     expect(getByText('LOCAL').closest('a')).toHaveProperty('href', `http://localhost${destination}`)
     expect(queryByLabelText('tuNews')).toBeFalsy()
   })
 
   it('should render the tünews news tab', () => {
-    const { queryByText, getByLabelText } = renderWithRouter(
-      <ThemeProvider theme={theme}>
-        <NewsTab type={TU_NEWS_TYPE} active={active} destination={destination} t={t} />
-      </ThemeProvider>,
+    const { queryByText, getByLabelText } = renderWithRouterAndTheme(
+      <NewsTab type={TU_NEWS_TYPE} active={active} destination={destination} t={t} />,
     )
     expect(getByLabelText('tünews INTERNATIONAL')).toHaveProperty('href', `http://localhost${destination}`)
     expect(queryByText('LOCAL')).toBeFalsy()

--- a/web/src/components/base/ChipButton.tsx
+++ b/web/src/components/base/ChipButton.tsx
@@ -14,14 +14,14 @@ const StyledButton = styled(Button)`
   margin: 0 2px;
   border-radius: 20px;
   gap: 4px;
-  background-color: ${props => props.theme.colors.backgroundColor};
-  color: ${props => props.theme.colors.textSecondaryColor};
-  font-family: ${props => props.theme.fonts.web.contentFont};
+  background-color: ${props => props.theme.legacy.colors.backgroundColor};
+  color: ${props => props.theme.legacy.colors.textSecondaryColor};
+  font-family: ${props => props.theme.legacy.fonts.web.contentFont};
   font-size: 0.875rem;
 `
 
 const StyledIcon = styled(Icon)`
-  color: ${props => props.theme.colors.textSecondaryColor};
+  color: ${props => props.theme.legacy.colors.textSecondaryColor};
   height: 16px;
   width: 16px;
 `

--- a/web/src/components/base/Icon.tsx
+++ b/web/src/components/base/Icon.tsx
@@ -10,11 +10,11 @@ const StyledIcon = styled(SVG, { shouldForwardProp })<{ directionDependent: bool
     (props.reverse === true) !== (props.directionDependent && props.theme.contentDirection === 'rtl')
       ? 'scaleX(-1)'
       : ''};
-  color: ${props => props.theme.colors.textColor};
+  color: ${props => props.theme.legacy.colors.textColor};
   width: 24px;
   height: 24px;
 
-  --theme-color: ${props => props.theme.colors.themeColor};
+  --theme-color: ${props => props.theme.legacy.colors.themeColor};
 `
 
 type IconProps = {
@@ -49,7 +49,7 @@ const Icon = ({ src, directionDependent = false, reverse = false, className, tit
       className={className}
       titleAccess={title}
       sx={{
-        color: theme.colors.textColor,
+        color: theme.legacy.colors.textColor,
         transform: shouldFlip ? 'scaleX(-1)' : undefined,
         width: 24,
         height: 24,

--- a/web/src/components/base/Link.tsx
+++ b/web/src/components/base/Link.tsx
@@ -8,12 +8,12 @@ import { UiDirectionType } from 'translations'
 import { isInternalLink, NEW_TAB, NEW_TAB_FEATURES } from '../../utils/openLink'
 
 const InternalLink = styled(RouterLink, { shouldForwardProp })<{ highlightedLink: boolean }>`
-  color: ${props => (props.highlightedLink ? props.theme.colors.linkColor : 'inherit')};
+  color: ${props => (props.highlightedLink ? props.theme.legacy.colors.linkColor : 'inherit')};
   text-decoration: ${props => (props.highlightedLink ? 'underline' : 'none')};
 `
 
 const ExternalLink = styled.a<{ highlightedLink: boolean }>`
-  color: ${props => (props.highlightedLink ? props.theme.colors.linkColor : 'inherit')};
+  color: ${props => (props.highlightedLink ? props.theme.legacy.colors.linkColor : 'inherit')};
   text-decoration: ${props => (props.highlightedLink ? 'underline' : 'none')};
 `
 

--- a/web/src/components/base/Tooltip.tsx
+++ b/web/src/components/base/Tooltip.tsx
@@ -7,8 +7,8 @@ const StyledTooltip = styled(ReactTooltip)`
   ${props =>
     props.theme.isContrastTheme &&
     `
-        color: ${props.theme.colors.textColor};
-        background-color: ${props.theme.colors.textSecondaryColor};
+        color: ${props.theme.legacy.colors.textColor};
+        background-color: ${props.theme.legacy.colors.textSecondaryColor};
       `}
 `
 

--- a/web/src/constants/layers.ts
+++ b/web/src/constants/layers.ts
@@ -1,7 +1,7 @@
+import { Theme } from '@mui/material/styles'
 import { Expression } from 'mapbox-gl'
 import { LayerProps } from 'react-map-gl/maplibre'
 
-import { LegacyThemeType } from 'build-configs/LegacyThemeType'
 import {
   circleRadiusLarge,
   circleRadiusSmall,
@@ -15,13 +15,19 @@ import {
   featureLayerId,
 } from 'shared'
 
-export const clusterLayer = (theme: LegacyThemeType): LayerProps => ({
+export const clusterLayer = (theme: Theme): LayerProps => ({
   id: clusterLayerId,
   type: 'circle',
   source: 'point',
   filter: ['has', 'point_count'],
   paint: {
-    'circle-color': ['step', ['get', 'point_count'], theme.colors.themeColor, groupCount, theme.colors.themeColor],
+    'circle-color': [
+      'step',
+      ['get', 'point_count'],
+      theme.legacy.colors.themeColor,
+      groupCount,
+      theme.legacy.colors.themeColor,
+    ],
     'circle-radius': ['step', ['get', 'point_count'], circleRadiusSmall, groupCount, circleRadiusLarge],
   },
 })

--- a/web/src/constants/theme.ts
+++ b/web/src/constants/theme.ts
@@ -15,26 +15,26 @@ export const helpers: HelpersType = {
   `,
   adaptiveFontSize: ({ theme }): SerializedStyles => css`
     font-size: clamp(
-      ${theme.fonts.adaptiveFontSizeSmall.min},
-      ${theme.fonts.adaptiveFontSizeSmall.value},
-      ${theme.fonts.adaptiveFontSizeSmall.max}
+      ${theme.legacy.fonts.adaptiveFontSizeSmall.min},
+      ${theme.legacy.fonts.adaptiveFontSizeSmall.value},
+      ${theme.legacy.fonts.adaptiveFontSizeSmall.max}
     );
   `,
   adaptiveWidth: ({ theme }): SerializedStyles => css`
     width: clamp(
-      ${theme.fonts.adaptiveFontSizeSmall.min},
-      ${theme.fonts.adaptiveFontSizeSmall.value},
-      ${theme.fonts.adaptiveFontSizeSmall.max}
+      ${theme.legacy.fonts.adaptiveFontSizeSmall.min},
+      ${theme.legacy.fonts.adaptiveFontSizeSmall.value},
+      ${theme.legacy.fonts.adaptiveFontSizeSmall.max}
     );
   `,
   adaptiveHeight: ({ theme }): SerializedStyles => css`
     height: clamp(
-      ${theme.fonts.adaptiveFontSizeSmall.min},
-      ${theme.fonts.adaptiveFontSizeSmall.value},
-      ${theme.fonts.adaptiveFontSizeSmall.max}
+      ${theme.legacy.fonts.adaptiveFontSizeSmall.min},
+      ${theme.legacy.fonts.adaptiveFontSizeSmall.value},
+      ${theme.legacy.fonts.adaptiveFontSizeSmall.max}
     );
   `,
   adaptiveThemeTextColor: ({ theme }): SerializedStyles => css`
-    color: ${theme.isContrastTheme ? theme.colors.backgroundColor : theme.colors.textColor};
+    color: ${theme.isContrastTheme ? theme.legacy.colors.backgroundColor : theme.legacy.colors.textColor};
   `,
 }

--- a/web/src/routes/CityNotCooperatingPage.tsx
+++ b/web/src/routes/CityNotCooperatingPage.tsx
@@ -20,14 +20,14 @@ const Heading = styled.p`
   font-weight: 600;
   text-align: center;
   font-size: 1.4rem;
-  font-family: ${props => props.theme.fonts.web.decorativeFont};
+  font-family: ${props => props.theme.legacy.fonts.web.decorativeFont};
   padding: 20px;
   white-space: pre-line;
 `
 
 const Text = styled.p`
-  font-size: ${props => props.theme.fonts.contentFontSize};
-  font-family: ${props => props.theme.fonts.web.contentFont};
+  font-size: ${props => props.theme.legacy.fonts.contentFontSize};
+  font-family: ${props => props.theme.legacy.fonts.web.contentFont};
 `
 
 const Icon = styled.img`
@@ -39,7 +39,7 @@ const Icon = styled.img`
 
 const ListHeading = styled(Heading)`
   padding: 0;
-  font-size: ${props => props.theme.fonts.decorativeFontSize};
+  font-size: ${props => props.theme.legacy.fonts.decorativeFontSize};
 `
 
 const ListItem = styled.div`
@@ -53,7 +53,7 @@ const StepNumber = styled.div`
   min-width: 2rem;
   height: 2rem;
   text-align: center;
-  background-color: ${props => props.theme.colors.themeColor};
+  background-color: ${props => props.theme.legacy.colors.themeColor};
   ${helpers.adaptiveThemeTextColor}
 `
 
@@ -71,7 +71,7 @@ const TemplateText = styled(Text)`
   position: relative;
   direction: ltr;
   top: -30px;
-  border: 1px solid ${props => props.theme.colors.themeColor};
+  border: 1px solid ${props => props.theme.legacy.colors.themeColor};
   padding: 50px 30px 30px;
   white-space: pre-line;
 `

--- a/web/src/routes/SearchPage.tsx
+++ b/web/src/routes/SearchPage.tsx
@@ -38,7 +38,7 @@ const List = styled.ul`
 
 const SearchCounter = styled.p`
   padding: 0 5px;
-  color: ${props => props.theme.colors.textSecondaryColor};
+  color: ${props => props.theme.legacy.colors.textSecondaryColor};
 `
 
 const SearchPage = ({ city, cityCode, languageCode }: CityRouteProps): ReactElement | null => {

--- a/web/src/routes/TuNewsDetailPage.tsx
+++ b/web/src/routes/TuNewsDetailPage.tsx
@@ -32,7 +32,7 @@ const StyledBanner = styled.div`
   overflow: hidden;
   align-items: center;
   margin: 25px 0;
-  background-color: ${props => props.theme.colors.tunewsThemeColorLight};
+  background-color: ${props => props.theme.legacy.colors.tunewsThemeColorLight};
   border-radius: 11px;
 `
 
@@ -47,8 +47,8 @@ const StyledTitle = styled.div`
   height: 100%;
   align-items: center;
   justify-content: center;
-  background-color: ${props => props.theme.colors.tunewsThemeColor};
-  color: ${props => props.theme.colors.backgroundColor};
+  background-color: ${props => props.theme.legacy.colors.tunewsThemeColor};
+  color: ${props => props.theme.legacy.colors.backgroundColor};
   font-size: 20px;
   font-weight: 700;
 `

--- a/web/src/styles/global/GlobalStyle.tsx
+++ b/web/src/styles/global/GlobalStyle.tsx
@@ -1,14 +1,13 @@
 import { css, SerializedStyles } from '@emotion/react'
+import { Theme } from '@mui/material/styles'
 
-import { LegacyThemeType } from 'build-configs'
-
-const GlobalStyle = ({ theme }: { theme: LegacyThemeType }): SerializedStyles => css`
+const GlobalStyle = ({ theme }: { theme: Theme }): SerializedStyles => css`
   body {
     position: relative;
 
     /* react-tooltip: https://react-tooltip.com/docs/getting-started#styling */
-    --rt-color-dark: ${theme.colors.textSecondaryColor};
-    --rt-color-white: ${theme.colors.backgroundColor};
+    --rt-color-dark: ${theme.legacy.colors.textSecondaryColor};
+    --rt-color-white: ${theme.legacy.colors.backgroundColor};
     --rt-opacity: 1;
 
     /* stylelint-disable selector-class-pattern */
@@ -16,13 +15,13 @@ const GlobalStyle = ({ theme }: { theme: LegacyThemeType }): SerializedStyles =>
     /* react-datepicker */
 
     .react-datepicker__header {
-      background-color: ${theme.colors.backgroundAccentColor};
+      background-color: ${theme.legacy.colors.backgroundAccentColor};
     }
 
     .react-datepicker__month,
     .react-datepicker__month-container,
     .react-datepicker__day {
-      background-color: ${theme.colors.backgroundColor};
+      background-color: ${theme.legacy.colors.backgroundColor};
     }
 
     .react-datepicker__current-month,
@@ -30,24 +29,24 @@ const GlobalStyle = ({ theme }: { theme: LegacyThemeType }): SerializedStyles =>
     .react-datepicker__day-name,
     .react-datepicker__week,
     .react-datepicker__day {
-      color: ${theme.colors.textColor};
+      color: ${theme.legacy.colors.textColor};
     }
 
     .react-datepicker__day--today {
-      border: 1px solid ${theme.colors.linkColor};
+      border: 1px solid ${theme.legacy.colors.linkColor};
       background-color: transparent !important;
       border-radius: 50% !important;
     }
 
     .react-datepicker__day--selected {
-      background-color: ${theme.colors.linkColor} !important;
+      background-color: ${theme.legacy.colors.linkColor} !important;
     }
 
     .react-datepicker__day--selected:not([aria-disabled='true']):hover,
     .react-datepicker__day--in-selecting-range:not([aria-disabled='true']):hover,
     .react-datepicker__day--in-range:not([aria-disabled='true']):hover,
     .react-datepicker__day:not([aria-disabled='true']):hover {
-      background-color: ${theme.colors.linkColor} !important;
+      background-color: ${theme.legacy.colors.linkColor} !important;
     }
 
     /* stylelint-enable selector-class-pattern */
@@ -55,13 +54,13 @@ const GlobalStyle = ({ theme }: { theme: LegacyThemeType }): SerializedStyles =>
     /* react-spring-bottom-sheet */
 
     [data-rsbs-header] {
-      background-color: ${theme.colors.backgroundAccentColor};
+      background-color: ${theme.legacy.colors.backgroundAccentColor};
       box-shadow: none;
       padding-top: calc(24px + env(safe-area-inset-top));
     }
 
     [data-rsbs-header]::before {
-      background-color: ${theme.colors.textColor};
+      background-color: ${theme.legacy.colors.textColor};
       width: 28px;
       height: 3px;
       top: calc(18px + env(safe-area-inset-top));
@@ -81,7 +80,7 @@ const GlobalStyle = ({ theme }: { theme: LegacyThemeType }): SerializedStyles =>
     }
 
     [data-rsbs-scroll='true'] {
-      background-color: ${theme.colors.backgroundColor};
+      background-color: ${theme.legacy.colors.backgroundColor};
     }
   }
 `


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Replace emotion with mui theme provider. This also fixes the issues in #3374.
The colorSchemes api is basically the same as our custom implemented high contrast mode. Having both therefore therefore leads to unexpected behavior if we use the dark theme and mui the light color theme or vice versa (see https://mui.com/material-ui/customization/dark-mode/#built-in-support).

The relevant changes are only in [ThemeContainer](https://github.com/digitalfabrik/integreat-app/pull/3466/files#diff-e413bcd35f739020e9d1c40e8bef08b72ac7242692a3290e4c2fd4925466408f).

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Replace emotion with mui theme provider
- Fix types
- Rename legacy theme
- Remove color schemes to fix wrongly picked up color

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Test the app in light and dark mode.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3465

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
