### PR TITLE
3310: Use MUI imports for styled and useTheme

### DIFF
--- a/web/src/@types/@emotion/react.d.ts
+++ b/web/src/@types/@emotion/react.d.ts
@@ -1,6 +1,0 @@
-import '@mui/material/styles'
-
-declare module '@mui/material/styles' {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-  export interface Theme {}
-}

--- a/web/src/@types/@emotion/react.d.ts
+++ b/web/src/@types/@emotion/react.d.ts
@@ -1,7 +1,6 @@
-import '@emotion/react'
-import { Theme as MuiTheme } from '@mui/material/styles'
+import '@mui/material/styles'
 
-declare module '@emotion/react' {
+declare module '@mui/material/styles' {
   // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-  export interface Theme extends MuiTheme {}
+  export interface Theme {}
 }

--- a/web/src/components/Accordion.tsx
+++ b/web/src/components/Accordion.tsx
@@ -1,7 +1,7 @@
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 import React, { useRef, useEffect, useState, ReactElement } from 'react'
 
-const AccordionWrapper = styled.div<{ height: number; overflowVisible: boolean }>`
+const AccordionWrapper = styled('div')<{ height: number; overflowVisible: boolean }>`
   transition: height 0.3s ease;
   height: ${props => props.height}px;
   width: 100%;

--- a/web/src/components/AppointmentOnlyIcon.tsx
+++ b/web/src/components/AppointmentOnlyIcon.tsx
@@ -1,19 +1,19 @@
-import styled from '@emotion/styled'
 import ErrorOutlineOutlinedIcon from '@mui/icons-material/ErrorOutlineOutlined'
 import Tooltip from '@mui/material/Tooltip'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 
 import Icon from './base/Icon'
 import Link from './base/Link'
 
-const Container = styled.div`
+const Container = styled('div')`
   position: absolute;
   inset-inline-end: -27px;
   top: 4px;
 `
 
-const IconContainer = styled.button`
+const IconContainer = styled('button')`
   padding: 0;
   border: none;
   background-color: transparent;
@@ -27,13 +27,13 @@ const StyledIcon = styled(Icon)`
   align-self: center;
 `
 
-const TooltipContent = styled.span`
+const TooltipContent = styled('span')`
   ${props => props.theme.breakpoints.down('md')} {
     font-size: 14px;
   }
 `
 
-const TooltipTitle = styled.div`
+const TooltipTitle = styled('div')`
   font-weight: 700;
   margin-bottom: 8px;
 

--- a/web/src/components/BottomActionSheet.tsx
+++ b/web/src/components/BottomActionSheet.tsx
@@ -1,5 +1,5 @@
-import styled from '@emotion/styled'
 import Divider from '@mui/material/Divider'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement, ReactNode, RefObject, useImperativeHandle, useRef, useState } from 'react'
 import { BottomSheet, BottomSheetRef } from 'react-spring-bottom-sheet'
 import 'react-spring-bottom-sheet/dist/style.css'
@@ -8,12 +8,12 @@ import { SpringEvent } from 'react-spring-bottom-sheet/dist/types'
 import { getSnapPoints } from '../utils/getSnapPoints'
 import { RichLayout } from './Layout'
 
-const Title = styled.h1`
+const Title = styled('h1')`
   font-size: 1.25rem;
   font-family: ${props => props.theme.legacy.fonts.web.contentFont};
 `
 
-const ToolbarContainer = styled.div`
+const ToolbarContainer = styled('div')`
   flex: 1;
   display: flex;
   flex-direction: column;

--- a/web/src/components/Breadcrumb.tsx
+++ b/web/src/components/Breadcrumb.tsx
@@ -1,10 +1,10 @@
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement, ReactNode } from 'react'
 
 import { helpers } from '../constants/theme'
 
 const SHRINK_FACTOR = 0.1
-const ListItem = styled.li<{ shrink: boolean }>`
+const ListItem = styled('li')<{ shrink: boolean }>`
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
@@ -22,7 +22,7 @@ const ListItem = styled.li<{ shrink: boolean }>`
   }
 `
 
-const Separator = styled.span`
+const Separator = styled('li')`
   &::before {
     color: ${props => props.theme.legacy.colors.textColor};
     font-size: 19px;

--- a/web/src/components/Breadcrumb.tsx
+++ b/web/src/components/Breadcrumb.tsx
@@ -22,7 +22,7 @@ const ListItem = styled('li')<{ shrink: boolean }>`
   }
 `
 
-const Separator = styled('li')`
+const Separator = styled('span')`
   &::before {
     color: ${props => props.theme.legacy.colors.textColor};
     font-size: 19px;

--- a/web/src/components/Breadcrumbs.tsx
+++ b/web/src/components/Breadcrumbs.tsx
@@ -1,5 +1,5 @@
-import styled from '@emotion/styled'
 import HomeOutlinedIcon from '@mui/icons-material/HomeOutlined'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 import { Link } from 'react-router-dom'
 
@@ -12,7 +12,7 @@ import Icon from './base/Icon'
 
 const opposite = (direction: UiDirectionType) => (direction === 'ltr' ? 'rtl' : 'ltr')
 
-const Wrapper = styled.nav`
+const Wrapper = styled('nav')`
   margin: 10px 0;
   text-align: start;
   white-space: nowrap;
@@ -21,7 +21,7 @@ const Wrapper = styled.nav`
   direction: ${props => opposite(props.theme.contentDirection)};
 `
 
-const OrderedList = styled.ol`
+const OrderedList = styled('ol')`
   direction: ${props => props.theme.contentDirection};
   display: flex;
   white-space: nowrap;

--- a/web/src/components/Caption.tsx
+++ b/web/src/components/Caption.tsx
@@ -1,7 +1,7 @@
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 
-const H1 = styled.h1`
+const H1 = styled('h1')`
   margin: 25px 0;
   font-size: 2rem;
   text-align: center;

--- a/web/src/components/CategoriesContent.tsx
+++ b/web/src/components/CategoriesContent.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -13,7 +13,7 @@ import OrganizationContentInfo from './OrganizationContentInfo'
 import Page from './Page'
 import Tiles from './Tiles'
 
-const List = styled.ul`
+const List = styled('ul')`
   list-style-type: none;
 
   & a {

--- a/web/src/components/CategoryListItem.tsx
+++ b/web/src/components/CategoryListItem.tsx
@@ -1,24 +1,24 @@
-import styled from '@emotion/styled'
 import Divider from '@mui/material/Divider'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 import { Link } from 'react-router-dom'
 
 import { CategoryModel } from 'shared/api'
 
-const Row = styled.li`
+const Row = styled('li')`
   width: 100%;
 `
 
-const SubCategoriesContainer = styled.ul`
+const SubCategoriesContainer = styled('ul')`
   list-style-type: none;
 `
 
-const SubCategory = styled.li`
+const SubCategory = styled('li')`
   text-align: start;
   width: 100%;
 `
 
-const CategoryThumbnail = styled.img`
+const CategoryThumbnail = styled('img')`
   width: 30px;
   height: 30px;
   padding: 0 5px;
@@ -27,7 +27,7 @@ const CategoryThumbnail = styled.img`
   filter: ${props => (props.theme.isContrastTheme ? 'invert(1)' : 'none')};
 `
 
-const CategoryItemCaption = styled.span`
+const CategoryItemCaption = styled('span')`
   align-items: center;
   padding: 15px 5px;
   color: inherit;

--- a/web/src/components/Chat.tsx
+++ b/web/src/components/Chat.tsx
@@ -1,6 +1,6 @@
-import styled from '@emotion/styled'
 import SendIcon from '@mui/icons-material/Send'
 import Button from '@mui/material/Button'
+import { styled } from '@mui/material/styles'
 import React, { KeyboardEvent, ReactElement, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -15,7 +15,7 @@ import PrivacyCheckbox from './PrivacyCheckbox'
 import Input from './base/Input'
 import InputSection from './base/InputSection'
 
-const Container = styled.div`
+const Container = styled('div')`
   height: 100%;
   padding: 12px 0;
   gap: ${props => props.theme.spacing(1)};
@@ -33,7 +33,7 @@ const LoadingContainer = styled(Container)`
   justify-content: center;
 `
 
-const SubmitContainer = styled.div`
+const SubmitContainer = styled('div')`
   gap: ${props => props.theme.spacing(1)};
   display: flex;
 `
@@ -42,7 +42,7 @@ const SubmitButton = styled(Button)`
   flex: 1;
 `
 
-const LoadingText = styled.div`
+const LoadingText = styled('div')`
   text-align: center;
 `
 
@@ -50,7 +50,7 @@ const StyledLoadingSpinner = styled(LoadingSpinner)`
   margin-top: 0;
 `
 
-const InputWrapper = styled.div`
+const InputWrapper = styled('div')`
   display: flex;
   flex-direction: column;
   padding: 0 12px;

--- a/web/src/components/ChatContainer.tsx
+++ b/web/src/components/ChatContainer.tsx
@@ -1,6 +1,6 @@
-import styled from '@emotion/styled'
 import QuestionAnswerOutlinedIcon from '@mui/icons-material/QuestionAnswerOutlined'
 import Fab from '@mui/material/Fab'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement, useContext, useEffect, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
 
@@ -18,7 +18,7 @@ import Icon from './base/Icon'
 
 const CHAT_BUTTON_SIZE = 48
 
-const ChatButtonContainer = styled.div<{ bottom: number }>`
+const ChatButtonContainer = styled('div')<{ bottom: number }>`
   position: fixed;
   bottom: ${props => props.bottom}px;
   inset-inline-end: 16px;
@@ -38,7 +38,7 @@ const StyledIcon = styled(Icon)`
   color: ${props => props.theme.legacy.colors.backgroundColor};
 `
 
-const ChatTitle = styled.span`
+const ChatTitle = styled('span')`
   text-align: center;
   margin-top: 8px;
   color: ${props => props.theme.legacy.colors.textColor};

--- a/web/src/components/ChatContentWrapper.tsx
+++ b/web/src/components/ChatContentWrapper.tsx
@@ -1,11 +1,11 @@
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement, ReactNode } from 'react'
 
 import { helpers } from '../constants/theme'
 import useWindowDimensions from '../hooks/useWindowDimensions'
 import ChatMenu from './ChatMenu'
 
-const Container = styled.div`
+const Container = styled('div')`
   display: flex;
   flex-direction: column;
   font-family: ${props => props.theme.legacy.fonts.web.decorativeFont};
@@ -18,7 +18,7 @@ const Container = styled.div`
   }
 `
 
-const Header = styled.div<{ small: boolean }>`
+const Header = styled('div')<{ small: boolean }>`
   display: flex;
   flex-direction: ${props => (props.small ? 'row-reverse' : 'row')};
   justify-content: space-between;

--- a/web/src/components/ChatConversation.tsx
+++ b/web/src/components/ChatConversation.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -6,17 +6,17 @@ import { ChatMessageModel } from 'shared/api'
 
 import ChatMessage, { InnerChatMessage } from './ChatMessage'
 
-const Container = styled.div`
+const Container = styled('div')`
   font-size: ${props => props.theme.legacy.fonts.hintFontSize};
   overflow: auto;
   padding: 0 12px;
 `
 
-const InitialMessage = styled.div`
+const InitialMessage = styled('div')`
   margin-bottom: 12px;
 `
 
-const ErrorSendingStatus = styled.div`
+const ErrorSendingStatus = styled('div')`
   background-color: ${props => props.theme.legacy.colors.invalidInput};
   border-radius: 5px;
   padding: 8px;

--- a/web/src/components/ChatMenu.tsx
+++ b/web/src/components/ChatMenu.tsx
@@ -1,6 +1,6 @@
-import styled from '@emotion/styled'
 import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew'
 import CloseFullscreenIcon from '@mui/icons-material/CloseFullscreen'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -25,7 +25,7 @@ const StyledIcon = styled(Icon)`
   }
 `
 
-const ButtonContainer = styled.div`
+const ButtonContainer = styled('div')`
   display: flex;
   gap: 8px;
 `

--- a/web/src/components/ChatMessage.tsx
+++ b/web/src/components/ChatMessage.tsx
@@ -1,6 +1,6 @@
-import styled from '@emotion/styled'
 import PersonOutlinedIcon from '@mui/icons-material/PersonOutlined'
 import SmartToyOutlinedIcon from '@mui/icons-material/SmartToyOutlined'
+import { styled } from '@mui/material/styles'
 import { TFunction } from 'i18next'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -10,7 +10,7 @@ import { ChatMessageModel } from 'shared/api'
 import RemoteContent from './RemoteContent'
 import Icon from './base/Icon'
 
-export const Message = styled.div`
+export const Message = styled('div')`
   color: ${props => props.theme.legacy.colors.textColor};
   border-radius: 5px;
   padding: 8px;
@@ -28,18 +28,18 @@ const StyledChatIcon = styled(Icon)`
   border-radius: 4px;
 `
 
-const Container = styled.div<{ isAuthor: boolean }>`
+const Container = styled('div')<{ isAuthor: boolean }>`
   display: flex;
   flex-direction: ${props => (props.isAuthor ? 'row-reverse' : 'row')};
   margin-bottom: 12px;
   gap: 8px;
 `
 
-const IconContainer = styled.div<{ visible: boolean }>`
+const IconContainer = styled('div')<{ visible: boolean }>`
   opacity: ${props => (props.visible ? 1 : 0)};
 `
 
-const Circle = styled.div`
+const Circle = styled('div')`
   display: flex;
   background-color: ${props => props.theme.legacy.colors.textColor};
   border-radius: 50%;

--- a/web/src/components/ChatModal.tsx
+++ b/web/src/components/ChatModal.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 import FocusTrap from 'focus-trap-react'
 import React, { ReactElement, ReactNode, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -16,7 +16,7 @@ const Overlay = styled(Button)`
   height: 100%;
 `
 
-const ModalContainer = styled.div`
+const ModalContainer = styled('div')`
   position: fixed;
   inset: 0;
   z-index: 100;
@@ -25,7 +25,7 @@ const ModalContainer = styled.div`
   justify-content: flex-end;
 `
 
-const ModalContentContainer = styled.div`
+const ModalContentContainer = styled('div')`
   ${props => props.theme.breakpoints.up('md')} {
     margin-inline-end: 20px;
   }

--- a/web/src/components/ChatPrivacyInformation.tsx
+++ b/web/src/components/ChatPrivacyInformation.tsx
@@ -1,5 +1,5 @@
-import styled from '@emotion/styled'
 import MailLock from '@mui/icons-material/MailLock'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 
 import buildConfig from '../constants/buildConfig'

--- a/web/src/components/CityContentFooter.tsx
+++ b/web/src/components/CityContentFooter.tsx
@@ -1,5 +1,5 @@
-import styled from '@emotion/styled'
 import Divider from '@mui/material/Divider'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -10,7 +10,7 @@ import useWindowDimensions from '../hooks/useWindowDimensions'
 import Footer from './Footer'
 import Link from './base/Link'
 
-const SidebarFooterContainer = styled.div`
+const SidebarFooterContainer = styled('div')`
   width: 100%;
   margin-top: -10px; /* to counteract the padding-top of the normal footer */
   padding: 0 27px;

--- a/web/src/components/CityEntry.tsx
+++ b/web/src/components/CityEntry.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 import { Link } from 'react-router-dom'
 
@@ -24,7 +24,7 @@ const CityListItem = styled(Link)`
   }
 `
 
-const AliasContainer = styled.div`
+const AliasContainer = styled('div')`
   margin: 0 4px;
   font-size: 12px;
 `

--- a/web/src/components/CityNotCooperatingFooter.tsx
+++ b/web/src/components/CityNotCooperatingFooter.tsx
@@ -1,6 +1,6 @@
-import styled from '@emotion/styled'
 import Button from '@mui/material/Button'
 import Divider from '@mui/material/Divider'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -10,7 +10,7 @@ import buildConfig from '../constants/buildConfig'
 import Icon from './base/Icon'
 import Link from './base/Link'
 
-const FooterContainer = styled.div`
+const FooterContainer = styled('div')`
   background-color: ${props => props.theme.legacy.colors.backgroundAccentColor};
   display: flex;
   flex-direction: column;
@@ -24,7 +24,7 @@ const StyledIcon = styled(Icon)`
   flex-shrink: 0;
 `
 
-const Question = styled.p`
+const Question = styled('p')`
   font: ${props => props.theme.legacy.fonts.web.decorativeFont};
   font-weight: 400;
 `

--- a/web/src/components/CitySelector.tsx
+++ b/web/src/components/CitySelector.tsx
@@ -1,6 +1,6 @@
-import styled from '@emotion/styled'
 import Divider from '@mui/material/Divider'
 import Typography from '@mui/material/Typography'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -14,7 +14,7 @@ import Failure from './Failure'
 import NearbyCities from './NearbyCities'
 import ScrollingSearchBox from './ScrollingSearchBox'
 
-const Container = styled.div`
+const Container = styled('div')`
   padding-top: 22px;
 `
 
@@ -28,7 +28,7 @@ export const CityListParent = styled(Typography)<{ stickyTop: number }>`
   background-color: ${props => props.theme.legacy.colors.backgroundColor};
 `
 
-const SearchCounter = styled.p`
+const SearchCounter = styled('p')`
   color: ${props => props.theme.legacy.colors.textSecondaryColor};
 `
 

--- a/web/src/components/Collapsible.tsx
+++ b/web/src/components/Collapsible.tsx
@@ -1,6 +1,6 @@
-import styled from '@emotion/styled'
 import ExpandLessIcon from '@mui/icons-material/ExpandLess'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -8,7 +8,7 @@ import { helpers } from '../constants/theme'
 import Button from './base/Button'
 import Icon from './base/Icon'
 
-const Container = styled.div`
+const Container = styled('div')`
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -20,7 +20,7 @@ const CollapsibleHeader = styled(Button)`
   color: ${props => props.theme.legacy.colors.textColor};
 `
 
-const Title = styled.div`
+const Title = styled('div')`
   display: flex;
   flex: 1;
   font-weight: 700;

--- a/web/src/components/ConsentSection.tsx
+++ b/web/src/components/ConsentSection.tsx
@@ -1,10 +1,10 @@
-import styled from '@emotion/styled'
 import Divider from '@mui/material/Divider'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 
 import Checkbox from './base/Checkbox'
 
-const Container = styled.div`
+const Container = styled('div')`
   flex-direction: row;
   padding: 16px 0;
 `

--- a/web/src/components/Contact.tsx
+++ b/web/src/components/Contact.tsx
@@ -1,9 +1,9 @@
-import styled from '@emotion/styled'
 import MailOutlinedIcon from '@mui/icons-material/MailOutlined'
 import OpenInNewIcon from '@mui/icons-material/OpenInNew'
 import PhoneOutlinedIcon from '@mui/icons-material/PhoneOutlined'
 import PublicOutlinedIcon from '@mui/icons-material/PublicOutlined'
 import Divider from '@mui/material/Divider'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -12,7 +12,7 @@ import { ContactModel } from 'shared/api'
 import { helpers } from '../constants/theme'
 import ContactItem from './ContactItem'
 
-const StyledContactHeader = styled.div`
+const StyledContactHeader = styled('div')`
   margin-bottom: 6px;
   ${helpers.adaptiveFontSize};
 `

--- a/web/src/components/ContactItem.tsx
+++ b/web/src/components/ContactItem.tsx
@@ -1,5 +1,5 @@
-import styled from '@emotion/styled'
 import { SvgIconProps } from '@mui/material/SvgIcon'
+import { styled } from '@mui/material/styles'
 import React, { ElementType, ReactElement } from 'react'
 
 import { helpers } from '../constants/theme'

--- a/web/src/components/ContrastThemeToggle.tsx
+++ b/web/src/components/ContrastThemeToggle.tsx
@@ -1,6 +1,5 @@
-import { useTheme } from '@emotion/react'
-import styled from '@emotion/styled'
 import ContrastIcon from '@mui/icons-material/Contrast'
+import { useTheme, styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 

--- a/web/src/components/CrashTestingIcon.tsx
+++ b/web/src/components/CrashTestingIcon.tsx
@@ -1,5 +1,5 @@
-import styled from '@emotion/styled'
 import LocationOnIcon from '@mui/icons-material/LocationOn'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement, useState } from 'react'
 
 import Icon from './base/Icon'

--- a/web/src/components/DatePicker.tsx
+++ b/web/src/components/DatePicker.tsx
@@ -1,6 +1,6 @@
-import styled from '@emotion/styled'
 import EventIcon from '@mui/icons-material/Event'
 import IconButton from '@mui/material/IconButton'
+import { styled } from '@mui/material/styles'
 import { DateTime } from 'luxon'
 import React, { ReactElement, useEffect, useState } from 'react'
 import DatePicker, { DatePickerProps } from 'react-datepicker'
@@ -11,12 +11,12 @@ import '../styles/DatePickerCalendar.css'
 
 const INPUT_HEIGHT = '56px'
 
-const DateContainer = styled.div`
+const DateContainer = styled('div')`
   width: fit-content;
   position: relative;
 `
 
-const StyledInputWrapper = styled.div`
+const StyledInputWrapper = styled('div')`
   display: flex;
 `
 
@@ -47,7 +47,7 @@ const StyledInput = styled(DatePickerWrapper)`
   }
 `
 
-const StyledTitle = styled.span`
+const StyledTitle = styled('span')`
   background-color: ${props => props.theme.legacy.colors.backgroundColor};
   position: absolute;
   top: -12px;
@@ -56,7 +56,7 @@ const StyledTitle = styled.span`
   font-size: 12px;
 `
 
-const StyledError = styled.div`
+const StyledError = styled('div')`
   font-size: 12px;
   font-weight: bold;
   color: ${props => props.theme.legacy.colors.invalidInput};

--- a/web/src/components/DatesPageDetail.tsx
+++ b/web/src/components/DatesPageDetail.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -9,7 +9,7 @@ import useWindowDimensions from '../hooks/useWindowDimensions'
 import Collapsible from './Collapsible'
 import PageDetail from './PageDetail'
 
-const Identifier = styled.span`
+const Identifier = styled('span')`
   font-weight: bold;
 `
 

--- a/web/src/components/DropDownContainer.tsx
+++ b/web/src/components/DropDownContainer.tsx
@@ -1,8 +1,8 @@
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 
 import dimensions from '../constants/dimensions'
 
-const DropDownContainer = styled.div<{ active: boolean }>`
+const DropDownContainer = styled('div')<{ active: boolean }>`
   position: absolute;
   top: ${dimensions.headerHeightLarge}px;
   inset-inline-end: 0;

--- a/web/src/components/EmbeddedOffers.tsx
+++ b/web/src/components/EmbeddedOffers.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 
 import { MALTE_HELP_FORM_OFFER_ALIAS, SPRUNGBRETT_OFFER_ALIAS } from 'shared'
@@ -8,7 +8,7 @@ import { CityRouteProps } from '../CityContentSwitcher'
 import MalteHelpForm from './MalteHelpForm'
 import SprungbrettOffer from './SprungbrettOffer'
 
-const Container = styled.div<{ withMargin: boolean }>`
+const Container = styled('div')<{ withMargin: boolean }>`
   ${props => props.withMargin && 'margin-top: 48px;'}
 `
 

--- a/web/src/components/EventListItem.tsx
+++ b/web/src/components/EventListItem.tsx
@@ -1,7 +1,7 @@
-import styled from '@emotion/styled'
 import EventRepeatOutlinedIcon from '@mui/icons-material/EventRepeatOutlined'
 import TodayOutlinedIcon from '@mui/icons-material/TodayOutlined'
 import Tooltip from '@mui/material/Tooltip'
+import { styled } from '@mui/material/styles'
 import { DateTime } from 'luxon'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -20,7 +20,7 @@ import { EXCERPT_MAX_CHARS } from '../constants'
 import useWindowDimensions from '../hooks/useWindowDimensions'
 import ListItem from './ListItem'
 
-const Content = styled.div`
+const Content = styled('div')`
   overflow-wrap: anywhere;
 `
 

--- a/web/src/components/EventsDateFilter.tsx
+++ b/web/src/components/EventsDateFilter.tsx
@@ -1,5 +1,5 @@
-import styled from '@emotion/styled'
 import CloseOutlinedIcon from '@mui/icons-material/CloseOutlined'
+import { styled } from '@mui/material/styles'
 import { DateTime } from 'luxon'
 import React, { ReactElement, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -10,7 +10,7 @@ import FilterToggle from './FilterToggle'
 import Button from './base/Button'
 import Icon from './base/Icon'
 
-const DateSection = styled.div`
+const DateSection = styled('div')`
   display: flex;
   gap: 10px;
   margin: 15px 5px;
@@ -21,7 +21,7 @@ const DateSection = styled.div`
     align-items: center;
   }
 `
-const Text = styled.span`
+const Text = styled('span')`
   color: ${props => props.theme.legacy.colors.textColor};
 `
 

--- a/web/src/components/ExportEventButton.tsx
+++ b/web/src/components/ExportEventButton.tsx
@@ -1,6 +1,6 @@
-import styled from '@emotion/styled'
 import DownloadIcon from '@mui/icons-material/Download'
 import Button from '@mui/material/Button'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -9,7 +9,7 @@ import { EventModel } from 'shared/api'
 import buildConfig from '../constants/buildConfig'
 import RadioGroup from './base/RadioGroup'
 
-const ButtonContainer = styled.div`
+const ButtonContainer = styled('div')`
   display: flex;
   gap: 16px;
 `

--- a/web/src/components/Failure.tsx
+++ b/web/src/components/Failure.tsx
@@ -1,12 +1,12 @@
-import styled from '@emotion/styled'
 import SentimentVeryDissatisfiedIcon from '@mui/icons-material/SentimentVeryDissatisfied'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 
 import Icon from './base/Icon'
 
-const Container = styled.div`
+const Container = styled('div')`
   display: flex;
   flex-direction: column;
   gap: 24px;

--- a/web/src/components/Feedback.tsx
+++ b/web/src/components/Feedback.tsx
@@ -1,6 +1,6 @@
-import styled from '@emotion/styled'
 import SendIcon from '@mui/icons-material/Send'
 import Button from '@mui/material/Button'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -14,7 +14,7 @@ import PrivacyCheckbox from './PrivacyCheckbox'
 import Input from './base/Input'
 import InputSection from './base/InputSection'
 
-export const Container = styled.div<{ fullWidth?: boolean }>`
+export const Container = styled('div')<{ fullWidth?: boolean }>`
   display: flex;
   flex: 1;
   max-height: 80vh;
@@ -34,7 +34,7 @@ export const Container = styled.div<{ fullWidth?: boolean }>`
   }
 `
 
-const ErrorSendingStatus = styled.div`
+const ErrorSendingStatus = styled('div')`
   font-weight: bold;
 `
 

--- a/web/src/components/FeedbackButtons.tsx
+++ b/web/src/components/FeedbackButtons.tsx
@@ -1,6 +1,6 @@
-import styled from '@emotion/styled'
 import SentimentDissatisfiedOutlinedIcon from '@mui/icons-material/SentimentDissatisfiedOutlined'
 import SentimentSatisfiedOutlinedIcon from '@mui/icons-material/SentimentSatisfiedOutlined'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 

--- a/web/src/components/FilterToggle.tsx
+++ b/web/src/components/FilterToggle.tsx
@@ -1,6 +1,6 @@
-import styled from '@emotion/styled'
 import CloseFullscreenIcon from '@mui/icons-material/CloseFullscreen'
 import FilterListIcon from '@mui/icons-material/FilterList'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -17,7 +17,7 @@ const StyledButton = styled(Button)`
   margin-bottom: 10px;
 `
 
-const Text = styled.span`
+const Text = styled('span')`
   color: ${props => props.theme.legacy.colors.textColor};
 `
 

--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement, ReactNode } from 'react'
 
 import buildConfig from '../constants/buildConfig'
@@ -8,7 +8,7 @@ type FooterProps = {
   overlay?: boolean
 }
 
-const FooterContainer = styled.footer<{ overlay: boolean }>`
+const FooterContainer = styled('footer')<{ overlay: boolean }>`
   display: flex;
   flex-wrap: wrap;
   justify-content: center;

--- a/web/src/components/GoBack.tsx
+++ b/web/src/components/GoBack.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react'
-import styled from '@emotion/styled'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import Divider from '@mui/material/Divider'
+import { styled } from '@mui/material/styles'
 import React, { memo, ReactElement } from 'react'
 
 import { helpers } from '../constants/theme'
@@ -29,7 +29,7 @@ const StyledButton = styled(Button)<{ viewportSmall: boolean }>`
     `};
 `
 
-const DetailsHeaderTitle = styled.span`
+const DetailsHeaderTitle = styled('span')`
   color: ${props => props.theme.legacy.colors.textColor};
   align-self: center;
   white-space: pre;

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -1,5 +1,5 @@
-import styled from '@emotion/styled'
 import Headroom from '@integreat-app/react-sticky-headroom'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement, ReactNode } from 'react'
 
 import dimensions from '../constants/dimensions'
@@ -23,7 +23,7 @@ type HeaderProps = {
   language: string
 }
 
-const HeaderContainer = styled.header`
+const HeaderContainer = styled('header')`
   display: flex;
   width: 100%;
   box-sizing: border-box;
@@ -39,7 +39,7 @@ const HeaderContainer = styled.header`
   }
 `
 
-const Row = styled.div`
+const Row = styled('div')`
   display: flex;
   flex: 1;
   max-width: 100%;
@@ -57,7 +57,7 @@ const Row = styled.div`
   }
 `
 
-const HeaderSeparator = styled.div`
+const HeaderSeparator = styled('div')`
   align-self: center;
   height: ${dimensions.headerHeightLarge / 2}px;
   width: 2px;
@@ -70,7 +70,7 @@ const HeaderSeparator = styled.div`
   }
 `
 
-const ActionBar = styled.nav`
+const ActionBar = styled('nav')`
   order: 3;
   display: flex;
   align-items: center;
@@ -83,7 +83,7 @@ const ActionBar = styled.nav`
   }
 `
 
-const NavigationBar = styled.nav`
+const NavigationBar = styled('nav')`
   display: flex;
   flex: 1 1 0;
   align-items: stretch;

--- a/web/src/components/HeaderActionItemDropDown.tsx
+++ b/web/src/components/HeaderActionItemDropDown.tsx
@@ -1,8 +1,7 @@
-import { useTheme } from '@emotion/react'
-import styled from '@emotion/styled'
 import Button from '@mui/material/Button'
 import IconButton from '@mui/material/IconButton'
 import Tooltip from '@mui/material/Tooltip'
+import { useTheme, styled } from '@mui/material/styles'
 import React, { ReactElement, ReactNode, useRef, useState } from 'react'
 
 import useOnClickOutside from '../hooks/useOnClickOutside'

--- a/web/src/components/HeaderActionItemLink.tsx
+++ b/web/src/components/HeaderActionItemLink.tsx
@@ -1,6 +1,6 @@
-import { useTheme } from '@emotion/react'
 import IconButton from '@mui/material/IconButton'
 import Tooltip from '@mui/material/Tooltip'
+import { useTheme } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 
 import Link from './base/Link'

--- a/web/src/components/HeaderLogo.tsx
+++ b/web/src/components/HeaderLogo.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 import { DateTime } from 'luxon'
 import React, { ReactElement } from 'react'
 import SVG from 'react-inlinesvg'
@@ -11,7 +11,7 @@ type HeaderLogoProps = {
   link: string
 }
 
-const LogoContainer = styled.div`
+const LogoContainer = styled('div')`
   box-sizing: border-box;
   padding: 0 10px;
   flex: initial;

--- a/web/src/components/HeaderNavigationItem.tsx
+++ b/web/src/components/HeaderNavigationItem.tsx
@@ -1,13 +1,13 @@
 import { css } from '@emotion/react'
-import styled from '@emotion/styled'
 import { SvgIconProps } from '@mui/material/SvgIcon'
+import { styled } from '@mui/material/styles'
 import React, { ElementType, ReactElement } from 'react'
 
 import { helpers } from '../constants/theme'
 import Icon from './base/Icon'
 import Link from './base/Link'
 
-const Container = styled.div`
+const Container = styled('div')`
   flex: 1 1 135px;
 `
 
@@ -61,14 +61,14 @@ const StyledLink = styled(Link)<{ active: boolean }>`
     `}
 `
 
-const StyledText = styled.span<{ active: boolean }>`
+const StyledText = styled('span')<{ active: boolean }>`
   font-weight: ${props => (props.active ? 'bold' : 'normal')};
 `
 
 const ICON_SIZE_LARGE = 50
 const ICON_SIZE_SMALL = 35
 
-const Circle = styled.div`
+const Circle = styled('div')`
   display: flex;
   justify-content: center;
   align-items: center;

--- a/web/src/components/HeaderTitle.tsx
+++ b/web/src/components/HeaderTitle.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 
 import dimensions from '../constants/dimensions'
@@ -6,7 +6,7 @@ import dimensions from '../constants/dimensions'
 const LONG_TITLE_LENGTH = 25
 export const HEADER_TITLE_HEIGHT = 50
 
-const HeaderTitleContainer = styled.div<{ long: boolean }>`
+const HeaderTitleContainer = styled('div')<{ long: boolean }>`
   display: flex;
   align-items: center;
   font-size: ${props => (props.long ? '1.3rem' : '1.8rem')};

--- a/web/src/components/HighlightBox.tsx
+++ b/web/src/components/HighlightBox.tsx
@@ -1,6 +1,6 @@
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 
-const HighlightBox = styled.div`
+const HighlightBox = styled('div')`
   background-color: ${props => props.theme.legacy.colors.backgroundAccentColor};
   border-radius: 4px;
   padding: 20px;

--- a/web/src/components/Highlighter.tsx
+++ b/web/src/components/Highlighter.tsx
@@ -1,4 +1,4 @@
-import { useTheme } from '@emotion/react'
+import { useTheme } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 import ReactHighlighter from 'react-highlight-words'
 

--- a/web/src/components/InfiniteScrollList.tsx
+++ b/web/src/components/InfiniteScrollList.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement, ReactNode, useCallback, useEffect, useState } from 'react'
 import InfiniteScroll from 'react-infinite-scroller'
 
@@ -6,12 +6,12 @@ import { loadAsync } from 'shared/api'
 
 import FailureSwitcher from './FailureSwitcher'
 
-const NoItemsMessage = styled.div`
+const NoItemsMessage = styled('div')`
   padding-top: 25px;
   text-align: center;
 `
 
-const StyledList = styled.div`
+const StyledList = styled('div')`
   position: relative;
   margin-bottom: 40px;
   padding-top: 1px;

--- a/web/src/components/KebabActionItem.tsx
+++ b/web/src/components/KebabActionItem.tsx
@@ -1,10 +1,10 @@
-import styled from '@emotion/styled'
 import { SvgIconProps } from '@mui/material/SvgIcon'
+import { styled } from '@mui/material/styles'
 import React, { ElementType, ReactElement } from 'react'
 
 import Icon from './base/Icon'
 
-const Container = styled.span`
+const Container = styled('span')`
   display: flex;
   flex: 1;
   text-decoration: none;

--- a/web/src/components/KebabActionItemDropDown.tsx
+++ b/web/src/components/KebabActionItemDropDown.tsx
@@ -1,5 +1,5 @@
-import styled from '@emotion/styled'
 import { SvgIconProps } from '@mui/material/SvgIcon'
+import { styled } from '@mui/material/styles'
 import React, { ElementType, ReactElement, ReactNode, useRef, useState } from 'react'
 
 import useOnClickOutside from '../hooks/useOnClickOutside'
@@ -12,7 +12,7 @@ const StyledButton = styled(Button)`
   flex: 1;
 `
 
-const Container = styled.div`
+const Container = styled('div')`
   display: flex;
 `
 

--- a/web/src/components/KebabMenu.tsx
+++ b/web/src/components/KebabMenu.tsx
@@ -1,8 +1,8 @@
-import styled from '@emotion/styled'
 import CloseIcon from '@mui/icons-material/Close'
 import MoreVertIcon from '@mui/icons-material/MoreVert'
 import Divider from '@mui/material/Divider'
 import IconButton from '@mui/material/IconButton'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement, ReactNode, useLayoutEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -17,13 +17,13 @@ type KebabMenuProps = {
   Footer: ReactNode
 }
 
-const ToggleContainer = styled.div`
+const ToggleContainer = styled('div')`
   display: flex;
   padding: 0 8px;
   z-index: 50;
 `
 
-const List = styled.div`
+const List = styled('div')`
   font-family: ${props => props.theme.legacy.fonts.web.decorativeFont};
   position: fixed;
   top: 0;
@@ -42,7 +42,7 @@ const List = styled.div`
   flex-direction: column;
 `
 
-const Overlay = styled.div<{ show: boolean }>`
+const Overlay = styled('div')<{ show: boolean }>`
   position: fixed;
   width: 100%;
   height: 100vh;
@@ -53,7 +53,7 @@ const Overlay = styled.div<{ show: boolean }>`
   display: ${props => (props.show ? `block` : `none`)};
 `
 
-const Heading = styled.div`
+const Heading = styled('div')`
   display: flex;
   justify-content: flex-end;
   background-color: ${props => props.theme.legacy.colors.backgroundAccentColor};
@@ -63,13 +63,13 @@ const Heading = styled.div`
   padding: 8px;
 `
 
-const ActionBar = styled.nav`
+const ActionBar = styled('nav')`
   display: flex;
   align-items: center;
   padding: 0 16px;
 `
 
-const Content = styled.div`
+const Content = styled('div')`
   padding: 0 32px;
 `
 

--- a/web/src/components/LanguageFailure.tsx
+++ b/web/src/components/LanguageFailure.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -7,7 +7,7 @@ import { CityModel } from 'shared/api'
 import Caption from './Caption'
 import LanguageSelector from './LanguageSelector'
 
-const ChooseLanguage = styled.p`
+const ChooseLanguage = styled('p')`
   margin: 25px 0;
   text-align: center;
 `

--- a/web/src/components/LastUpdateInfo.tsx
+++ b/web/src/components/LastUpdateInfo.tsx
@@ -1,9 +1,9 @@
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 import { DateTime } from 'luxon'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
-const TimeStamp = styled.p`
+const TimeStamp = styled('p')`
   color: ${props => props.theme.legacy.colors.textSecondaryColor};
   font-family: ${props => props.theme.legacy.fonts.web.contentFont};
   font-size: ${props => props.theme.legacy.fonts.contentFontSize};

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -1,12 +1,12 @@
 import { css } from '@emotion/react'
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement, ReactNode } from 'react'
 
 import dimensions from '../constants/dimensions'
 import { MobileBanner } from './MobileBanner'
 import Portal from './Portal'
 
-export const RichLayout = styled.div`
+export const RichLayout = styled('div')`
   position: relative;
   display: flex;
   min-height: 100vh;
@@ -28,7 +28,7 @@ export const RichLayout = styled.div`
   }
 `
 
-const Body = styled.div<{ fullWidth: boolean; disableScrollingSafari: boolean }>`
+const Body = styled('div')<{ fullWidth: boolean; disableScrollingSafari: boolean }>`
   width: 100%;
   box-sizing: border-box;
   margin: 0 auto;
@@ -60,7 +60,7 @@ const Body = styled.div<{ fullWidth: boolean; disableScrollingSafari: boolean }>
     `};
 `
 
-const Main = styled.main<{ fullWidth: boolean }>`
+const Main = styled('main')<{ fullWidth: boolean }>`
   display: inline-block;
   width: ${props =>
     props.fullWidth ? '100%' : `${props.theme.breakpoints.values.lg - 2 * dimensions.toolbarWidth}px`};
@@ -83,7 +83,7 @@ const Main = styled.main<{ fullWidth: boolean }>`
   }
 `
 
-const Aside = styled.aside`
+const Aside = styled('aside')`
   position: fixed;
   top: 35%;
   width: 100px;

--- a/web/src/components/LicenseItem.tsx
+++ b/web/src/components/LicenseItem.tsx
@@ -1,10 +1,10 @@
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import ListItem from '../components/ListItem'
 
-const LicenseContainer = styled.div`
+const LicenseContainer = styled('div')`
   padding: 5px 10px;
   line-height: 120%;
 `

--- a/web/src/components/List.tsx
+++ b/web/src/components/List.tsx
@@ -1,8 +1,8 @@
-import styled from '@emotion/styled'
 import Divider from '@mui/material/Divider'
+import { styled } from '@mui/material/styles'
 import React, { ReactNode } from 'react'
 
-const NoItemsMessage = styled.div`
+const NoItemsMessage = styled('div')`
   padding-top: 25px;
   text-align: center;
 `

--- a/web/src/components/ListItem.tsx
+++ b/web/src/components/ListItem.tsx
@@ -1,14 +1,14 @@
-import styled from '@emotion/styled'
 import Divider from '@mui/material/Divider'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement, ReactNode } from 'react'
 
 import Link from './base/Link'
 
-const ListItemContainer = styled.article`
+const ListItemContainer = styled('article')`
   display: flex;
 `
 
-const Thumbnail = styled.img<{ thumbnailSize?: number }>`
+const Thumbnail = styled('img')<{ thumbnailSize?: number }>`
   width: ${props => props.thumbnailSize ?? '100'}px;
   height: ${props => props.thumbnailSize ?? '100'}px;
   flex-shrink: 0;
@@ -17,7 +17,7 @@ const Thumbnail = styled.img<{ thumbnailSize?: number }>`
   align-self: center;
 `
 
-export const Description = styled.div`
+export const Description = styled('div')`
   display: flex;
   height: 100%;
   min-width: 1px; /* needed to enable line breaks for too long words, exact value doesn't matter */
@@ -28,7 +28,7 @@ export const Description = styled.div`
   gap: 8px;
 `
 
-const Title = styled.div`
+const Title = styled('div')`
   font-weight: 700;
 `
 
@@ -37,7 +37,7 @@ const FullWidthLink = styled(Link)`
   flex: 1;
 `
 
-const TitleRow = styled.div`
+const TitleRow = styled('div')`
   display: flex;
   justify-content: space-between;
   gap: 8px;

--- a/web/src/components/LoadingSpinner.tsx
+++ b/web/src/components/LoadingSpinner.tsx
@@ -1,5 +1,5 @@
 import { keyframes } from '@emotion/react'
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 
 /** From https://github.com/ConnorAtherton/loaders.css/blob/master/loaders.css */
@@ -17,7 +17,7 @@ const lineScaleParty = keyframes`
   }
 `
 
-const Spinner = styled.div`
+const Spinner = styled('div')`
   margin-top: 50px;
   text-align: center;
   animation-name: ${lineScaleParty};

--- a/web/src/components/LocalNewsList.tsx
+++ b/web/src/components/LocalNewsList.tsx
@@ -1,18 +1,18 @@
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement, ReactNode } from 'react'
 
 import { LocalNewsModel } from 'shared/api'
 
-const NoItemsMessage = styled.div`
+const NoItemsMessage = styled('div')`
   padding-top: 25px;
   text-align: center;
 `
 
-const StyledList = styled.div`
+const StyledList = styled('div')`
   position: relative;
   padding-top: 1px;
 `
-const Wrapper = styled.div`
+const Wrapper = styled('div')`
   background-color: ${({ theme }) => theme.legacy.colors.backgroundColor};
 `
 

--- a/web/src/components/MalteHelpForm.tsx
+++ b/web/src/components/MalteHelpForm.tsx
@@ -1,8 +1,8 @@
-import styled from '@emotion/styled'
 import HealthAndSafetyOutlinedIcon from '@mui/icons-material/HealthAndSafetyOutlined'
 import PeopleOutlineOutlinedIcon from '@mui/icons-material/PeopleOutlineOutlined'
 import SendIcon from '@mui/icons-material/Send'
 import Button from '@mui/material/Button'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement, SyntheticEvent, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
@@ -25,7 +25,7 @@ import InputSection from './base/InputSection'
 import RadioGroup from './base/RadioGroup'
 import Spacing from './base/Spacing'
 
-const Note = styled.div`
+const Note = styled('div')`
   display: flex;
   padding-bottom: 10px;
   gap: 20px;
@@ -35,18 +35,18 @@ const StyledIcon = styled(Icon)`
   flex-shrink: 0;
 `
 
-const Form = styled.form`
+const Form = styled('form')`
   display: flex;
   flex-direction: column;
   gap: 12px;
 `
 
-const SubmitErrorHeading = styled.h5`
+const SubmitErrorHeading = styled('h5')`
   margin: 0;
   font-size: ${props => props.theme.legacy.fonts.subTitleFontSize};
 `
 
-const ErrorSendingStatus = styled.div`
+const ErrorSendingStatus = styled('div')`
   background-color: ${props => props.theme.legacy.colors.invalidInput}35;
   padding: 20px 10px;
   margin: 10px 0;

--- a/web/src/components/MapAttribution.tsx
+++ b/web/src/components/MapAttribution.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement, useState } from 'react'
 
 import { openStreeMapCopyright } from 'shared'
@@ -6,7 +6,7 @@ import { openStreeMapCopyright } from 'shared'
 import Button from './base/Button'
 import Link from './base/Link'
 
-const Attribution = styled.div`
+const Attribution = styled('div')`
   display: flex;
   direction: ltr;
   padding: 0 4px;
@@ -31,7 +31,7 @@ const OpenStreetMapsLink = styled(Link)`
   color: ${props => props.theme.legacy.colors.linkColor};
 `
 
-const Label = styled.span`
+const Label = styled('span')`
   padding: 0 4px;
   color: rgb(0 0 0 / 75%);
 `

--- a/web/src/components/MapView.tsx
+++ b/web/src/components/MapView.tsx
@@ -1,5 +1,4 @@
-import { useTheme } from '@emotion/react'
-import styled from '@emotion/styled'
+import { styled, useTheme } from '@mui/material/styles'
 import maplibregl from 'maplibre-gl'
 import 'maplibre-gl/dist/maplibre-gl.css'
 import React, {
@@ -31,7 +30,7 @@ import { midSnapPercentage } from '../utils/getSnapPoints'
 import { reportError } from '../utils/sentry'
 import MapAttribution from './MapAttribution'
 
-const MapContainer = styled.div`
+const MapContainer = styled('div')`
   height: 100%;
   width: 100%;
   display: flex;
@@ -39,7 +38,7 @@ const MapContainer = styled.div`
   position: relative;
 `
 
-const OverlayContainer = styled.div`
+const OverlayContainer = styled('div')`
   display: flex;
   padding: 12px 8px;
   flex: 1;

--- a/web/src/components/MobileBanner.tsx
+++ b/web/src/components/MobileBanner.tsx
@@ -1,5 +1,5 @@
-import styled from '@emotion/styled'
 import CloseIcon from '@mui/icons-material/Close'
+import { styled } from '@mui/material/styles'
 import { DateTime } from 'luxon'
 import React, { ReactElement, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -9,7 +9,7 @@ import useLocalStorage from '../hooks/useLocalStorage'
 import Button from './base/Button'
 import Icon from './base/Icon'
 
-const StyledBanner = styled.div<{ isInstalled: boolean }>`
+const StyledBanner = styled('div')<{ isInstalled: boolean }>`
   display: none;
   justify-content: space-between;
   background-color: ${props => props.theme.legacy.colors.themeColor};
@@ -23,7 +23,7 @@ const StyledBanner = styled.div<{ isInstalled: boolean }>`
   }
 `
 
-const StyledDiv = styled.div`
+const StyledDiv = styled('div')`
   display: flex;
   align-items: center;
   gap: 10px;
@@ -40,14 +40,14 @@ const StyledBannerIcon = styled(Icon)<{ isInstalled: boolean }>`
   border-radius: 5;
 `
 
-const StyledDivText = styled.div`
+const StyledDivText = styled('div')`
   display: flex;
   flex-direction: column;
   justify-content: center;
   gap: 2px;
 `
 
-const StyledAppName = styled.span`
+const StyledAppName = styled('span')`
   font-weight: bold;
   font-size: 12px;
   color: ${props => props.theme.legacy.colors.themeContrast};
@@ -55,13 +55,13 @@ const StyledAppName = styled.span`
 
 const smallScreenSize = 400
 
-const StyledDescription = styled.span<{ screenSize: number }>`
+const StyledDescription = styled('span')<{ screenSize: number }>`
   color: ${props => props.theme.legacy.colors.themeContrast};
   white-space: nowrap;
   font-size: ${props => (props.screenSize <= smallScreenSize ? '10px' : '12px')};
 `
 
-const StyledButton = styled.button<{ isInstalled: boolean }>`
+const StyledButton = styled('button')<{ isInstalled: boolean }>`
   background-color: ${props => (!props.isInstalled ? 'transparent' : props.theme.legacy.colors.textColor)};
   color: ${props =>
     !props.isInstalled ? props.theme.legacy.colors.themeContrast : props.theme.legacy.colors.themeColor};

--- a/web/src/components/Modal.tsx
+++ b/web/src/components/Modal.tsx
@@ -1,5 +1,4 @@
-import { useTheme } from '@emotion/react'
-import styled from '@emotion/styled'
+import { styled, useTheme } from '@mui/material/styles'
 import FocusTrap from 'focus-trap-react'
 import React, { CSSProperties, ReactElement, ReactNode, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -24,7 +23,7 @@ const Overlay = styled(Button)`
   height: 100%;
 `
 
-const ModalContainer = styled.div`
+const ModalContainer = styled('div')`
   position: fixed;
   inset: 0;
   z-index: 100;
@@ -33,7 +32,7 @@ const ModalContainer = styled.div`
   justify-content: center;
 `
 
-const ModalContentContainer = styled.div`
+const ModalContentContainer = styled('div')`
   position: relative;
   display: flex;
   flex-direction: column;

--- a/web/src/components/ModalContent.tsx
+++ b/web/src/components/ModalContent.tsx
@@ -1,19 +1,19 @@
-import { css, useTheme } from '@emotion/react'
-import styled from '@emotion/styled'
+import { css } from '@emotion/react'
 import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew'
 import CloseIcon from '@mui/icons-material/Close'
 import IconButton from '@mui/material/IconButton'
+import { styled, useTheme } from '@mui/material/styles'
 import React, { CSSProperties, ReactElement, ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 
-const Container = styled.div`
-  display: flex;
-  flex-direction: column;
-  background-color: ${props => props.theme.legacy.colors.backgroundColor};
-  font-family: ${props => props.theme.legacy.fonts.web.decorativeFont};
-`
+const Container = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  backgroundColor: theme.legacy.colors.backgroundColor,
+  fontFamily: theme.legacy.fonts.web.decorativeFont,
+}))
 
-const Header = styled.div<{ small: boolean }>`
+const Header = styled('div')<{ small: boolean }>`
   display: flex;
   padding: 16px;
   flex-direction: ${props => (props.small ? 'row-reverse' : 'row')};
@@ -30,7 +30,7 @@ const Header = styled.div<{ small: boolean }>`
     `}
 `
 
-const TitleContainer = styled.div`
+const TitleContainer = styled('div')`
   display: flex;
   flex-direction: row;
   justify-content: center;

--- a/web/src/components/NavigationBarScrollContainer.tsx
+++ b/web/src/components/NavigationBarScrollContainer.tsx
@@ -1,6 +1,5 @@
-import { useTheme } from '@emotion/react'
-import styled from '@emotion/styled'
 import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew'
+import { styled, useTheme } from '@mui/material/styles'
 import React, { ReactElement, ReactNode, RefObject, useCallback, useState } from 'react'
 
 import dimensions from '../constants/dimensions'
@@ -14,7 +13,7 @@ type NavigationBarScrollContainerProps = {
   activeIndex: number
 }
 
-const Container = styled.div`
+const Container = styled('div')`
   display: flex;
 `
 
@@ -26,7 +25,7 @@ const Arrow = styled(Icon)<{ visible: boolean }>`
   opacity: ${props => (props.visible ? 1 : 0)};
 `
 
-const ScrollContainer = styled.div<{ showArrowContainer: boolean }>`
+const ScrollContainer = styled('div')<{ showArrowContainer: boolean }>`
   display: flex;
   flex: 1;
   max-width: 100%;

--- a/web/src/components/NearbyCities.tsx
+++ b/web/src/components/NearbyCities.tsx
@@ -1,7 +1,7 @@
-import styled from '@emotion/styled'
 import RefreshIcon from '@mui/icons-material/Refresh'
 import Divider from '@mui/material/Divider'
 import IconButton from '@mui/material/IconButton'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -13,13 +13,13 @@ import CityEntry from './CityEntry'
 import { CityListParent } from './CitySelector'
 import Icon from './base/Icon'
 
-const NearbyMessageContainer = styled.div`
+const NearbyMessageContainer = styled('div')`
   display: flex;
   padding: 8px;
   justify-content: space-between;
 `
 
-const NearbyMessage = styled.span`
+const NearbyMessage = styled('span')`
   color: ${props => props.theme.legacy.colors.textColor};
   font-family: ${props => props.theme.legacy.fonts.web.decorativeFont};
   align-self: center;

--- a/web/src/components/NewsListItem.tsx
+++ b/web/src/components/NewsListItem.tsx
@@ -1,5 +1,5 @@
-import styled from '@emotion/styled'
 import Divider from '@mui/material/Divider'
+import { styled } from '@mui/material/styles'
 import { TFunction } from 'i18next'
 import { DateTime } from 'luxon'
 import React, { ReactElement } from 'react'
@@ -15,7 +15,7 @@ const StyledLink = styled(Link)`
   display: flex;
   background-color: ${({ theme }) => theme.legacy.colors.backgroundColor};
 `
-const ReadMore = styled.div<{ newsType: NewsType }>`
+const ReadMore = styled('div')<{ newsType: NewsType }>`
   align-self: flex-end;
   color: ${({ theme, newsType }) =>
     theme.isContrastTheme || newsType === LOCAL_NEWS_TYPE
@@ -24,24 +24,24 @@ const ReadMore = styled.div<{ newsType: NewsType }>`
   font-weight: 600;
 `
 
-const Title = styled.h3`
+const Title = styled('h3')`
   margin-bottom: 0;
   font-family: ${props => props.theme.legacy.fonts.web.decorativeFont};
   font-size: ${props => props.theme.legacy.fonts.subTitleFontSize};
   font-weight: 700;
 `
 
-const Body = styled.p`
+const Body = styled('p')`
   font-size: 16px;
   line-height: 1.38;
   white-space: pre-line;
 `
 
-const StyledNewsListItem = styled.article`
+const StyledNewsListItem = styled('article')`
   padding-bottom: 2px;
 `
 
-const StyledContainer = styled.div`
+const StyledContainer = styled('div')`
   display: flex;
   width: 100%;
   justify-content: space-between;

--- a/web/src/components/NewsTab.tsx
+++ b/web/src/components/NewsTab.tsx
@@ -1,5 +1,5 @@
 import shouldForwardProp from '@emotion/is-prop-valid'
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 import { TFunction } from 'i18next'
 import React, { ReactElement } from 'react'
 import { Link } from 'react-router-dom'

--- a/web/src/components/NewsTabs.tsx
+++ b/web/src/components/NewsTabs.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 import { TFunction } from 'i18next'
 import React, { ReactNode, ReactElement } from 'react'
 
@@ -7,7 +7,7 @@ import { LOCAL_NEWS_TYPE, NEWS_ROUTE, NewsType, pathnameFromRouteInformation, TU
 import Caption from './Caption'
 import NewsTab from './NewsTab'
 
-const StyledTabs = styled.div`
+const StyledTabs = styled('div')`
   display: flex;
   padding-bottom: 40px;
   justify-content: center;

--- a/web/src/components/Note.tsx
+++ b/web/src/components/Note.tsx
@@ -1,11 +1,11 @@
-import styled from '@emotion/styled'
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 
 import { helpers } from '../constants/theme'
 import Icon from './base/Icon'
 
-const NoteContainer = styled.div`
+const NoteContainer = styled('div')`
   display: flex;
   background-color: ${props => props.theme.legacy.colors.warningColor};
   padding: 12px;
@@ -13,7 +13,7 @@ const NoteContainer = styled.div`
   align-items: center;
 `
 
-const NoteText = styled.span`
+const NoteText = styled('span')`
   font-size: ${props => props.theme.legacy.fonts.decorativeFontSizeSmall};
   ${helpers.adaptiveThemeTextColor}
 `

--- a/web/src/components/OpeningEntry.tsx
+++ b/web/src/components/OpeningEntry.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -9,7 +9,7 @@ import AppointmentOnlyIcon from './AppointmentOnlyIcon'
 const fontBold = 600
 const fontStandard = 400
 
-const EntryContainer = styled.div<{ isCurrentDay: boolean }>`
+const EntryContainer = styled('div')<{ isCurrentDay: boolean }>`
   display: flex;
   justify-content: space-between;
   padding: 4px 0;
@@ -17,18 +17,18 @@ const EntryContainer = styled.div<{ isCurrentDay: boolean }>`
   position: relative;
 `
 
-const Timeslot = styled.div`
+const Timeslot = styled('div')`
   display: flex;
   flex-direction: column;
 `
 
-const OpeningContainer = styled.div`
+const OpeningContainer = styled('div')`
   display: flex;
   align-items: center;
   gap: 8px;
 `
 
-const TimeSlotEntry = styled.span`
+const TimeSlotEntry = styled('span')`
   &:not(:first-of-type) {
     margin-top: 8px;
   }

--- a/web/src/components/OpeningHours.tsx
+++ b/web/src/components/OpeningHours.tsx
@@ -1,5 +1,5 @@
-import styled from '@emotion/styled'
 import OpenInNewIcon from '@mui/icons-material/OpenInNew'
+import { styled } from '@mui/material/styles'
 import { DateTime } from 'luxon'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -13,18 +13,18 @@ import OpeningEntry from './OpeningEntry'
 import Icon from './base/Icon'
 import Link from './base/Link'
 
-const OpeningLabel = styled.span<{ isOpen: boolean }>`
+const OpeningLabel = styled('span')<{ isOpen: boolean }>`
   color: ${props =>
     props.isOpen ? props.theme.legacy.colors.positiveHighlight : props.theme.legacy.colors.negativeHighlight};
   padding-inline-end: 12px;
 `
 
-const Content = styled.div`
+const Content = styled('div')`
   padding-inline-end: 26px;
   ${helpers.adaptiveFontSize};
 `
 
-const TitleContainer = styled.div`
+const TitleContainer = styled('div')`
   display: flex;
   flex: 1;
   justify-content: space-between;
@@ -34,7 +34,7 @@ const TitleContainer = styled.div`
   ${helpers.adaptiveFontSize};
 `
 
-const OpeningContainer = styled.div`
+const OpeningContainer = styled('div')`
   display: flex;
   align-items: center;
   gap: 8px;
@@ -46,7 +46,7 @@ const StyledLink = styled(Link)`
   gap: 8px;
 `
 
-const LinkLabel = styled.span`
+const LinkLabel = styled('span')`
   color: ${props => props.theme.legacy.colors.linkColor};
   ${helpers.adaptiveFontSize};
   align-self: flex-end;

--- a/web/src/components/OrganizationContentInfo.tsx
+++ b/web/src/components/OrganizationContentInfo.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 
@@ -8,14 +8,14 @@ import useWindowDimensions from '../hooks/useWindowDimensions'
 import HighlightBox from './HighlightBox'
 import Link from './base/Link'
 
-const StyledImage = styled.img<{ viewportSmall: boolean }>`
+const StyledImage = styled('img')<{ viewportSmall: boolean }>`
   width: 100%;
   transition: transform 0.2s;
   object-fit: contain;
   ${props => props.viewportSmall && 'margin-bottom: 8px;'}
 `
 
-const ThumbnailSizer = styled.div`
+const ThumbnailSizer = styled('div')`
   width: 150px;
 `
 
@@ -28,12 +28,12 @@ const Box = styled(HighlightBox)<{ viewportSmall: boolean }>`
   gap: 20px;
 `
 
-const Column = styled.div`
+const Column = styled('div')`
   display: flex;
   flex-direction: column;
 `
 
-const OrganizationContent = styled.div`
+const OrganizationContent = styled('div')`
   padding-bottom: 8px;
   font-weight: 600;
 `

--- a/web/src/components/Page.tsx
+++ b/web/src/components/Page.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 import { DateTime } from 'luxon'
 import React, { ReactElement, ReactNode, useContext } from 'react'
 
@@ -10,7 +10,7 @@ import { TtsContext } from './TtsContainer'
 
 export const THUMBNAIL_WIDTH = 300
 
-const Thumbnail = styled.img`
+const Thumbnail = styled('img')`
   display: flex;
   width: ${THUMBNAIL_WIDTH}px;
   height: ${THUMBNAIL_WIDTH}px;
@@ -19,7 +19,7 @@ const Thumbnail = styled.img`
   object-fit: contain;
 `
 
-const SpaceForTts = styled.div<{ ttsPlayerVisible: boolean }>`
+const SpaceForTts = styled('div')<{ ttsPlayerVisible: boolean }>`
   height: ${props => (props.ttsPlayerVisible ? dimensions.ttsPlayerHeight : 0)}px;
   transition: height 250ms ease-in;
 `

--- a/web/src/components/PageDetail.tsx
+++ b/web/src/components/PageDetail.tsx
@@ -1,9 +1,9 @@
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 
 import Link from './base/Link'
 
-const Identifier = styled.span`
+const Identifier = styled('span')`
   font-weight: 700;
 `
 

--- a/web/src/components/PoiChips.tsx
+++ b/web/src/components/PoiChips.tsx
@@ -1,6 +1,6 @@
-import styled from '@emotion/styled'
 import AccessibleIcon from '@mui/icons-material/Accessible'
 import NotAccessibleIcon from '@mui/icons-material/NotAccessible'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -8,7 +8,7 @@ import { PoiModel } from 'shared/api'
 
 import Icon from './base/Icon'
 
-const ChipsContainer = styled.div`
+const ChipsContainer = styled('div')`
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
@@ -18,7 +18,7 @@ const ChipsContainer = styled.div`
   justify-content: flex-start;
 `
 
-const Chip = styled.div`
+const Chip = styled('div')`
   color: ${props => props.theme.legacy.colors.textSecondaryColor};
   display: flex;
   padding-inline: 12px;

--- a/web/src/components/PoiDetails.tsx
+++ b/web/src/components/PoiDetails.tsx
@@ -1,7 +1,7 @@
-import styled from '@emotion/styled'
 import LocationOnOutlinedIcon from '@mui/icons-material/LocationOnOutlined'
 import OpenInNewIcon from '@mui/icons-material/OpenInNew'
 import Divider from '@mui/material/Divider'
+import { styled } from '@mui/material/styles'
 import React, { Fragment, ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -23,7 +23,7 @@ const StyledDivider = styled(Divider)`
   margin: 12px 0;
 `
 
-const DetailsContainer = styled.div`
+const DetailsContainer = styled('div')`
   font-family: ${props => props.theme.legacy.fonts.web.contentFont};
 `
 
@@ -39,7 +39,7 @@ const StyledExternalLinkIcon = styled(StyledIcon)`
   color: ${props => props.theme.legacy.colors.linkColor};
 `
 
-const Thumbnail = styled.img`
+const Thumbnail = styled('img')`
   height: clamp(120px, 14vh, 160px);
   width: 100%;
   flex-shrink: 0;
@@ -53,17 +53,17 @@ const Thumbnail = styled.img`
   }
 `
 
-const Distance = styled.div`
+const Distance = styled('div')`
   ${helpers.adaptiveFontSize};
 `
 
-const AddressContentWrapper = styled.div`
+const AddressContentWrapper = styled('div')`
   display: flex;
   ${helpers.adaptiveFontSize};
   gap: 8px;
 `
 
-const AddressContent = styled.div`
+const AddressContent = styled('div')`
   display: flex;
   flex-direction: column;
   ${helpers.adaptiveFontSize};
@@ -73,12 +73,12 @@ const AddressContent = styled.div`
   }
 `
 
-const Heading = styled.div`
+const Heading = styled('div')`
   margin: 12px 0;
   font-weight: 700;
 `
 
-const Subheading = styled.div`
+const Subheading = styled('div')`
   margin: 12px 0;
   font-weight: 700;
   ${helpers.adaptiveFontSize};
@@ -90,18 +90,18 @@ const StyledLink = styled(Link)`
   gap: 8px;
 `
 
-const LinkLabel = styled.span`
+const LinkLabel = styled('span')`
   color: ${props => props.theme.legacy.colors.linkColor};
   ${helpers.adaptiveFontSize};
   align-self: flex-end;
 `
 
-const HeadingSection = styled.div`
+const HeadingSection = styled('div')`
   display: flex;
   flex-direction: column;
 `
 
-const DetailSection = styled.div`
+const DetailSection = styled('div')`
   display: flex;
   flex-direction: column;
 
@@ -115,11 +115,11 @@ const StyledCollapsible = styled(Collapsible)`
   gap: 0;
 `
 
-const StyledContactsContainer = styled.div`
+const StyledContactsContainer = styled('div')`
   margin-top: 12px;
 `
 
-const ToolbarWrapper = styled.div`
+const ToolbarWrapper = styled('div')`
   display: flex;
   justify-content: center;
 `

--- a/web/src/components/PoiFilters.tsx
+++ b/web/src/components/PoiFilters.tsx
@@ -1,6 +1,6 @@
-import styled from '@emotion/styled'
 import AccessTimeIcon from '@mui/icons-material/AccessTime'
 import Button from '@mui/material/Button'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -14,7 +14,7 @@ import ToggleButton, { toggleButtonWidth } from './base/ToggleButton'
 
 const tileColumnGap = 16
 
-const Container = styled.div`
+const Container = styled('div')`
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -22,27 +22,27 @@ const Container = styled.div`
   gap: 24px;
 `
 
-const SubTitle = styled.div`
+const SubTitle = styled('div')`
   font-size: 0.875rem;
   color: ${props => props.theme.legacy.colors.textColor};
   font-family: ${props => props.theme.legacy.fonts.web.decorativeFont};
   font-weight: bold;
 `
 
-const Section = styled.div`
+const Section = styled('div')`
   display: flex;
   flex-direction: column;
   width: 100%;
   gap: 24px;
 `
 
-const Row = styled.div`
+const Row = styled('div')`
   display: flex;
   gap: 8px;
   align-items: center;
 `
 
-const SortingHint = styled.div`
+const SortingHint = styled('div')`
   align-self: flex-end;
   font-size: 0.75rem;
   color: ${props => props.theme.legacy.colors.textColor};

--- a/web/src/components/PoiListItem.tsx
+++ b/web/src/components/PoiListItem.tsx
@@ -1,5 +1,5 @@
-import styled from '@emotion/styled'
 import Divider from '@mui/material/Divider'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -9,7 +9,7 @@ import { PoiThumbnailPlaceholder } from '../assets'
 import { helpers } from '../constants/theme'
 import Button from './base/Button'
 
-const ListItemContainer = styled.ul`
+const ListItemContainer = styled('ul')`
   font-family: ${props => props.theme.legacy.fonts.web.contentFont};
   display: flex;
   padding: clamp(10px, 1vh, 20px) 0;
@@ -20,7 +20,7 @@ const ListItemContainer = styled.ul`
   }
 `
 
-const Thumbnail = styled.img`
+const Thumbnail = styled('img')`
   width: clamp(70px, 10vh, 100px);
   height: clamp(70px, 10vh, 100px);
   flex-shrink: 0;
@@ -29,16 +29,16 @@ const Thumbnail = styled.img`
   border-radius: 10px;
 `
 
-const Distance = styled.div`
+const Distance = styled('div')`
   ${helpers.adaptiveFontSize};
 `
 
-const Category = styled.div`
+const Category = styled('div')`
   ${helpers.adaptiveFontSize};
   color: ${props => props.theme.legacy.colors.textSecondaryColor};
 `
 
-export const Description = styled.div`
+export const Description = styled('div')`
   display: flex;
   justify-content: center;
   height: 100%;
@@ -52,7 +52,7 @@ export const Description = styled.div`
   hyphens: auto;
 `
 
-const Title = styled.span`
+const Title = styled('span')`
   ${helpers.adaptiveFontSize};
   font-weight: 700;
 `

--- a/web/src/components/PoiPanelNavigation.tsx
+++ b/web/src/components/PoiPanelNavigation.tsx
@@ -1,5 +1,5 @@
-import styled from '@emotion/styled'
 import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -7,7 +7,7 @@ import { helpers } from '../constants/theme'
 import Button from './base/Button'
 import Icon from './base/Icon'
 
-const NavigationContainer = styled.div`
+const NavigationContainer = styled('div')`
   display: flex;
   padding: 12px;
   justify-content: space-between;
@@ -18,7 +18,7 @@ const StyledButton = styled(Button)`
   color: ${props => props.theme.legacy.colors.textColor};
 `
 
-const Label = styled.span`
+const Label = styled('span')`
   align-self: center;
   ${helpers.adaptiveFontSize};
 `

--- a/web/src/components/PoiSharedChildren.tsx
+++ b/web/src/components/PoiSharedChildren.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 

--- a/web/src/components/Pois.tsx
+++ b/web/src/components/Pois.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement, useState } from 'react'
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
 
@@ -25,7 +25,7 @@ import useWindowDimensions from '../hooks/useWindowDimensions'
 import moveViewportToCity from '../utils/moveViewportToCity'
 import PoiFiltersOverlayButtons from './PoiFiltersOverlayButtons'
 
-const Container = styled.div<{ panelHeights: number }>`
+const Container = styled('div')<{ panelHeights: number }>`
   display: flex;
   ${({ panelHeights }) => `height: calc(100vh - ${panelHeights}px);`};
 `

--- a/web/src/components/PoisDesktop.tsx
+++ b/web/src/components/PoisDesktop.tsx
@@ -1,5 +1,4 @@
-import { useTheme } from '@emotion/react'
-import styled from '@emotion/styled'
+import { styled, useTheme } from '@mui/material/styles'
 import React, { ReactElement, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { GeolocateControl, NavigationControl } from 'react-map-gl'
@@ -14,7 +13,7 @@ import MapView from './MapView'
 import PoiPanelNavigation from './PoiPanelNavigation'
 import PoiSharedChildren from './PoiSharedChildren'
 
-const PanelContainer = styled.article`
+const PanelContainer = styled('article')`
   overflow: auto;
   height: 100%;
   display: flex;
@@ -25,20 +24,20 @@ const PanelContainer = styled.article`
   min-width: ${dimensions.poiDesktopPanelWidth}px;
 `
 
-const ListViewWrapper = styled.div<{ panelHeights: number; bottomBarHeight: number }>`
+const ListViewWrapper = styled('div')<{ panelHeights: number; bottomBarHeight: number }>`
   padding: 16px;
   overflow: auto;
   ${({ panelHeights, bottomBarHeight }) => `height: calc(100vh - ${panelHeights}px - ${bottomBarHeight}px);`};
 `
 
-const ToolbarContainer = styled.div`
+const ToolbarContainer = styled('div')`
   display: flex;
   justify-content: center;
   background-color: ${props => props.theme.legacy.colors.backgroundColor};
   box-shadow: 1px 0 4px 0 rgb(0 0 0 / 20%);
 `
 
-const ListHeader = styled.div`
+const ListHeader = styled('div')`
   padding-top: clamp(16px, 1.4vh, 32px);
   padding-bottom: clamp(10px, 1vh, 20px);
   text-align: center;
@@ -49,7 +48,7 @@ const ListHeader = styled.div`
   margin-bottom: clamp(10px, 1vh, 20px);
 `
 
-const FooterContainer = styled.div`
+const FooterContainer = styled('div')`
   position: absolute;
   bottom: 0;
 `

--- a/web/src/components/PoisMobile.tsx
+++ b/web/src/components/PoisMobile.tsx
@@ -1,7 +1,6 @@
-import { useTheme } from '@emotion/react'
-import styled from '@emotion/styled'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import IconButton from '@mui/material/IconButton'
+import { styled, useTheme } from '@mui/material/styles'
 import { GeolocateControl } from 'maplibre-gl'
 import React, { ReactElement, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -16,16 +15,16 @@ import GoBack from './GoBack'
 import MapView, { MapViewRef } from './MapView'
 import PoiSharedChildren from './PoiSharedChildren'
 
-const ListContainer = styled.div`
+const ListContainer = styled('div')`
   padding: 0 30px;
 `
 
-const ListTitle = styled.div`
+const ListTitle = styled('div')`
   margin: 12px 0;
   font-weight: 700;
 `
 
-const GoBackContainer = styled.div`
+const GoBackContainer = styled('div')`
   display: flex;
   flex-direction: column;
   max-height: 10vh;
@@ -34,7 +33,7 @@ const GoBackContainer = styled.div`
   padding: 0 30px;
 `
 
-const GeocontrolContainer = styled.div<{ maxOffset: number }>`
+const GeocontrolContainer = styled('div')<{ maxOffset: number }>`
   position: absolute;
   inset-inline-end: 10px;
   bottom: calc(min(var(--rsbs-overlay-h, 0), ${props => props.maxOffset}px) + 8px);

--- a/web/src/components/Portal.tsx
+++ b/web/src/components/Portal.tsx
@@ -1,4 +1,4 @@
-import { useTheme } from '@emotion/react'
+import { useTheme } from '@mui/material/styles'
 import React, { CSSProperties, ReactNode, ReactPortal, useEffect, useLayoutEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 

--- a/web/src/components/RemoteContent.tsx
+++ b/web/src/components/RemoteContent.tsx
@@ -1,4 +1,4 @@
-import { useTheme } from '@emotion/react'
+import { useTheme } from '@mui/material/styles'
 import Dompurify from 'dompurify'
 import React, { ReactElement, useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'

--- a/web/src/components/RemoteContentSandBox.ts
+++ b/web/src/components/RemoteContentSandBox.ts
@@ -1,9 +1,9 @@
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 
 import { ExternalLinkIcon, PersonIcon } from '../assets'
 import { helpers } from '../constants/theme'
 
-const RemoteContentSandBox = styled.div<{ centered: boolean; smallText: boolean }>`
+const RemoteContentSandBox = styled('div')<{ centered: boolean; smallText: boolean }>`
   font-family: ${props => props.theme.legacy.fonts.web.contentFont};
   font-size: ${props => (props.smallText ? helpers.adaptiveFontSize : props.theme.legacy.fonts.contentFontSize)};
   line-height: ${props => props.theme.legacy.fonts.contentLineHeight};

--- a/web/src/components/SearchFeedback.tsx
+++ b/web/src/components/SearchFeedback.tsx
@@ -1,5 +1,5 @@
-import styled from '@emotion/styled'
 import Button from '@mui/material/Button'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -9,21 +9,21 @@ import { config } from 'translations'
 import buildConfig from '../constants/buildConfig'
 import FeedbackContainer from './FeedbackContainer'
 
-const Container = styled.div`
+const Container = styled('div')`
   display: flex;
   flex-direction: column;
   align-items: center;
 `
 
-const CenteredContainer = styled.div`
+const CenteredContainer = styled('div')`
   text-align: center;
 `
 
-const SmallTitle = styled.p`
+const SmallTitle = styled('p')`
   font-weight: 600;
 `
 
-const Hint = styled.p`
+const Hint = styled('p')`
   padding-bottom: 16px;
 `
 

--- a/web/src/components/SearchInput.tsx
+++ b/web/src/components/SearchInput.tsx
@@ -1,20 +1,20 @@
-import styled from '@emotion/styled'
 import ClearIcon from '@mui/icons-material/Clear'
 import SearchOutlinedIcon from '@mui/icons-material/SearchOutlined'
 import { formHelperTextClasses } from '@mui/material/FormHelperText'
 import IconButton from '@mui/material/IconButton'
 import InputAdornment from '@mui/material/InputAdornment'
 import TextField from '@mui/material/TextField'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import Icon from './base/Icon'
 
-const Spacer = styled.div<{ space: boolean }>`
+const Spacer = styled('div')<{ space: boolean }>`
   ${props => props.space && 'margin: 16px 0;'}
 `
 
-const Wrapper = styled.div`
+const Wrapper = styled('div')`
   gap: 4px;
   position: relative;
   width: 100%;
@@ -30,7 +30,7 @@ const Wrapper = styled.div`
   }
 `
 
-const Column = styled.div`
+const Column = styled('div')`
   display: flex;
   flex-direction: column;
   width: 100%;

--- a/web/src/components/SearchListItem.tsx
+++ b/web/src/components/SearchListItem.tsx
@@ -1,5 +1,5 @@
-import styled from '@emotion/styled'
 import Divider from '@mui/material/Divider'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 import { Link } from 'react-router-dom'
 
@@ -8,11 +8,11 @@ import { getExcerpt } from 'shared'
 import { EXCERPT_MAX_CHARS } from '../constants'
 import Highlighter from './Highlighter'
 
-const Row = styled.li`
+const Row = styled('li')`
   width: 100%;
 `
 
-const CategoryThumbnail = styled.img`
+const CategoryThumbnail = styled('img')`
   width: 30px;
   height: 30px;
   padding: 0 5px;
@@ -20,13 +20,13 @@ const CategoryThumbnail = styled.img`
   object-fit: contain;
 `
 
-const CategoryTitleContainer = styled.div`
+const CategoryTitleContainer = styled('div')`
   display: flex;
   align-items: center;
   flex-direction: row;
 `
 
-const CategoryItemContainer = styled.div`
+const CategoryItemContainer = styled('div')`
   display: flex;
   flex-direction: column;
   padding: 15px 5px;

--- a/web/src/components/Selector.tsx
+++ b/web/src/components/Selector.tsx
@@ -1,6 +1,6 @@
-import { css, Theme } from '@emotion/react'
-import styled from '@emotion/styled'
+import { css } from '@emotion/react'
 import Tooltip from '@mui/material/Tooltip'
+import { styled, Theme } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 
 import dimensions from '../constants/dimensions'
@@ -42,19 +42,19 @@ const SelectorItem = styled(Link)<{ selected: boolean }>`
         }`}
 `
 
-const DisabledSelectorItem = styled.div`
+const DisabledSelectorItem = styled('div')`
   ${selectorItemStyle};
   color: ${props => props.theme.legacy.colors.textDisabledColor};
 `
 
-const BoldSpacer = styled.div`
+const BoldSpacer = styled('div')`
   font-weight: 700;
   height: 0;
   overflow: hidden;
   visibility: hidden;
 `
 
-const Wrapper = styled.div<{ vertical: boolean }>`
+const Wrapper = styled('div')<{ vertical: boolean }>`
   display: flex;
   width: 100%;
   flex-flow: ${props => (props.vertical ? 'column' : 'row wrap')};

--- a/web/src/components/SharingPopup.tsx
+++ b/web/src/components/SharingPopup.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/react'
-import styled from '@emotion/styled'
 import CheckIcon from '@mui/icons-material/Check'
 import CloseIcon from '@mui/icons-material/Close'
 import ContentCopyIcon from '@mui/icons-material/ContentCopy'
@@ -9,6 +8,7 @@ import ShareOutlinedIcon from '@mui/icons-material/ShareOutlined'
 import WhatsAppIcon from '@mui/icons-material/WhatsApp'
 import IconButton from '@mui/material/IconButton'
 import Tooltip from '@mui/material/Tooltip'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -24,7 +24,7 @@ type SharingPopupProps = {
   portalNeeded: boolean
 }
 
-const TooltipContainer = styled.div<{
+const TooltipContainer = styled('div')<{
   tooltipFlow: 'vertical' | 'horizontal'
   optionsVisible: boolean
 }>`
@@ -138,7 +138,7 @@ const BackdropContainer = styled(Button)`
   z-index: 1;
 `
 
-const SharingPopupContainer = styled.div`
+const SharingPopupContainer = styled('div')`
   position: relative;
 `
 

--- a/web/src/components/SpacedToggleButtonGroup.tsx
+++ b/web/src/components/SpacedToggleButtonGroup.tsx
@@ -1,5 +1,5 @@
-import styled from '@emotion/styled'
 import ToggleButtonGroup, { toggleButtonGroupClasses } from '@mui/material/ToggleButtonGroup'
+import { styled } from '@mui/material/styles'
 
 const SpacedToggleButtonGroup = styled(ToggleButtonGroup)`
   .${toggleButtonGroupClasses.grouped} {

--- a/web/src/components/SprungbrettListItem.tsx
+++ b/web/src/components/SprungbrettListItem.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 import React, { memo, ReactElement } from 'react'
 
 import { SprungbrettJobModel } from 'shared/api'
@@ -6,7 +6,7 @@ import { SprungbrettJobModel } from 'shared/api'
 import { SprungbrettIcon } from '../assets'
 import ListItem from './ListItem'
 
-const Content = styled.div`
+const Content = styled('div')`
   overflow-wrap: anywhere;
 `
 

--- a/web/src/components/StyledSmallViewTip.tsx
+++ b/web/src/components/StyledSmallViewTip.tsx
@@ -1,6 +1,6 @@
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 
-const StyledSmallViewTip = styled.p`
+const StyledSmallViewTip = styled('p')`
   display: block;
   font-size: 12px;
   font-weight: 400;

--- a/web/src/components/Tile.tsx
+++ b/web/src/components/Tile.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement, ReactNode, useRef } from 'react'
 
 import { TileModel } from 'shared'
@@ -6,7 +6,7 @@ import { request } from 'shared/api'
 
 import Link from './base/Link'
 
-const Thumbnail = styled.div`
+const Thumbnail = styled('div')`
   position: relative;
   display: block;
   width: 100%;
@@ -24,7 +24,7 @@ const Thumbnail = styled.div`
   }
 `
 
-const ThumbnailSizer = styled.div`
+const ThumbnailSizer = styled('div')`
   width: 150px;
   max-width: 33.3vw;
   margin: 0 auto;
@@ -39,13 +39,13 @@ const ThumbnailSizer = styled.div`
   }
 `
 
-const TileTitle = styled.div`
+const TileTitle = styled('div')`
   margin: 5px 0;
   color: ${props => props.theme.legacy.colors.textColor};
   text-align: center;
 `
 
-const TileContainer = styled.div`
+const TileContainer = styled('div')`
   margin-bottom: 20px;
 
   & > a,

--- a/web/src/components/Tiles.tsx
+++ b/web/src/components/Tiles.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 
 import { TileModel } from 'shared'
@@ -6,7 +6,7 @@ import { TileModel } from 'shared'
 import Caption from './Caption'
 import Tile from './Tile'
 
-const TilesRow = styled.div`
+const TilesRow = styled('div')`
   display: grid;
 
   /* https://css-tricks.com/intrinsically-responsive-css-grid-with-minmax-and-min/ */

--- a/web/src/components/Toolbar.tsx
+++ b/web/src/components/Toolbar.tsx
@@ -1,15 +1,15 @@
 import { css } from '@emotion/react'
-import styled from '@emotion/styled'
 import Divider from '@mui/material/Divider'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement, ReactNode } from 'react'
 
 import useWindowDimensions from '../hooks/useWindowDimensions'
 
-const Container = styled.div`
+const Container = styled('div')`
   /* noop */
 `
 
-const ToolbarContainer = styled.div<{ direction: 'row' | 'column'; hasPadding: boolean }>`
+const ToolbarContainer = styled('div')<{ direction: 'row' | 'column'; hasPadding: boolean }>`
   display: flex;
   box-sizing: border-box;
   flex-direction: ${props => props.direction};

--- a/web/src/components/ToolbarItem.tsx
+++ b/web/src/components/ToolbarItem.tsx
@@ -1,7 +1,7 @@
-import { css, SerializedStyles, Theme } from '@emotion/react'
-import styled from '@emotion/styled'
+import { css, SerializedStyles } from '@emotion/react'
 import { SvgIconProps } from '@mui/material/SvgIcon'
 import Tooltip from '@mui/material/Tooltip'
+import { styled, Theme } from '@mui/material/styles'
 import React, { ElementType, ReactElement } from 'react'
 
 import useWindowDimensions from '../hooks/useWindowDimensions'

--- a/web/src/components/TtsHelpModal.tsx
+++ b/web/src/components/TtsHelpModal.tsx
@@ -1,7 +1,6 @@
-import { useTheme } from '@emotion/react'
-import styled from '@emotion/styled'
 import OpenInNewIcon from '@mui/icons-material/OpenInNew'
 import WarningAmberOutlinedIcon from '@mui/icons-material/WarningAmberOutlined'
+import { styled, useTheme } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -23,7 +22,7 @@ const ModalContent = styled(Container)`
   padding: 0 16px 16px;
 `
 
-const StyledWarningText = styled.div`
+const StyledWarningText = styled('div')`
   font-family: ${props => props.theme.legacy.fonts.web.contentFont};
   font-size: 16px;
   color: ${props => props.theme.legacy.colors.textColor};
@@ -33,7 +32,7 @@ const StyledWarningIcon = styled(Icon)`
   color: ${props => props.theme.legacy.colors.ttsPlayerWarningColor};
 `
 
-const StyledList = styled.div`
+const StyledList = styled('div')`
   display: flex;
   flex-direction: column;
   gap: 8px;

--- a/web/src/components/TtsPlayer.tsx
+++ b/web/src/components/TtsPlayer.tsx
@@ -1,4 +1,3 @@
-import styled from '@emotion/styled'
 import CloseIcon from '@mui/icons-material/Close'
 import FastForwardIcon from '@mui/icons-material/FastForward'
 import FastRewindIcon from '@mui/icons-material/FastRewind'
@@ -7,12 +6,13 @@ import PlayArrowIcon from '@mui/icons-material/PlayArrow'
 import Button from '@mui/material/Button'
 import IconButton from '@mui/material/IconButton'
 import Typography from '@mui/material/Typography'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import useWindowDimensions from '../hooks/useWindowDimensions'
 
-const StyledTtsPlayer = styled.dialog<{ footerHeight: number }>`
+const StyledTtsPlayer = styled('dialog')<{ footerHeight: number }>`
   background-color: ${props =>
     props.theme.isContrastTheme
       ? props.theme.legacy.colors.backgroundAccentColor
@@ -37,7 +37,7 @@ const StyledTtsPlayer = styled.dialog<{ footerHeight: number }>`
   }
 `
 
-const StyledPanel = styled.div`
+const StyledPanel = styled('div')`
   display: flex;
   align-items: center;
   gap: 20px;
@@ -61,7 +61,7 @@ const StyledIconButton = styled(IconButton)`
   align-items: center;
 `
 
-const HeaderText = styled.div`
+const HeaderText = styled('div')`
   display: inline-block;
   white-space: nowrap;
   text-overflow: ellipsis;

--- a/web/src/components/__tests__/ContrastThemeToggle.spec.tsx
+++ b/web/src/components/__tests__/ContrastThemeToggle.spec.tsx
@@ -1,4 +1,4 @@
-import { useTheme } from '@emotion/react'
+import { useTheme } from '@mui/material/styles'
 import { fireEvent } from '@testing-library/react'
 import { mocked } from 'jest-mock'
 import React from 'react'

--- a/web/src/components/base/Button.tsx
+++ b/web/src/components/base/Button.tsx
@@ -1,7 +1,7 @@
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement, ReactNode } from 'react'
 
-const StyledButton = styled.button<{ disabled: boolean }>`
+const StyledButton = styled('button')<{ disabled: boolean }>`
   background-color: transparent;
   cursor: ${props => (props.disabled ? 'default' : 'pointer')};
   pointer-events: ${props => (props.disabled ? 'none' : 'default')};

--- a/web/src/components/base/ChipButton.tsx
+++ b/web/src/components/base/ChipButton.tsx
@@ -1,6 +1,6 @@
-import styled from '@emotion/styled'
 import CloseIcon from '@mui/icons-material/Close'
 import { SvgIconProps } from '@mui/material/SvgIcon'
+import { styled } from '@mui/material/styles'
 import React, { ElementType, ReactElement } from 'react'
 
 import Button from './Button'

--- a/web/src/components/base/Icon.tsx
+++ b/web/src/components/base/Icon.tsx
@@ -1,7 +1,6 @@
 import shouldForwardProp from '@emotion/is-prop-valid'
-import { useTheme } from '@emotion/react'
-import styled from '@emotion/styled'
 import { SvgIconProps } from '@mui/material/SvgIcon'
+import { styled, useTheme } from '@mui/material/styles'
 import React, { ReactElement, ElementType } from 'react'
 import SVG from 'react-inlinesvg'
 

--- a/web/src/components/base/InputSection.tsx
+++ b/web/src/components/base/InputSection.tsx
@@ -1,22 +1,22 @@
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import InputComponent from './Input'
 
-const Container = styled.div`
+const Container = styled('div')`
   display: flex;
   flex-direction: column;
   gap: 8px;
 `
 
-const TitleContainer = styled.div`
+const TitleContainer = styled('div')`
   display: flex;
   justify-content: space-between;
   align-items: center;
 `
 
-export const Title = styled.label`
+export const Title = styled('label')`
   font-weight: bold;
 `
 

--- a/web/src/components/base/Link.tsx
+++ b/web/src/components/base/Link.tsx
@@ -1,5 +1,5 @@
 import shouldForwardProp from '@emotion/is-prop-valid'
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement, ReactNode } from 'react'
 import { Link as RouterLink } from 'react-router-dom'
 
@@ -12,7 +12,7 @@ const InternalLink = styled(RouterLink, { shouldForwardProp })<{ highlightedLink
   text-decoration: ${props => (props.highlightedLink ? 'underline' : 'none')};
 `
 
-const ExternalLink = styled.a<{ highlightedLink: boolean }>`
+const ExternalLink = styled('a')<{ highlightedLink: boolean }>`
   color: ${props => (props.highlightedLink ? props.theme.legacy.colors.linkColor : 'inherit')};
   text-decoration: ${props => (props.highlightedLink ? 'underline' : 'none')};
 `

--- a/web/src/components/base/RadioGroup.tsx
+++ b/web/src/components/base/RadioGroup.tsx
@@ -1,9 +1,9 @@
-import styled from '@emotion/styled'
 import FormControl from '@mui/material/FormControl'
 import FormControlLabel from '@mui/material/FormControlLabel'
 import FormLabel from '@mui/material/FormLabel'
 import Radio from '@mui/material/Radio'
 import MuiRadioGroup from '@mui/material/RadioGroup'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 
 import Input, { InputProps } from './Input'

--- a/web/src/components/base/Spacing.tsx
+++ b/web/src/components/base/Spacing.tsx
@@ -1,6 +1,6 @@
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 
-const Spacing = styled.div<{ scalingFactor?: number }>`
+const Spacing = styled('div')<{ scalingFactor?: number }>`
   width: ${props => props.theme.spacing(props.scalingFactor ?? 1)};
   height: ${props => props.theme.spacing(props.scalingFactor ?? 1)};
 `

--- a/web/src/components/base/ToggleButton.tsx
+++ b/web/src/components/base/ToggleButton.tsx
@@ -1,6 +1,6 @@
-import styled from '@emotion/styled'
 import { SvgIconProps } from '@mui/material/SvgIcon'
 import MuiToggleButton from '@mui/material/ToggleButton'
+import { styled } from '@mui/material/styles'
 import React, { ElementType, ReactElement } from 'react'
 
 import Icon from './Icon'
@@ -22,7 +22,7 @@ const StyledButton = styled(MuiToggleButton)`
   text-align: center;
 `
 
-const StyledLabel = styled.span`
+const StyledLabel = styled('span')`
   line-height: 1;
   font-size: 12px;
   font-weight: 400;

--- a/web/src/constants/theme.ts
+++ b/web/src/constants/theme.ts
@@ -1,4 +1,5 @@
-import { css, SerializedStyles, Theme } from '@emotion/react'
+import { css, SerializedStyles } from '@emotion/react'
+import { Theme } from '@mui/material/styles'
 
 export type HelpersType = {
   removeLinkHighlighting: SerializedStyles

--- a/web/src/routes/CityNotCooperatingPage.tsx
+++ b/web/src/routes/CityNotCooperatingPage.tsx
@@ -1,7 +1,7 @@
-import styled from '@emotion/styled'
 import CopyIcon from '@mui/icons-material/ContentCopy'
 import DoneIcon from '@mui/icons-material/Done'
 import Button from '@mui/material/Button'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -11,12 +11,12 @@ import buildConfig from '../constants/buildConfig'
 import { helpers } from '../constants/theme'
 import useScrollToTopOnMount from '../hooks/useScrollToTopOnMount'
 
-const Container = styled.div`
+const Container = styled('div')`
   display: flex;
   flex-direction: column;
 `
 
-const Heading = styled.p`
+const Heading = styled('p')`
   font-weight: 600;
   text-align: center;
   font-size: 1.4rem;
@@ -25,12 +25,12 @@ const Heading = styled.p`
   white-space: pre-line;
 `
 
-const Text = styled.p`
+const Text = styled('p')`
   font-size: ${props => props.theme.legacy.fonts.contentFontSize};
   font-family: ${props => props.theme.legacy.fonts.web.contentFont};
 `
 
-const Icon = styled.img`
+const Icon = styled('img')`
   width: calc(40px + 10vw);
   height: calc(40px + 10vw);
   flex-shrink: 0;
@@ -42,12 +42,12 @@ const ListHeading = styled(Heading)`
   font-size: ${props => props.theme.legacy.fonts.decorativeFontSize};
 `
 
-const ListItem = styled.div`
+const ListItem = styled('div')`
   display: flex;
   align-items: center;
 `
 
-const StepNumber = styled.div`
+const StepNumber = styled('div')`
   border-radius: 50%;
   line-height: 2rem;
   min-width: 2rem;

--- a/web/src/routes/ConsentPage.tsx
+++ b/web/src/routes/ConsentPage.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -14,7 +14,7 @@ import buildConfig from '../constants/buildConfig'
 import useLocalStorage from '../hooks/useLocalStorage'
 import { LOCAL_STORAGE_ITEM_EXTERNAL_SOURCES } from '../utils/iframes'
 
-const Description = styled.div`
+const Description = styled('div')`
   margin-bottom: 24px;
 `
 

--- a/web/src/routes/EventsPage.tsx
+++ b/web/src/routes/EventsPage.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 import { DateTime } from 'luxon'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -27,7 +27,7 @@ import usePreviousProp from '../hooks/usePreviousProp'
 import useTtsPlayer from '../hooks/useTtsPlayer'
 import featuredImageToSrcSet from '../utils/featuredImageToSrcSet'
 
-const Spacing = styled.div<{ content: string; lastUpdate?: DateTime }>`
+const Spacing = styled('div')<{ content: string; lastUpdate?: DateTime }>`
   display: flex;
   flex-direction: column;
   padding-top: 12px;

--- a/web/src/routes/SearchPage.tsx
+++ b/web/src/routes/SearchPage.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSearchParams } from 'react-router-dom'
@@ -28,7 +28,7 @@ import { cmsApiBaseUrl } from '../constants/urls'
 import useLoadSearchDocuments from '../hooks/useLoadSearchDocuments'
 import useReportError from '../hooks/useReportError'
 
-const List = styled.ul`
+const List = styled('ul')`
   list-style-type: none;
 
   & a {
@@ -36,7 +36,7 @@ const List = styled.ul`
   }
 `
 
-const SearchCounter = styled.p`
+const SearchCounter = styled('p')`
   padding: 0 5px;
   color: ${props => props.theme.legacy.colors.textSecondaryColor};
 `

--- a/web/src/routes/TuNewsDetailPage.tsx
+++ b/web/src/routes/TuNewsDetailPage.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useParams } from 'react-router-dom'
@@ -19,13 +19,13 @@ import { tunewsApiBaseUrl } from '../constants/urls'
 import useTtsPlayer from '../hooks/useTtsPlayer'
 import { TU_NEWS_DETAIL_ROUTE } from './index'
 
-const StyledContainer = styled.div`
+const StyledContainer = styled('div')`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
 `
 
-const StyledBanner = styled.div`
+const StyledBanner = styled('div')`
   position: relative;
   display: flex;
   height: 60px;
@@ -41,7 +41,7 @@ const StyledIcon = styled(Icon)`
   height: 100%;
 `
 
-const StyledTitle = styled.div`
+const StyledTitle = styled('div')`
   display: flex;
   width: 185px;
   height: 100%;


### PR DESCRIPTION
### Short Description

This PR replaces all the occurences of styled and useTheme from '@emotion/styled' with '@mui/material/styles' as well as adjusts `styled`

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Replace '@emotion/styled' with '@mui/material/styles' 

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

Test the web app and see that it does not breaks anything :muscle: 

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3310 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
