### PR TITLE
3489: Add chinese fallback to show chinese app translations

### DIFF
--- a/native/src/components/I18nProvider.tsx
+++ b/native/src/components/I18nProvider.tsx
@@ -24,7 +24,7 @@ const I18nProvider = ({ children }: I18nProviderProps): ReactElement | null => {
       const i18nextInstance = i18next.createInstance().use(NativeLanguageDetector)
       await i18nextInstance.init({
         resources,
-        fallbackLng: { ...config.fallbacks, default: [config.defaultFallback] },
+        fallbackLng: { ...config.getTranslationFallbacks(), default: [config.defaultFallback] },
 
         /* Only allow supported languages (languages which can appear  in content of cms */
         supportedLngs: [...config.getSupportedLanguageTags(), ...config.getFallbackLanguageTags()],

--- a/native/src/components/__tests__/I18nProvider.spec.tsx
+++ b/native/src/components/__tests__/I18nProvider.spec.tsx
@@ -54,6 +54,16 @@ describe('I18nProvider', () => {
     await waitFor(() => expect(getByText('Zanyariyên xwecihî')).toBeTruthy())
   })
 
+  it('should choose the default fallback for ui translations for fallback languages', async () => {
+    mockDetect.mockReturnValue(['zh'])
+    const { findByText } = render(
+      <I18nProvider>
+        <Translation>{t => <Text>{t('dashboard:events')}</Text>}</Translation>
+      </I18nProvider>,
+    )
+    expect(await findByText('Veranstaltungen')).toBeTruthy()
+  })
+
   it('should choose the default fallback for ui translations', async () => {
     mockDetect.mockReturnValue('en')
     const { getByText } = render(

--- a/release-notes/unreleased/3489-chinese.yml
+++ b/release-notes/unreleased/3489-chinese.yml
@@ -1,0 +1,7 @@
+issue_key: 3489
+show_in_stores: true
+platforms:
+  - android
+  - ios
+en: Add Chinese app translations.
+de: Die App wurde ins Chinesische übersetzt.

--- a/translations/src/config.ts
+++ b/translations/src/config.ts
@@ -158,7 +158,6 @@ class Config {
     },
   }
 
-  // Fallbacks for unnormalized language codes from our backend
   fallbacks: FallbacksType = {
     ku: ['kmr'],
     fa: ['pes'],
@@ -175,7 +174,15 @@ class Config {
     'zh-cn': ['zh-CN'],
   }
 
-  defaultFallback = 'de' // If the language code is not found in our translations then use this
+  // If the language code is not found in our translations then use this
+  defaultFallback = 'de'
+
+  // Fallbacks for unnormalized language codes from our backend
+  getTranslationFallbacks(): FallbacksType {
+    return Object.fromEntries(
+      Object.entries(this.fallbacks).map(([key, value]) => [key, [...value, this.defaultFallback]]),
+    )
+  }
 
   constructor() {
     this.checkConsistency()

--- a/translations/src/config.ts
+++ b/translations/src/config.ts
@@ -168,6 +168,7 @@ class Config {
     sr: ['sr-Cyrl'],
     'pt-br': ['pt'],
     'zh-hans': ['zh-CN'],
+    zh: ['zh-CN'],
     // Slugs from the CMS are (and have to be) lowercase
     'sr-cyrl': ['sr-Cyrl'],
     'sr-latn': ['sr-Latn'],

--- a/web/src/components/I18nProvider.tsx
+++ b/web/src/components/I18nProvider.tsx
@@ -26,7 +26,7 @@ const I18nProvider = ({ children, contentLanguage }: I18nProviderProps): ReactEl
       await i18nextInstance.init({
         resources,
         fallbackLng: {
-          ...config.fallbacks,
+          ...config.getTranslationFallbacks(),
           default: [config.defaultFallback],
         },
         supportedLngs: [...config.getSupportedLanguageTags(), ...config.getFallbackLanguageTags()],

--- a/web/src/components/__tests__/I18nProvider.spec.tsx
+++ b/web/src/components/__tests__/I18nProvider.spec.tsx
@@ -130,6 +130,16 @@ describe('I18nProvider', () => {
     expect(await findByText('Lokale Informationen')).toBeTruthy()
   })
 
+  it('should choose the default fallback for ui translations for fallback languages', async () => {
+    mockDetect.mockReturnValue(['zh'])
+    const { findByText } = render(
+      <I18nProvider contentLanguage={undefined}>
+        <Translation>{t => <p>{t('dashboard:events')}</p>}</Translation>
+      </I18nProvider>,
+    )
+    expect(await findByText('Veranstaltungen')).toBeTruthy()
+  })
+
   it('should set document language', async () => {
     render(<I18nProvider contentLanguage='ar'>Hello</I18nProvider>)
     await waitFor(() => expect(document.documentElement.lang).toBe('ar'))

--- a/web/src/components/__tests__/I18nProvider.spec.tsx
+++ b/web/src/components/__tests__/I18nProvider.spec.tsx
@@ -31,7 +31,8 @@ describe('I18nProvider', () => {
     ${'ku'}          | ${undefined}    | ${'ku'}          | ${'Zanyariyên xwecihî'}
     ${'en'}          | ${'invalid'}    | ${'en'}          | ${'Lokale Informationen'}
     ${'zh-CN'}       | ${undefined}    | ${'zh-CN'}       | ${'本地信息'}
-    ${'zh-hans'}     | ${undefined}    | ${'zh-CN'}       | ${'本地信息'}
+    ${'zh-hans'}     | ${undefined}    | ${'zh'}          | ${'本地信息'}
+    ${'zh'}          | ${undefined}    | ${'zh'}          | ${'本地信息'}
     ${'de-DE'}       | ${undefined}    | ${'de'}          | ${'Lokale Informationen'}
   `(
     `should detect correct language and translation for detected $detectedLanguage and content language $contentLanguage`,


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Add chinese fallback to show chinese app translations.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Add fallback from `zh` to `zh-CN`
- Add second fallback to the default language for fallback languages (translations only)

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- ~~It seems like using a language slug fallback (i.e. from `zh` to `zh-CN`) breaks the fallback of missing translations to the default language (German), see e.g. http://localhost:9000/muenchen/zh and open the chat. `privacyPolicyInformation` is just displayed as is.~~ Fixed this by adding the default language as second fallback to all fallback languages.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Check http://localhost:9000/muenchen/zh and http://localhost:9000/oberhausen/zh and assure that the app is translated to Chinese.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3489

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
