### PR TITLE
3477: Fix details and the re-rendering issue

### DIFF
--- a/web/src/components/RemoteContent.tsx
+++ b/web/src/components/RemoteContent.tsx
@@ -1,6 +1,6 @@
 import { useTheme } from '@mui/material/styles'
 import Dompurify from 'dompurify'
-import React, { ReactElement, useCallback, useEffect, useState } from 'react'
+import React, { ReactElement, useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 
@@ -116,12 +116,15 @@ const RemoteContent = ({ html, centered = false, smallText = false }: RemoteCont
     isContrastTheme,
   ])
 
-  const dangerouslySetInnerHTML = {
-    __html: Dompurify.sanitize(html, {
-      ADD_TAGS: [DOMPURIFY_TAG_IFRAME],
-      ADD_ATTR: [DOMPURIFY_ATTRIBUTE_FULLSCREEN, DOMPURIFY_ATTRIBUTE_TARGET],
+  const dangerouslySetInnerHTML = useMemo(
+    () => ({
+      __html: Dompurify.sanitize(html, {
+        ADD_TAGS: [DOMPURIFY_TAG_IFRAME],
+        ADD_ATTR: [DOMPURIFY_ATTRIBUTE_FULLSCREEN, DOMPURIFY_ATTRIBUTE_TARGET],
+      }),
     }),
-  }
+    [html],
+  )
 
   return (
     <RemoteContentSandBox

--- a/web/src/components/RemoteContentSandBox.ts
+++ b/web/src/components/RemoteContentSandBox.ts
@@ -74,7 +74,16 @@ const RemoteContentSandBox = styled('div')<{ centered: boolean; smallText: boole
   }
 
   details > * {
-    padding: 0 25px;
+    padding: 0 8px;
+    user-select: text;
+  }
+
+  details {
+    user-select: none;
+  }
+
+  details > img {
+    padding: 0;
   }
 
   details > summary {


### PR DESCRIPTION
### Short Description

Details component not opening up at https://future.integreat.app/muenchen/de/beratung-und-hilfe-4/beratung-und-hilfe-integration/migrationsberatung-f%C3%BCr-erwachsene-mbe

And investigate and fix content flickering while scrolling.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Just used `useMemo` for `dangerouslySetInnerHTML`.
- Adjust the padding for the icons and content inside the details.
- Prevented the details (button/ the opener) to get selected while clicking on it.

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None.

### Testing

- go to http://localhost:9000/muenchen/de/beratung-und-hilfe-4/beratung-und-hilfe-integration/migrationsberatung-f%C3%BCr-erwachsene-mbe
- Select text then scroll.
- Open the details.
- Check also http://localhost:9000/muenchen/de/gesundheit/notfaelle-sos/krankenhaus on contrast mode.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3477 and #3484

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
