### PR TITLE
3341: Add TTS intent to the Android manifest

### DIFF
--- a/native/android/app/src/main/AndroidManifest.xml
+++ b/native/android/app/src/main/AndroidManifest.xml
@@ -74,5 +74,8 @@
         <action android:name="android.intent.action.VIEW" />
         <data android:scheme="geo"/>
     </intent>
+    <intent>
+        <action android:name="android.intent.action.TTS_SERVICE" />
+    </intent>
 </queries>
 </manifest>


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
It looks like the intent might be needed in Android API 30 and higher on some Android devices. It's not mentioned in the documentation of `react-native-tts` but there are some mentions of it on Stackoverflow: https://stackoverflow.com/questions/74928642/why-is-android-11-mandating-intent-action-tts-service

And it fixed TTS on David's personal Android device for Lunes: https://github.com/digitalfabrik/lunes-app/pull/1135#discussion_r2291577677

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Add an intent for TTS to the Android Manifest

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

Hopefully none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Test TTS on an Android device, ideally a real one.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3341 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
