### PR TITLE
Increase TTS timeout

### DIFF
--- a/web/src/components/TtsContainer.tsx
+++ b/web/src/components/TtsContainer.tsx
@@ -10,6 +10,9 @@ import { getTtsVoice, isTtsCancelError, ttsInitialized } from '../utils/tts'
 import TtsHelpModal from './TtsHelpModal'
 import TtsPlayer from './TtsPlayer'
 
+const TTS_TIMEOUT = 5000
+const TTS_RETRY_INTERVAL = 250
+
 export type TtsContextType = {
   enabled?: boolean
   canRead: boolean
@@ -48,7 +51,7 @@ const TtsContainer = ({ languageCode, children }: TtsContainerProps): ReactEleme
 
   const initializeTts = useCallback(() => {
     if (buildConfig().featureFlags.tts) {
-      EasySpeech.init({ maxTimeout: 500, interval: 250 })
+      EasySpeech.init({ maxTimeout: TTS_TIMEOUT, interval: TTS_RETRY_INTERVAL })
         .then(() => setVisible(true))
         .catch(() => setShowHelpModal(true))
     }


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
As discussed in https://chat.tuerantuer.org/digitalfabrik/pl/zzyqp4zfstdz7qrtidmyf1hchc, we currently have a timeout for TTS of half a second, while the [EasySpeech docs](https://github.com/leaonline/easy-speech/blob/master/API.md#module_EasySpeech--module.exports..EasySpeech.init) use 5 seconds as a timeout. We should increase it to 5 seconds here as well to hopefully improve the TTS experience in web.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Increase the TTS timeout to 5000ms

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be None

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Test TTS in a browser

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
