### PR TITLE
Fix French translation

### DIFF
--- a/translations/translations.json
+++ b/translations/translations.json
@@ -6040,7 +6040,7 @@
       "checkQuery": "Vérifie tes critères de recherche ou change la langue définie pour l’appli {{appName}}.",
       "informationMissing": "Il manque des informations ?",
       "noResultsInUserLanguage": "Désolé, aucun résultat correspondant à ta langue n’a été trouvé.",
-      "noResultsInUserAndSourceLanguage": "Désolé, aucun résultat correspondant n’a été trouvé dans ta langue ou en français."
+      "noResultsInUserAndSourceLanguage": "Désolé, aucun résultat correspondant n’a été trouvé dans ta langue ou en allemand."
     },
     "hi": {
       "send": "भेजें",


### PR DESCRIPTION
### Short Description

I noticed that the French translation for no search results said that no results were found in the selected language or in French. It should be that no results were found in the selected language or in German (our current fallback language).

localhost:9000/augsburg/fr/search/?query=asdfj
