### PR TITLE
3524: Fix Easy speech not initialized state

### DIFF
--- a/web/src/components/TtsHelpModal.tsx
+++ b/web/src/components/TtsHelpModal.tsx
@@ -25,7 +25,8 @@ const ModalContent = styled(Container)`
 const StyledWarningText = styled('div')`
   font-family: ${props => props.theme.legacy.fonts.web.contentFont};
   font-size: 16px;
-  color: ${props => props.theme.legacy.colors.textColor};
+  color: ${props => props.theme.palette.text.primary};
+  margin-bottom: 16px;
 `
 
 const StyledWarningIcon = styled(Icon)`
@@ -36,7 +37,7 @@ const StyledList = styled('div')`
   display: flex;
   flex-direction: column;
   gap: 8px;
-  color: ${props => props.theme.legacy.colors.textColor};
+  color: ${props => props.theme.palette.text.primary};
 `
 
 const StyledExternalIcon = styled(Icon)`
@@ -46,7 +47,7 @@ const StyledExternalIcon = styled(Icon)`
 `
 
 const StyledBookIcon = styled(Icon)`
-  color: black;
+  color: ${props => props.theme.palette.text.primary};
 `
 
 const helpItemsData = [


### PR DESCRIPTION
### Short Description

When I click on Read aloud at any content page it takes about 5 seconds and if you clicked on other page like news or map it will crash.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Created a state called `isInitializing` to show a backdrop with spinner while initializing.
- Lowered the `TTS_TIMEOUT` to 2 seconds.
- Changed  the color of BookIcon at the `TtsHelperModal` to the correct one and replaced legacy text color with palette one.

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None.

### Testing
- For this test you need unsupported browser like brave or base chromium.
- Test Read aloud on any content page.
- Test it on small screens.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3524

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
