### PR TITLE
3556: Remove bottom navigation labels

### DIFF
--- a/web/src/components/BottomNavigation.tsx
+++ b/web/src/components/BottomNavigation.tsx
@@ -9,6 +9,7 @@ import { CATEGORIES_ROUTE, EVENTS_ROUTE, NEWS_ROUTE, POIS_ROUTE } from 'shared'
 import { CityModel } from 'shared/api'
 
 import useCityContentParams from '../hooks/useCityContentParams'
+import useDimensions from '../hooks/useDimensions'
 import getNavigationItems from '../utils/navigationItems'
 import Link from './base/Link'
 
@@ -31,6 +32,7 @@ type BottomNavigationProps = {
 const BottomNavigation = ({ cityModel, languageCode }: BottomNavigationProps): ReactElement | null => {
   const { route } = useCityContentParams()
   const { t } = useTranslation('layout')
+  const { xsmall } = useDimensions()
 
   const navigationItems = getNavigationItems({ cityModel, languageCode })
   const validTabValues: string[] = [CATEGORIES_ROUTE, POIS_ROUTE, NEWS_ROUTE, EVENTS_ROUTE]
@@ -53,7 +55,8 @@ const BottomNavigation = ({ cityModel, languageCode }: BottomNavigationProps): R
             component={Link}
             to={item.to}
             value={item.value}
-            label={t(item.label)}
+            label={xsmall ? undefined : t(item.label)}
+            aria-label={xsmall ? t(item.label) : undefined}
             icon={<item.Icon />}
           />
         ))}


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Remove bottom navigation labels on small screens.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Remove bottom navigation labels on small screens and add an aria-label instead

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

This deviates from the mui defaults, see reasoning in the issue.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Check the bottom navigation bar in different screen sizes.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3556

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
