### PR TITLE
Fix DatePicker test to use fixed date values

### DIFF
--- a/web/src/components/__tests__/DatePicker.spec.tsx
+++ b/web/src/components/__tests__/DatePicker.spec.tsx
@@ -52,9 +52,9 @@ describe('DatePicker', () => {
   })
 
   it('handles date change correctly', () => {
-    const currentDate = DateTime.local()
-    const newValue = DateTime.now().plus({ days: 1 }).setLocale('de')
-    const placeholderDate = DateTime.now()
+    const currentDate = DateTime.local(2025, 9, 15)
+    const newValue = DateTime.local(2025, 9, 20).setLocale('de')
+    const placeholderDate = DateTime.local(2025, 9, 15)
     const ariaLabel = `Datum auswählen, gewähltes Datum ist ${currentDate.toLocaleString({ day: 'numeric', month: 'short', year: 'numeric' }, { locale: 'de' })}`
 
     const { getByLabelText, getByText } = renderCustomDatePicker({

--- a/web/src/components/__tests__/DatePicker.spec.tsx
+++ b/web/src/components/__tests__/DatePicker.spec.tsx
@@ -54,7 +54,6 @@ describe('DatePicker', () => {
   it('handles date change correctly', () => {
     const currentDate = DateTime.local(2025, 9, 15)
     const newValue = DateTime.local(2025, 9, 20).setLocale('de')
-    const placeholderDate = DateTime.local(2025, 9, 15)
     const ariaLabel = `Datum auswählen, gewähltes Datum ist ${currentDate.toLocaleString({ day: 'numeric', month: 'short', year: 'numeric' }, { locale: 'de' })}`
 
     const { getByLabelText, getByText } = renderCustomDatePicker({
@@ -62,7 +61,7 @@ describe('DatePicker', () => {
       date: currentDate,
       setDate,
       error: '',
-      placeholderDate,
+      placeholderDate: currentDate,
       calendarLabel: 'calendar',
     })
     fireEvent.click(getByLabelText(ariaLabel))


### PR DESCRIPTION
### Short Description

`yarn test` is failing at
```bash
 FAIL  src/components/__tests__/DatePicker.spec.tsx
  ● DatePicker › handles date change correctly

    expect(jest.fn()).toHaveBeenCalledWith(...expected)

    - Expected
    + Received

    - "2025-10-01T12:44:26.986+02:00"
    + "2025-09-01T12:44:26.986+02:00",
      {"validationError": null},

    Number of calls: 1
```
- Today is the 30th of September when it adds 1 day plus it will expect 1st of October not September this is clearly means that it selects the day from the same month `fireEvent.click(getByText(newValue.day))`.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Just used fixed dates instead of `DateTime.now()`

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None.

### Testing

- `yarn test` at web.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
