### PR TITLE
3385: Use mui components for search

### DIFF
--- a/web/src/components/SearchFeedback.tsx
+++ b/web/src/components/SearchFeedback.tsx
@@ -7,6 +7,7 @@ import { SEARCH_ROUTE } from 'shared'
 import { config } from 'translations'
 
 import buildConfig from '../constants/buildConfig'
+import useCityContentParams from '../hooks/useCityContentParams'
 import FeedbackContainer from './FeedbackContainer'
 
 const Container = styled('div')`
@@ -28,14 +29,13 @@ const Hint = styled('p')`
 `
 
 type SearchFeedbackProps = {
-  cityCode: string
-  languageCode: string
   query: string
   noResults: boolean
 }
 
-const SearchFeedback = ({ cityCode, languageCode, query, noResults }: SearchFeedbackProps): ReactElement => {
+const SearchFeedback = ({ query, noResults }: SearchFeedbackProps): ReactElement => {
   const [showFeedback, setShowFeedback] = useState<boolean>(false)
+  const { cityCode, languageCode } = useCityContentParams()
   const { t } = useTranslation('feedback')
 
   useEffect(() => setShowFeedback(false), [query])

--- a/web/src/components/SearchListItem.tsx
+++ b/web/src/components/SearchListItem.tsx
@@ -1,5 +1,6 @@
-import Divider from '@mui/material/Divider'
-import { styled } from '@mui/material/styles'
+import ListItem from '@mui/material/ListItem'
+import ListItemButton from '@mui/material/ListItemButton'
+import ListItemText from '@mui/material/ListItemText'
 import React, { ReactElement } from 'react'
 
 import { getExcerpt } from 'shared'
@@ -8,79 +9,25 @@ import { EXCERPT_MAX_CHARS } from '../constants'
 import Highlighter from './Highlighter'
 import Link from './base/Link'
 
-const Row = styled('li')`
-  width: 100%;
-`
-
-const CategoryThumbnail = styled('img')`
-  width: 30px;
-  height: 30px;
-  padding: 0 5px;
-  flex-shrink: 0;
-  object-fit: contain;
-`
-
-const CategoryTitleContainer = styled('div')`
-  display: flex;
-  align-items: center;
-  flex-direction: row;
-`
-
-const CategoryItemContainer = styled('div')`
-  display: flex;
-  flex-direction: column;
-  padding: 15px 5px;
-  color: inherit;
-  text-decoration: inherit;
-  height: 100%;
-  min-width: 1px; /* needed to enable line breaks for too long words, exact value doesn't matter */
-  flex-grow: 1;
-  word-wrap: break-word;
-`
-
-const StyledHighlighter = styled(Highlighter)`
-  display: inline-block;
-`
-
-const StyledLink = styled(Link)`
-  display: inline-flex;
-  margin: 0 auto;
-  width: inherit;
-
-  &:hover {
-    color: inherit;
-    text-decoration: inherit;
-    transition: background-color 0.5s ease;
-    background-color: ${props => props.theme.legacy.colors.backgroundAccentColor};
-  }
-`
-
 type SearchListItemProps = {
   title: string
   contentWithoutHtml: string
   query: string
   path: string
-  thumbnail: string | null
 }
 
-const SearchListItem = ({ title, contentWithoutHtml, query, path, thumbnail }: SearchListItemProps): ReactElement => {
+const SearchListItem = ({ title, contentWithoutHtml, query, path }: SearchListItemProps): ReactElement => {
   const excerpt = getExcerpt(contentWithoutHtml, { query, maxChars: EXCERPT_MAX_CHARS })
 
   return (
-    <Row>
-      <StyledLink to={path}>
-        <CategoryItemContainer dir='auto'>
-          <CategoryTitleContainer>
-            {!!thumbnail && <CategoryThumbnail alt='' src={thumbnail} />}
-            <Highlighter dir='auto' search={query} text={title} />
-          </CategoryTitleContainer>
-          <div style={{ margin: '0 5px', fontSize: '12px' }} dir='auto'>
-            {excerpt.length > 0 && <StyledHighlighter search={query} text={excerpt} />}
-          </div>
-        </CategoryItemContainer>
-      </StyledLink>
-      <Divider />
-    </Row>
+    <ListItem disablePadding>
+      <ListItemButton component={Link} to={path}>
+        <ListItemText
+          primary={<Highlighter search={query} text={title} />}
+          secondary={excerpt.length > 0 && <Highlighter search={query} text={excerpt} />}
+        />
+      </ListItemButton>
+    </ListItem>
   )
 }
 

--- a/web/src/components/__tests__/SearchFeedback.spec.tsx
+++ b/web/src/components/__tests__/SearchFeedback.spec.tsx
@@ -15,13 +15,8 @@ jest.mock('react-i18next', () => ({
 }))
 
 describe('SearchFeedback', () => {
-  const cityCode = 'augsburg'
-  const languageCode = 'de'
-
   it('should open FeedbackSection on button click', () => {
-    const { getByText, getByLabelText, queryByText } = renderWithTheme(
-      <SearchFeedback cityCode={cityCode} languageCode={languageCode} query='ab' noResults={false} />,
-    )
+    const { getByText, getByLabelText, queryByText } = renderWithTheme(<SearchFeedback query='ab' noResults={false} />)
     expect(queryByText('feedback:wantedInformation')).toBeNull()
 
     fireEvent.click(getByText('feedback:informationNotFound'))
@@ -31,7 +26,7 @@ describe('SearchFeedback', () => {
 
   it('should stop showing feedback if query changes', () => {
     const { getByLabelText, getByText, queryByText, rerender } = renderWithTheme(
-      <SearchFeedback cityCode={cityCode} languageCode={languageCode} query='ab' noResults={false} />,
+      <SearchFeedback query='ab' noResults={false} />,
     )
     expect(queryByText('feedback:wantedInformation')).toBeNull()
     fireEvent.click(getByText('feedback:informationNotFound'))
@@ -39,7 +34,7 @@ describe('SearchFeedback', () => {
 
     rerender(
       <ThemeContainer contentDirection='ltr'>
-        <SearchFeedback cityCode={cityCode} languageCode={languageCode} query='a' noResults={false} />
+        <SearchFeedback query='a' noResults={false} />
       </ThemeContainer>,
     )
 
@@ -47,16 +42,12 @@ describe('SearchFeedback', () => {
   })
 
   it('should show feedback button if no results found', () => {
-    const { getByText } = renderWithTheme(
-      <SearchFeedback cityCode={cityCode} languageCode={languageCode} query='ab' noResults />,
-    )
+    const { getByText } = renderWithTheme(<SearchFeedback query='ab' noResults />)
     expect(getByText('feedback:giveFeedback')).toBeTruthy()
   })
 
   it('should not allow sending search feedback if query term is removed', async () => {
-    const { getByText, rerender } = renderWithTheme(
-      <SearchFeedback cityCode={cityCode} languageCode={languageCode} query='ab' noResults />,
-    )
+    const { getByText, rerender } = renderWithTheme(<SearchFeedback query='ab' noResults />)
     fireEvent.click(getByText('feedback:giveFeedback'))
     getByText('common:privacyPolicy').click()
     expect(getByText('feedback:send')).toBeEnabled()
@@ -64,7 +55,7 @@ describe('SearchFeedback', () => {
     // the query is controlled in the parent of SearchFeedback, so we need to update the props
     rerender(
       <ThemeContainer contentDirection='ltr'>
-        <SearchFeedback cityCode={cityCode} languageCode={languageCode} query='' noResults />
+        <SearchFeedback query='' noResults />
       </ThemeContainer>,
     )
     fireEvent.click(getByText('feedback:giveFeedback'))

--- a/web/src/components/__tests__/SearchListItem.spec.tsx
+++ b/web/src/components/__tests__/SearchListItem.spec.tsx
@@ -78,17 +78,4 @@ describe('SearchListItem', () => {
     expect(getByText(categoryParams.title)).not.toHaveProperty('style', expect.objectContaining(highlightStyle))
     expect(getByText(excerpt)).not.toHaveProperty('style', expect.objectContaining(highlightStyle))
   })
-
-  it('should render with thumbnail when provided', () => {
-    const { getByAltText } = renderWithRouterAndTheme(<SearchListItem query='' {...categoryParams} />)
-    const thumbnail = getByAltText('')
-    expect(thumbnail).toBeInTheDocument()
-  })
-
-  it('should render without thumbnail when not provided', () => {
-    const { queryByAltText } = renderWithRouterAndTheme(
-      <SearchListItem {...categoryParams} thumbnail={null} query='' />,
-    )
-    expect(queryByAltText('')).not.toBeInTheDocument()
-  })
 })

--- a/web/src/routes/SearchPage.tsx
+++ b/web/src/routes/SearchPage.tsx
@@ -110,14 +110,13 @@ const SearchPage = ({ city, cityCode, languageCode }: CityRouteProps): ReactElem
           <SearchCounter aria-live={results.length === 0 ? 'assertive' : 'polite'}>
             {t('searchResultsCount', { count: results.length })}
           </SearchCounter>
-          {results.map(({ title, content, path, thumbnail }) => (
+          {results.map(({ title, content, path }) => (
             <SearchListItem
               title={title}
               contentWithoutHtml={parseHTML(content)}
               key={path}
               query={debouncedQuery}
               path={path}
-              thumbnail={thumbnail}
             />
           ))}
         </List>

--- a/web/src/routes/SearchPage.tsx
+++ b/web/src/routes/SearchPage.tsx
@@ -1,6 +1,5 @@
-import List from '@mui/material/List'
 import Stack from '@mui/material/Stack'
-import { styled } from '@mui/material/styles'
+import Typography from '@mui/material/Typography'
 import React, { ReactElement, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSearchParams } from 'react-router-dom'
@@ -15,6 +14,7 @@ import {
   MAX_SEARCH_RESULTS,
   filterRedundantFallbackLanguageResults,
 } from 'shared'
+import { ExtendedPageModel } from 'shared/api'
 import { config } from 'translations'
 
 import { CityRouteProps } from '../CityContentSwitcher'
@@ -25,13 +25,42 @@ import LoadingSpinner from '../components/LoadingSpinner'
 import SearchFeedback from '../components/SearchFeedback'
 import SearchInput from '../components/SearchInput'
 import SearchListItem from '../components/SearchListItem'
+import List from '../components/base/List'
 import { cmsApiBaseUrl } from '../constants/urls'
 import useLoadSearchDocuments from '../hooks/useLoadSearchDocuments'
 import useReportError from '../hooks/useReportError'
 
-const SearchCounter = styled('p')`
-  color: ${props => props.theme.legacy.colors.textSecondaryColor};
-`
+type SearchProps = {
+  query: string
+  loading: boolean
+  results: ExtendedPageModel[]
+}
+
+const SearchResults = ({ query, loading, results }: SearchProps): ReactElement | null => {
+  const { t } = useTranslation('search')
+
+  if (query.length === 0) {
+    return null
+  }
+
+  if (loading) {
+    return <LoadingSpinner />
+  }
+
+  const items = results.map(({ title, content, path }) => (
+    <SearchListItem title={title} contentWithoutHtml={parseHTML(content)} key={path} query={query} path={path} />
+  ))
+
+  return (
+    <>
+      <Typography variant='label1' aria-live={results.length === 0 ? 'assertive' : 'polite'}>
+        {t('searchResultsCount', { count: results.length })}
+      </Typography>
+      <List items={items} />
+      <SearchFeedback noResults={results.length === 0} query={query} />
+    </>
+  )
+}
 
 const SearchPage = ({ city, cityCode, languageCode }: CityRouteProps): ReactElement | null => {
   const [queryParams, setQueryParams] = useSearchParams()
@@ -96,40 +125,6 @@ const SearchPage = ({ city, cityCode, languageCode }: CityRouteProps): ReactElem
     )
   }
 
-  const getPageContent = () => {
-    if (query.length === 0) {
-      return null
-    }
-    if (loading) {
-      return <LoadingSpinner />
-    }
-
-    return (
-      <>
-        <List>
-          <SearchCounter aria-live={results.length === 0 ? 'assertive' : 'polite'}>
-            {t('searchResultsCount', { count: results.length })}
-          </SearchCounter>
-          {results.map(({ title, content, path }) => (
-            <SearchListItem
-              title={title}
-              contentWithoutHtml={parseHTML(content)}
-              key={path}
-              query={debouncedQuery}
-              path={path}
-            />
-          ))}
-        </List>
-        <SearchFeedback
-          cityCode={cityCode}
-          languageCode={languageCode}
-          noResults={results.length === 0}
-          query={debouncedQuery}
-        />
-      </>
-    )
-  }
-
   return (
     <CityContentLayout isLoading={false} {...layoutParams}>
       <Helmet
@@ -137,14 +132,14 @@ const SearchPage = ({ city, cityCode, languageCode }: CityRouteProps): ReactElem
         languageChangePaths={languageChangePaths}
         cityModel={city}
       />
-      <Stack paddingTop={4}>
+      <Stack paddingTop={4} gap={2}>
         <SearchInput
           filterText={query}
           placeholderText={t('searchPlaceholder')}
           onFilterTextChange={setQuery}
           autoFocus
         />
-        {getPageContent()}
+        <SearchResults results={results} query={debouncedQuery} loading={loading} />
       </Stack>
     </CityContentLayout>
   )


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Use mui components for search list and list items.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Use mui components for `SearchListItem`
- Use mui list for search
- Extract search content to own component

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Icons are not displayed anymore

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Check out the city content search.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3385

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
