### PR TITLE
[Proposal] 3376: Refactor breadcrumbs

### DIFF
--- a/web/src/components/Breadcrumb.tsx
+++ b/web/src/components/Breadcrumb.tsx
@@ -2,6 +2,9 @@ import Button from '@mui/material/Button'
 import Typography from '@mui/material/Typography'
 import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
+import { useLocation } from 'react-router-dom'
+
+import { normalizePath } from 'shared'
 
 import Link from './base/Link'
 
@@ -20,10 +23,18 @@ type BreadcrumbProps = {
   to: string
 }
 
-const Breadcrumb = ({ title, to }: BreadcrumbProps): ReactElement => (
-  <StyledButton component={Link} to={to} variant='text' color='inherit'>
-    <StyledTypography>{title} </StyledTypography>
-  </StyledButton>
-)
+const Breadcrumb = ({ title, to }: BreadcrumbProps): ReactElement => {
+  const current = to === normalizePath(useLocation().pathname)
+
+  if (current) {
+    return <StyledTypography>{title} </StyledTypography>
+  }
+
+  return (
+    <StyledButton component={Link} to={to} variant='text' color='inherit'>
+      <StyledTypography>{title} </StyledTypography>
+    </StyledButton>
+  )
+}
 
 export default Breadcrumb

--- a/web/src/components/Breadcrumb.tsx
+++ b/web/src/components/Breadcrumb.tsx
@@ -1,4 +1,3 @@
-import shouldForwardProp from '@emotion/is-prop-valid'
 import Button from '@mui/material/Button'
 import Typography from '@mui/material/Typography'
 import { styled } from '@mui/material/styles'
@@ -6,53 +5,25 @@ import React, { ReactElement } from 'react'
 
 import Link from './base/Link'
 
-const SHRINK_FACTOR = 0.1
+const StyledButton = styled(Button)({
+  width: '100%',
+}) as typeof Button
 
-const StyledButton = styled(Button)`
-  display: list-item;
-  overflow: hidden;
-  white-space: nowrap;
-  text-transform: none;
-  justify-self: normal !important;
-  margin: 0 !important;
-  padding: 0;
-` as typeof Button
-
-const StyledTypography = styled(Typography, { shouldForwardProp })<{ shrinkFactor: number; isCurrent?: boolean }>`
-  display: list-item;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  flex-shrink: ${props => props.shrinkFactor};
-  color: ${props => (props.isCurrent ? props.theme.palette.primary.main : props.theme.palette.text.secondary)};
-`
+const StyledTypography = styled(Typography)({
+  overflow: 'hidden',
+  whiteSpace: 'nowrap',
+  textOverflow: 'ellipsis',
+})
 
 type BreadcrumbProps = {
   title: string
   to: string
-  shrink: boolean
-  isCurrent?: boolean
 }
 
-/**
- * Displays breadcrumbs (Links) for lower category levels
- */
-const Breadcrumb = ({ title, to, shrink, isCurrent }: BreadcrumbProps): ReactElement => {
-  const shrinkFactor = shrink ? SHRINK_FACTOR : 0
-
-  if (isCurrent) {
-    return (
-      <StyledTypography isCurrent shrinkFactor={shrinkFactor} aria-current='page'>
-        {title}
-      </StyledTypography>
-    )
-  }
-
-  return (
-    <StyledButton component={Link} to={to}>
-      <StyledTypography shrinkFactor={shrinkFactor}>{title} </StyledTypography>
-    </StyledButton>
-  )
-}
+const Breadcrumb = ({ title, to }: BreadcrumbProps): ReactElement => (
+  <StyledButton component={Link} to={to} variant='text' color='inherit'>
+    <StyledTypography>{title} </StyledTypography>
+  </StyledButton>
+)
 
 export default Breadcrumb

--- a/web/src/components/Breadcrumbs.tsx
+++ b/web/src/components/Breadcrumbs.tsx
@@ -1,201 +1,94 @@
 import HomeOutlinedIcon from '@mui/icons-material/HomeOutlined'
 import MoreHorizIcon from '@mui/icons-material/MoreHoriz'
-import Box from '@mui/material/Box'
-import MuiBreadcrumbs from '@mui/material/Breadcrumbs'
-import IconButton from '@mui/material/IconButton'
+import MuiBreadcrumbs, { breadcrumbsClasses } from '@mui/material/Breadcrumbs'
+import IconButton, { iconButtonClasses } from '@mui/material/IconButton'
 import Menu from '@mui/material/Menu'
 import MenuItem from '@mui/material/MenuItem'
+import Stack from '@mui/material/Stack'
 import { styled } from '@mui/material/styles'
 import React, { ReactElement, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 
+import useDimensions from '../hooks/useDimensions'
 import BreadcrumbModel from '../models/BreadcrumbModel'
 import Breadcrumb from './Breadcrumb'
 import JsonLdBreadcrumbs from './JsonLdBreadcrumbs'
-import Icon from './base/Icon'
 import Link from './base/Link'
 
-const StyledBox = styled(Box)`
-  margin: 10px 0;
-  overflow: hidden;
-  width: 100%;
-  align-items: center;
-`
-
-const StyledMuiBreadcrumbs = styled(MuiBreadcrumbs)<{ length: number }>`
-  & ol {
+const StyledMuiBreadcrumbs = styled(MuiBreadcrumbs)`
+  .${breadcrumbsClasses.ol} {
     flex-wrap: nowrap;
     overflow: hidden;
-    align-items: flex-start;
   }
 
-  & li {
+  .${breadcrumbsClasses.li} {
     overflow: hidden;
 
     &:first-of-type {
       overflow: visible;
     }
 
-    /* Shrink last breadcrumb item more if it has more than 2 items on small screens to make previous items more readable */
-    ${props => props.theme.breakpoints.down('sm')} {
+    ${props => props.theme.breakpoints.between('sm', 'md')} {
       &:last-of-type {
-        max-width: ${props => (props.length > 2 ? '100px' : 'none')};
+        max-width: 50%;
       }
     }
   }
 
-  & li:nth-of-type(even) {
-    overflow: visible;
-    flex-shrink: 0;
-    min-width: 16px;
-  }
-
-  /* Collapsed MuiBreadcrumbs */
-  /* stylelint-disable-next-line selector-class-pattern */
-  & .MuiButtonBase-root {
-    justify-self: center;
-    margin-top: 5px;
-  }
-
-  & li:has([data-ellipsis]) {
+  & li:has(.${iconButtonClasses.root}) {
     overflow: visible;
   }
-
-  /* stylelint-disable-next-line selector-class-pattern */
-  & li:has(.MuiIconButton-root) {
-    overflow: visible;
-    margin-top: 0;
-  }
-`
-
-const StyledIcon = styled(Icon)`
-  width: 24px;
-  height: 24px;
-`
-
-const StyledLink = styled(Link)`
-  margin-inline-end: 4px;
-  flex-shrink: 0;
-  overflow: visible;
-`
-
-const Separator = styled('div')`
-  &::before {
-    color: ${props => props.theme.legacy.colors.textColor};
-    font-size: 19px;
-    content: ' > ';
-  }
-`
-
-const StyledIconButton = styled(IconButton)`
-  white-space: nowrap;
-  flex-shrink: 0;
-  min-width: auto;
-  margin-top: 0 !important;
-  color: ${props => props.theme.palette.text.secondary};
 `
 
 type BreadcrumbsProps = {
-  ancestorBreadcrumbs: BreadcrumbModel[]
-  currentBreadcrumb: BreadcrumbModel
+  breadcrumbs: BreadcrumbModel[]
 }
 
-const getBreadcrumbs = (
-  ancestorBreadcrumbs: BreadcrumbModel[],
-  currentBreadcrumb: BreadcrumbModel,
-): { breadcrumbs: BreadcrumbModel[]; collapsedBreadcrumbs: BreadcrumbModel[] } => {
-  const allBreadcrumbs = [...ancestorBreadcrumbs, currentBreadcrumb]
-  const breadCrumbsLimit = 3 // with home included
-  const lastTwoCrumbs = -2
+const Breadcrumbs = ({ breadcrumbs }: BreadcrumbsProps): ReactElement | null => {
+  const [menuAnchorElement, setMenuAnchorElement] = useState<HTMLButtonElement | null>(null)
+  const { small } = useDimensions()
+  const { t } = useTranslation('common')
 
-  if (ancestorBreadcrumbs.length === 0) {
-    return { breadcrumbs: [], collapsedBreadcrumbs: [] }
+  const openMenu = (event: React.MouseEvent<HTMLButtonElement>) => setMenuAnchorElement(event.currentTarget)
+  const closeMenu = () => setMenuAnchorElement(null)
+
+  const maxVisible = small ? 1 : 2
+  const [home, ...rest] = breadcrumbs
+  const hiddenBreadcrumbs = rest.slice(0, -maxVisible)
+  const visibleBreadcrumbs = rest.slice(-maxVisible)
+
+  if (!home) {
+    return null
   }
-
-  if (allBreadcrumbs.length <= breadCrumbsLimit) {
-    return { breadcrumbs: allBreadcrumbs, collapsedBreadcrumbs: [] }
-  }
-
-  const home = allBreadcrumbs[0] as BreadcrumbModel
-  const rest = allBreadcrumbs.slice(1)
-
-  const ellipsis = new BreadcrumbModel({
-    title: '...',
-    pathname: '',
-    node: null,
-  })
-
-  return {
-    breadcrumbs: [home, ellipsis, ...rest.slice(lastTwoCrumbs)],
-    collapsedBreadcrumbs: rest.slice(0, lastTwoCrumbs),
-  }
-}
-
-const Breadcrumbs = ({ ancestorBreadcrumbs, currentBreadcrumb }: BreadcrumbsProps): ReactElement => {
-  // The current page should not be listed in the UI, but should be within the JsonLd.
-  const jsonLdBreadcrumbs = [...ancestorBreadcrumbs, currentBreadcrumb]
-  // Min text length after which the last breadcrumb item should shrink
-  const MIN_SHRINK_CHARS = 20
-
-  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
-  const open = Boolean(anchorEl)
-
-  const handleMenuOpen = (event: React.MouseEvent<HTMLButtonElement>) => {
-    setAnchorEl(event.currentTarget)
-  }
-
-  const handleMenuClose = () => {
-    setAnchorEl(null)
-  }
-
-  const breadcrumbData = getBreadcrumbs(ancestorBreadcrumbs, currentBreadcrumb)
 
   return (
-    <StyledBox>
-      <JsonLdBreadcrumbs breadcrumbs={jsonLdBreadcrumbs} />
-      <StyledMuiBreadcrumbs length={ancestorBreadcrumbs.length} aria-label='Breadcrumb' separator={<Separator />}>
-        {breadcrumbData.breadcrumbs.map((breadcrumb, index, array) => {
-          const isHome = array.length > 1 && index === 0
-          const isLast = index === array.length - 1
-
-          if (isHome) {
-            return (
-              <StyledLink key={breadcrumb.pathname} to={breadcrumb.pathname}>
-                <StyledIcon src={HomeOutlinedIcon} title={breadcrumb.title} />
-              </StyledLink>
-            )
-          }
-
-          if (breadcrumb.title === '...') {
-            return (
-              <StyledIconButton
-                key='menu'
-                size='small'
-                onClick={handleMenuOpen}
-                aria-label='Show collapsed breadcrumbs'>
-                <MoreHorizIcon />
-              </StyledIconButton>
-            )
-          }
-
-          return (
-            <Breadcrumb
-              title={breadcrumb.title}
-              to={breadcrumb.pathname}
-              shrink={breadcrumb.title.length >= MIN_SHRINK_CHARS}
-              isCurrent={isLast}
-              key={breadcrumb.title}
-            />
-          )
-        })}
+    <Stack paddingBlock={1} overflow='hidden'>
+      <JsonLdBreadcrumbs breadcrumbs={breadcrumbs} />
+      <StyledMuiBreadcrumbs aria-label='Breadcrumb' separator='>'>
+        {breadcrumbs.length > 1 ? (
+          <IconButton key='home' component={Link} to={home.pathname} aria-label={home.title}>
+            <HomeOutlinedIcon />
+          </IconButton>
+        ) : (
+          <Breadcrumb key='home' title={home.title} to={home.pathname} />
+        )}
+        {hiddenBreadcrumbs.length > 0 && (
+          <IconButton key='menu' onClick={openMenu} aria-label={t('showMore')}>
+            <MoreHorizIcon />
+          </IconButton>
+        )}
+        {visibleBreadcrumbs.map(breadcrumb => (
+          <Breadcrumb key={breadcrumb.title} title={breadcrumb.title} to={breadcrumb.pathname} />
+        ))}
       </StyledMuiBreadcrumbs>
-      <Menu anchorEl={anchorEl} open={open} onClose={handleMenuClose}>
-        {breadcrumbData.collapsedBreadcrumbs.map(item => (
-          <MenuItem key={item.pathname} onClick={handleMenuClose}>
-            <Link to={item.pathname}>{item.title}</Link>
+      <Menu anchorEl={menuAnchorElement} open={!!menuAnchorElement} onClose={closeMenu}>
+        {hiddenBreadcrumbs.map(item => (
+          <MenuItem key={item.pathname} component={Link} to={item.pathname}>
+            {item.title}
           </MenuItem>
         ))}
       </Menu>
-    </StyledBox>
+    </Stack>
   )
 }
 

--- a/web/src/components/Breadcrumbs.tsx
+++ b/web/src/components/Breadcrumbs.tsx
@@ -57,21 +57,17 @@ const Breadcrumbs = ({ breadcrumbs }: BreadcrumbsProps): ReactElement | null => 
   const hiddenBreadcrumbs = rest.slice(0, -maxVisible)
   const visibleBreadcrumbs = rest.slice(-maxVisible)
 
-  if (!home) {
-    return null
+  if (breadcrumbs.length < 2 || !home) {
+    return <JsonLdBreadcrumbs breadcrumbs={breadcrumbs} />
   }
 
   return (
     <Stack paddingBlock={1} overflow='hidden'>
       <JsonLdBreadcrumbs breadcrumbs={breadcrumbs} />
       <StyledMuiBreadcrumbs aria-label='Breadcrumb' separator='>'>
-        {breadcrumbs.length > 1 ? (
-          <IconButton key='home' component={Link} to={home.pathname} aria-label={home.title}>
-            <HomeOutlinedIcon />
-          </IconButton>
-        ) : (
-          <Breadcrumb key='home' title={home.title} to={home.pathname} />
-        )}
+        <IconButton key='home' component={Link} to={home.pathname} aria-label={home.title}>
+          <HomeOutlinedIcon />
+        </IconButton>
         {hiddenBreadcrumbs.length > 0 && (
           <IconButton key='menu' onClick={openMenu} aria-label={t('showMore')}>
             <MoreHorizIcon />

--- a/web/src/components/Tiles.tsx
+++ b/web/src/components/Tiles.tsx
@@ -1,3 +1,4 @@
+import Stack from '@mui/material/Stack'
 import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 
@@ -21,14 +22,14 @@ type TilesProps = {
 }
 
 const Tiles = ({ title, tiles }: TilesProps): ReactElement => (
-  <div>
+  <Stack paddingTop={2}>
     {!!title && <Caption title={title} />}
     <TilesRow>
       {tiles.map(tile => (
         <Tile key={tile.path} tile={tile} />
       ))}
     </TilesRow>
-  </div>
+  </Stack>
 )
 
 export default Tiles

--- a/web/src/components/__tests__/Breadcrumbs.spec.tsx
+++ b/web/src/components/__tests__/Breadcrumbs.spec.tsx
@@ -4,6 +4,8 @@ import BreadcrumbModel from '../../models/BreadcrumbModel'
 import { renderWithRouterAndTheme } from '../../testing/render'
 import Breadcrumbs from '../Breadcrumbs'
 
+jest.mock('react-i18next')
+
 const homeBreadcrumb: BreadcrumbModel = {
   title: 'Home',
   _title: 'Home',
@@ -41,7 +43,7 @@ const breadcrumb2: BreadcrumbModel = {
 }
 
 const render = (ancestors: BreadcrumbModel[], current: BreadcrumbModel) =>
-  renderWithRouterAndTheme(<Breadcrumbs ancestorBreadcrumbs={ancestors} currentBreadcrumb={current} />)
+  renderWithRouterAndTheme(<Breadcrumbs breadcrumbs={[...ancestors, current]} />)
 
 describe('Breadcrumbs', () => {
   it('should display correctly on the first level', () => {
@@ -65,9 +67,9 @@ describe('Breadcrumbs', () => {
 
   it('should show menu button when there are more than 3 breadcrumbs', () => {
     const ancestors = [homeBreadcrumb, breadcrumb0, breadcrumb1]
-    const { getByRole } = render(ancestors, breadcrumb2)
+    const { getByLabelText } = render(ancestors, breadcrumb2)
 
-    expect(getByRole('button', { name: 'Show collapsed breadcrumbs' })).toBeTruthy()
+    expect(getByLabelText('common:showMore')).toBeTruthy()
   })
 
   it('should show home icon for first breadcrumb when multiple exist', () => {
@@ -75,13 +77,5 @@ describe('Breadcrumbs', () => {
     const { getByTestId } = render(ancestors, breadcrumb1)
 
     expect(getByTestId('HomeOutlinedIcon')).toBeTruthy()
-  })
-
-  it('should apply primary color to current breadcrumb', () => {
-    const ancestors = [homeBreadcrumb, breadcrumb0]
-    const { getByText } = render(ancestors, breadcrumb1)
-
-    const currentBreadcrumb = getByText(breadcrumb1.title)
-    expect(currentBreadcrumb).toHaveStyle('color: rgb(75, 110, 218)')
   })
 })

--- a/web/src/routes/CategoriesPage.tsx
+++ b/web/src/routes/CategoriesPage.tsx
@@ -168,6 +168,7 @@ const CategoriesPage = ({ city, pathname, cityCode, languageCode }: CityRoutePro
   const ancestorBreadcrumbs = parents
     .sort((a, b) => a.parentPath.length - b.parentPath.length)
     .map((categoryModel: CategoryModel) => getBreadcrumb(categoryModel, city.name))
+  const breadcrumbs = [...ancestorBreadcrumbs, getBreadcrumb(category, city.name)]
 
   const metaDescription = t('categories:metaDescription', { appName: buildConfig().appName })
 
@@ -179,7 +180,7 @@ const CategoriesPage = ({ city, pathname, cityCode, languageCode }: CityRoutePro
         languageChangePaths={languageChangePaths}
         cityModel={city}
       />
-      <Breadcrumbs ancestorBreadcrumbs={ancestorBreadcrumbs} currentBreadcrumb={getBreadcrumb(category, city.name)} />
+      <Breadcrumbs breadcrumbs={breadcrumbs} />
       <CategoriesContent
         city={city}
         cityCode={cityCode}


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Proposal PR to refactor the breadcrumbs to get rid of loads of custom logic and styling.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Simplify breadcrumbs logic
- Remove most of the custom breadcrumb logic
- Only show one breadcrumb on small devices
- Remove highlighting of current breadcrumb

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Checkout the breadcrumbs on different pages/screen sizes.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: N/A

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
