### PR TITLE
3574: Remove hardcoded locale from poi model

### DIFF
--- a/shared/api/models/PoiModel.ts
+++ b/shared/api/models/PoiModel.ts
@@ -128,12 +128,8 @@ class PoiModel extends ExtendedPageModel {
       }
 
       return currentDay.timeSlots.some(timeslot => {
-        // converts time string into numeric hours and minutes
-        const [startHour, startMinute] = timeslot.start.split(':').map(Number)
-        const [endHour, endMinute] = timeslot.end.split(':').map(Number)
-
-        const startTime = now.set({ hour: startHour, minute: startMinute, second: 0, millisecond: 0 })
-        const endTime = now.set({ hour: endHour, minute: endMinute, second: 0, millisecond: 0 })
+        const startTime = DateTime.fromFormat(timeslot.start, 'HH:mm')
+        const endTime = DateTime.fromFormat(timeslot.end, 'HH:mm')
         return Interval.fromDateTimes(startTime, endTime).contains(now)
       })
     }

--- a/shared/utils/__tests__/pois.spec.ts
+++ b/shared/utils/__tests__/pois.spec.ts
@@ -1,3 +1,5 @@
+import { Settings } from 'luxon'
+
 import PoiModelBuilder from '../../api/endpoints/testing/PoiModelBuilder'
 import { LocationType } from '../../constants/maps'
 import { prepareMapFeatures } from '../geoJson'
@@ -21,6 +23,35 @@ describe('sortPois', () => {
 
   it('should sort features by name ascending', () => {
     expect(sortPois([poi2, poi1, poi3], null)).toEqual([poi3, poi1, poi2])
+  })
+})
+
+describe('isCurrentlyOpen', () => {
+  beforeAll(() => {
+    jest.useFakeTimers({ now: new Date('2025-10-13T13:00:00.443+02:00') })
+  })
+  afterEach(() => {
+    Settings.defaultZone = 'system'
+  })
+
+  it('should return true when currently open in Berlin at 13:00 and it is not all day', () => {
+    Settings.defaultZone = 'Europe/Berlin'
+    expect(poi2.isCurrentlyOpen).toBe(true)
+  })
+
+  it('should return true when currently open in New York at 07:00 and it is not all day', () => {
+    Settings.defaultZone = 'America/New_York'
+    expect(poi2.isCurrentlyOpen).toBe(false)
+  })
+
+  it('should return false when closed in Tokyo at 20:00 and it is not all day', () => {
+    Settings.defaultZone = 'Asia/Tokyo'
+    expect(poi2.isCurrentlyOpen).toBe(false)
+  })
+
+  it('should return true when it is all day despite New York time at 07:00', () => {
+    Settings.defaultZone = 'America/New_York'
+    expect(poi1.isCurrentlyOpen).toBe(true)
   })
 })
 


### PR DESCRIPTION
### Short Description

This PR removes hardcoded locale from poi model. It should be based on the time zone of a user

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Remove hardcoded locale
- Preserve timezone by directly setting hours and minutes on the same day as `now`

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

Go to Poi details in http://localhost:9000/testumgebung/de/locations and see opening hours (depending on your timezone (check with different timezone), it should show whether it is closed or open for you now) Check both native and web

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3574 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
