### PR TITLE
3581: Break the words in the header, not the header itself

### DIFF
--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -31,7 +31,6 @@ const Row = styled('div')`
   align-items: center;
   min-height: ${HEADER_HEIGHT}px;
   justify-content: space-between;
-  flex-wrap: wrap;
   overflow-x: auto;
   padding: 0 16px;
 

--- a/web/src/components/HeaderTitle.tsx
+++ b/web/src/components/HeaderTitle.tsx
@@ -13,7 +13,8 @@ const LONG_TITLE_LENGTH = 25
 
 const StyledTitle = styled(Typography)(({ theme }) => ({
   [theme.breakpoints.down('sm')]: {
-    width: 'min-content',
+    wordWrap: 'break-word',
+    hyphens: 'auto',
   },
 }))
 


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
The header was behaving a little weird on small screens, e.g. breaking "Alb-Donau-Kreis" into three lines when there was plenty of space to not do that. We also forced the header to break if the municipality name is too long, instead of just breaking the municipality name. That should all be fixed now.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- The municipality name in the header breaks if it's too long to fit the entire header on one line
- The municipality name in the header doesn't break if it can fit on one line

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- The header doesn't break into two lines anymore, which means that at widths below ca. 300px, the icon to open the sidebar slowly starts to disappear. There shouldn't be any devices that thin though.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Test a couple of headers on a small screen, e.g. http://localhost:9000/albdonaukreis/de and http://localhost:9000/potsdam/de

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3581


---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
