### PR TITLE
3584: Fix warnings from react-router-dom

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -36,7 +36,7 @@ const App = (): ReactElement => {
       <I18nProvider contentLanguage={contentLanguage}>
         <>
           <Helmet pageTitle={t('pageTitle')} rootPage />
-          <Router>
+          <Router future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
             <TtsContainer languageCode={contentLanguage}>
               <RootSwitcher setContentLanguage={setContentLanguage} />
             </TtsContainer>

--- a/web/src/components/__tests__/TtsContainer.spec.tsx
+++ b/web/src/components/__tests__/TtsContainer.spec.tsx
@@ -59,7 +59,7 @@ describe('TtsContainer', () => {
 
   const renderTtsPlayer = (languageCode = 'en') =>
     renderWithTheme(
-      <MemoryRouter>
+      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
         <TtsContainer languageCode={languageCode}>
           <TestChild />
         </TtsContainer>

--- a/web/src/testing/render.tsx
+++ b/web/src/testing/render.tsx
@@ -19,7 +19,9 @@ type RenderRouteOptions = {
 const theme = { ...buildConfig().legacyLightTheme, contentDirection: 'ltr' as UiDirectionType }
 
 const AllTheProviders = ({ children, options }: { children: ReactNode; options?: { pathname: string } }) => (
-  <MemoryRouter initialEntries={options ? [options.pathname] : ['/']}>
+  <MemoryRouter
+    initialEntries={options ? [options.pathname] : ['/']}
+    future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
     <ThemeProvider theme={theme}>{children}</ThemeProvider>
   </MemoryRouter>
 )
@@ -30,7 +32,12 @@ export const renderWithRouterAndTheme = (ui: ReactElement, options?: { pathname:
 export const renderWithTheme = (ui: ReactElement): RenderResult =>
   render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>)
 
-export const renderWithRouter = (ui: ReactElement): RenderResult => render(ui, { wrapper: MemoryRouter })
+export const renderWithRouter = (ui: ReactElement): RenderResult =>
+  render(ui, {
+    wrapper: (props: { children: ReactNode }) => (
+      <MemoryRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>{props.children}</MemoryRouter>
+    ),
+  })
 
 type ExtendedRenderResult = RenderResult & {
   router: Router
@@ -55,7 +62,7 @@ export const renderRoute = (ui: ReactElement, options: RenderRouteOptions): Exte
     initialEntries: [...(options.previousRoutes ?? []), { pathname: options.pathname, search: options.searchParams }],
   })
   return {
-    ...renderWithTheme(<RouterProvider router={router} />),
+    ...renderWithTheme(<RouterProvider router={router} future={{ v7_startTransition: true }} />),
     router,
   }
 }


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
This PR adds [future flags](https://reactrouter.com/6.30.1/upgrading/future) for `react-router-dom` to get it to stop throwing warnings in the console and in tests.

### Proposed Changes

<!-- Describe this PR in more detail. -->
- Add future flags in the Router invocations

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- These flags will have to be removed when upgrading `react-router-dom`, I opened this issue for that: #3591.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
- Run the tests and see if you still see the warnings (you can search for "future" in the console and should only find one test that uses that word but no warnings)
- Use the web app and keep an eye on the browser console, see if you get any errors there.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes #3584 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
