### PR TITLE
3592: Fix prop error from react dom

### DIFF
--- a/web/src/components/Selector.tsx
+++ b/web/src/components/Selector.tsx
@@ -18,10 +18,10 @@ const SelectorItemButton = styled(ListItemButton)`
 ` as typeof ListItemButton
 
 const StyledList = styled(List, {
-  shouldForwardProp: prop => prop !== '$vertical',
-})<{ $vertical: boolean }>`
+  shouldForwardProp: prop => prop !== 'vertical',
+})<{ vertical: boolean }>`
   display: flex;
-  flex-flow: ${props => (props.$vertical ? 'column' : 'row wrap')};
+  flex-flow: ${props => (props.vertical ? 'column' : 'row wrap')};
   justify-content: space-evenly;
   gap: 4px;
   padding: 8px 0;
@@ -46,7 +46,7 @@ const Selector = ({
   close,
   disabledItemTooltip,
 }: SelectorProps): ReactElement => (
-  <StyledList disablePadding $vertical={verticalLayout}>
+  <StyledList disablePadding vertical={verticalLayout}>
     {items.map(item =>
       item.href ? (
         <StyledListItem key={item.code} disablePadding>


### PR DESCRIPTION
### Short Description

This PR fixes browser console error related to prop being passed down to react dom. 

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Use `shouldForwardProp` function with transient prop to exclude style prop from being passed down the dom which could potentially impact the performace

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

- Go to http://localhost:9000/testumgebung/de
- Open a browser console
- Click on Language Selector
- See no error from react-dom

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3592 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
