### PR TITLE
3428: Increase toggle button contrast in dark theme

### DIFF
--- a/web/src/components/base/Svg.tsx
+++ b/web/src/components/base/Svg.tsx
@@ -1,4 +1,3 @@
-import { useTheme } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 import SVG from 'react-inlinesvg'
 
@@ -16,9 +15,8 @@ const Svg = ({
   width = DEFAULT_ICON_SIZE,
   height = DEFAULT_ICON_SIZE,
   className,
-}: CustomIconProps): ReactElement => {
-  const theme = useTheme()
-  return <SVG src={src} width={width} height={height} color={theme.palette.text.primary} className={className} />
-}
+}: CustomIconProps): ReactElement => (
+  <SVG src={src} width={width} height={height} color='inherit' className={className} />
+)
 
 export default Svg

--- a/web/src/components/base/ToggleButton.tsx
+++ b/web/src/components/base/ToggleButton.tsx
@@ -8,15 +8,26 @@ import Svg from './Svg'
 
 export const toggleButtonWidth = 100
 
-const StyledButton = styled(MuiToggleButton)`
-  display: flex;
-  flex-direction: column;
-  width: ${toggleButtonWidth}px;
-  height: 100px;
-  padding: 8px;
-  text-align: center;
-  gap: 8px;
-`
+const StyledButton = styled(MuiToggleButton)(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  width: toggleButtonWidth,
+  height: 100,
+  textAlign: 'center',
+  gap: 8,
+  wordBreak: 'break-word',
+  hyphens: 'auto',
+
+  ...(theme.isContrastTheme && {
+    '&.Mui-selected': {
+      color: theme.palette.text.primary,
+      backgroundColor: theme.palette.primary.main,
+      '&:hover': {
+        backgroundColor: theme.palette.primary.dark,
+      },
+    },
+  }),
+}))
 
 type ToggleButtonProps = {
   text: string


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
This PR increases the contrast of selected toggle buttons in the dark theme.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Use primary color as background and text color as color for toggle buttons in dark theme

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

I did not change the styling for unselected toggle buttons contrary to the design since they look disabled there and the contrast is good enough there imo.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Check out the poi filters and the feedback in both light and dark theme.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3428

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
