### PR TITLE
3607: Fix MalteHelpForm sent without privacy agreeing

### DIFF
--- a/web/src/components/MalteHelpForm.tsx
+++ b/web/src/components/MalteHelpForm.tsx
@@ -67,7 +67,8 @@ const MalteHelpForm = ({ pageTitle, languageCode, cityCode, malteHelpFormOffer }
     if (
       !name.length ||
       (contactChannel === 'email' && !email.length) ||
-      (contactChannel === 'telephone' && !telephone.length)
+      (contactChannel === 'telephone' && !telephone.length) ||
+      !privacyPolicyAccepted
     ) {
       return
     }

--- a/web/src/components/__tests__/MalteHelpForm.spec.tsx
+++ b/web/src/components/__tests__/MalteHelpForm.spec.tsx
@@ -337,4 +337,28 @@ describe('MalteHelpForm', () => {
 
     await waitFor(() => expect(getByText('malteHelpForm:submitFailedReasoning')).toBeInTheDocument())
   })
+
+  it('should show an error if privacy policy is not accepted and prevent submission', async () => {
+    const { getByLabelText, getByText, queryByText, getAllByLabelText } = renderWithRouterAndTheme(
+      <MalteHelpForm {...props} />,
+    )
+
+    const submitButton = getByText(submitButtonLabel)
+
+    const nameInput = getByLabelText(nameInputLabel, { exact: false })
+    fireEvent.change(nameInput, { target: { value: name } })
+
+    const emailInput = getAllByLabelText(emailInputLabel, { exact: false })[1]!
+    fireEvent.change(emailInput, { target: { value: email } })
+
+    const messageInput = getByLabelText(messageInputLabel, { exact: false })
+    fireEvent.change(messageInput, { target: { value: message } })
+
+    fireEvent.click(submitButton)
+    await waitFor(() => {
+      expect(queryByText('malteHelpForm:common:notePrivacyPolicy')).toBeInTheDocument()
+    })
+
+    expect(submitMalteHelpForm).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
### Short Description

This PR fixes MalteHelpForm being sent and success Snackbar being shown despite not accepting privacy policy.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Add to return if privacyPolicy is not accepted
- Add test

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

Go http://localhost:9000/testumgebung/de/kontaktformular by setting `api-url` in LocalStorage to `https://cms-test.malteapp.de`

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3607 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
