### PR TITLE
Fix breadcrumbs direction for RTL

### DIFF
--- a/web/src/components/ThemeContainer.tsx
+++ b/web/src/components/ThemeContainer.tsx
@@ -96,7 +96,7 @@ const createTheme = (
         },
         MuiBreadcrumbs: {
           defaultProps: {
-            dir: theme.palette.mode,
+            dir: contentDirection,
           },
         },
         MuiTooltip: {


### PR DESCRIPTION
### Short Description

This is a quick fix for the direction of the breadcrumbs for rtl languages.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Added direction propriety to MuiBreadcrumbs at the `ThemeContainer.tsx`

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None.

### Testing

- Check breadcrumbs at any category content.
- Test rtl and ltr languages.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
