### PR TITLE
Rename chat to Frag Integreat

### DIFF
--- a/shared/constants/index.ts
+++ b/shared/constants/index.ts
@@ -1,6 +1,5 @@
 export const MAX_DATE_RECURRENCES = 3
 export const MAX_SEARCH_RESULTS = 75
-export const TTS_MAX_TITLE_DISPLAY_CHARS = 20
 export const DEFAULT_ROWS_NUMBER = 4
 export const SNACKBAR_AUTO_HIDE_DURATION = 5000
 export const SPRUNGBRETT_OFFER_ALIAS = 'sprungbrett'


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
As discussed in https://chat.tuerantuer.org/digitalfabrik/pl/4zaur91fhfr8xbwj11nej8thqy, we want to have a consistent chat naming of "Frag Integreat" (mind the space). This PR adjust the naming in the app accordingly.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Use `Frag Integreat` instead of `FragIntegreat` as chat name

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Check the name of the chat both in the chat button as in the dialog title.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: N/A

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
