### PR TITLE
Fix contact card icon color and background image position

### DIFF
--- a/native/src/utils/renderHtml.ts
+++ b/native/src/utils/renderHtml.ts
@@ -101,8 +101,12 @@ const renderJS = (
         element.style.removeProperty('color');
       }
       
-      if (element instanceof HTMLImageElement && element.src.endsWith('.svg') && ${theme.isContrastTheme}) {
-        element.style.setProperty('filter', 'invert(1)');
+      if (element instanceof HTMLImageElement && element.src.endsWith('.svg')) {
+        if (${theme.isContrastTheme}) {
+          element.style.setProperty('filter', 'invert(1)')
+        } else {
+          element.style.removeProperty('filter')
+        }
       }
     });
   })();

--- a/web/src/components/RemoteContent.tsx
+++ b/web/src/components/RemoteContent.tsx
@@ -69,8 +69,12 @@ const RemoteContent = ({ html, centered = false, smallText = false }: RemoteCont
       if (element instanceof HTMLElement && element.style.color === 'rgb(0, 0, 0)') {
         element.style.removeProperty('color')
       }
-      if (element instanceof HTMLImageElement && element.src.endsWith('.svg') && isContrastTheme) {
-        element.style.setProperty('filter', 'invert(1)')
+      if (element instanceof HTMLImageElement && element.src.endsWith('.svg')) {
+        if (isContrastTheme) {
+          element.style.setProperty('filter', 'invert(1)')
+        } else {
+          element.style.removeProperty('filter')
+        }
       }
     })
 

--- a/web/src/components/RemoteContentSandBox.ts
+++ b/web/src/components/RemoteContentSandBox.ts
@@ -172,7 +172,6 @@ const RemoteContentSandBox = styled('div')<{ centered: boolean; smallText: boole
     img {
       color: ${props => props.theme.palette.text.primary};
       margin-inline-end: 8px;
-      filter: none;
     }
 
     ${props => props.theme.breakpoints.down('md')} {


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
This PR fixes the background position on RTL layouts and the icon color if switching to/from contrast theme.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Remove icon inversion if switching contrast mode
- Fix background image position on rtl layouts

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

Contact cards have the wrong direction on rtl layouts, but this is a CMS issue:
https://github.com/digitalfabrik/integreat-cms/issues/3954

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Checkout the contact cards here: http://localhost:9000/testumgebung/ar/%D8%B5%D9%81%D8%AD%D8%A9
Check both rtl and ltr and light and dark contrast.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: N/A

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
