### PR TITLE
Increase primary color contrast for dark mode

### DIFF
--- a/build-configs/ThemeType.ts
+++ b/build-configs/ThemeType.ts
@@ -20,7 +20,6 @@ export type ActionColor = {
 }
 
 export type CommonColors = {
-  primary: PaletteColor
   error: PaletteColor
   warning: SimplePaletteColor
   success: SimplePaletteColor
@@ -46,6 +45,7 @@ export type TypeBackground = {
 
 export type CommonColorPalette = CommonColors & {
   mode: PaletteMode
+  primary: PaletteColor
   tertiary: PaletteColor
   background: TypeBackground
   text: TypeText

--- a/build-configs/common/theme/colors.ts
+++ b/build-configs/common/theme/colors.ts
@@ -1,12 +1,6 @@
 import { CommonColorPalette, CommonColors } from '../../ThemeType'
 
 const commonColors: CommonColors = {
-  primary: {
-    light: '#C0DCFF',
-    main: '#4B6EDA',
-    dark: '#475CC7',
-    contrastText: '#E6E0E9',
-  },
   error: {
     light: '#FFCCCF',
     main: '#DF1D1D',
@@ -30,6 +24,12 @@ const commonColors: CommonColors = {
 export const commonLightColors: CommonColorPalette = {
   ...commonColors,
   mode: 'light',
+  primary: {
+    light: '#C0DCFF',
+    main: '#4B6EDA',
+    dark: '#475CC7',
+    contrastText: '#E6E0E9',
+  },
   tertiary: {
     light: '#EAEEF9',
     main: '#364153',
@@ -56,6 +56,12 @@ export const commonLightColors: CommonColorPalette = {
 export const commonDarkColors: CommonColorPalette = {
   ...commonColors,
   mode: 'dark',
+  primary: {
+    light: '#98C7FF',
+    main: '#4F8FFD',
+    dark: '#475CC7',
+    contrastText: '#E6E0E9',
+  },
   tertiary: {
     light: '#E9EDFB',
     main: '#AFBACC',


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
This changes the primary color for dark mode from `#4B6EDA` to `#4F8FFD` to increase the contrast of buttons and links in the dark mode.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Use different primary color for dark mode

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Check the new color.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3614

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
