### PR TITLE
Add space for city name in header for fixed cities

### DIFF
--- a/web/src/components/HeaderTitle.tsx
+++ b/web/src/components/HeaderTitle.tsx
@@ -31,9 +31,9 @@ const HeaderTitle = ({ title, landingPath }: HeaderTitleProps): ReactElement => 
   const variant = title.length >= LONG_TITLE_LENGTH && xsmall ? 'subtitle2' : 'subtitle1'
   const [tooltipOpen, setTooltipOpen] = useState(false)
 
-  if (featureFlags.fixedCity !== null) {
+  if (featureFlags.fixedCity) {
     return (
-      <StyledTitle variant={variant} alignContent='center'>
+      <StyledTitle variant={variant} alignContent='center' paddingInline={1}>
         {title}
       </StyledTitle>
     )


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Since the city name in the title is not wrapped in a button for fixed cities, there is no space between the icon and the city name. This PR adds a padding between.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Add space for city name in header for fixed cities.

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Checkout https://webnext.aschaffenburg.app

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: N/A

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
