### PR TITLE
Prevent header action item from being focused twice

### DIFF
--- a/web/src/components/HeaderActionItem.tsx
+++ b/web/src/components/HeaderActionItem.tsx
@@ -1,4 +1,4 @@
-import Button from '@mui/material/Button'
+import MuiButton from '@mui/material/Button'
 import IconButton from '@mui/material/IconButton'
 import Tooltip from '@mui/material/Tooltip'
 import { styled } from '@mui/material/styles'
@@ -6,14 +6,14 @@ import React, { ReactElement } from 'react'
 
 import Link from './base/Link'
 
-const StyledButton = styled(Button)`
-  background-color: ${props => props.theme.palette.tertiary.light};
-  padding: 2px 12px;
-`
+const StyledButton = styled(MuiButton)(({ theme }) => ({
+  backgroundColor: theme.palette.tertiary.light,
+  padding: '2px 12px',
+})) as typeof MuiButton
 
-const StyledIconButton = styled(IconButton)`
-  background-color: ${props => props.theme.palette.tertiary.light};
-`
+const StyledIconButton = styled(IconButton)(({ theme }) => ({
+  backgroundColor: theme.palette.tertiary.light,
+})) as typeof IconButton
 
 type HeaderActionItemLinkProps = {
   text: string
@@ -22,25 +22,21 @@ type HeaderActionItemLinkProps = {
 } & ({ to: string; onClick?: never } | { to?: never; onClick: () => void })
 
 const HeaderActionItem = ({ to, text, icon, onClick, innerText }: HeaderActionItemLinkProps): ReactElement => {
-  const Button = innerText ? (
-    <StyledButton onClick={onClick} startIcon={icon} aria-label={text}>
-      {innerText}
-    </StyledButton>
-  ) : (
-    <StyledIconButton onClick={onClick} color='primary' aria-label={text}>
-      {icon}
-    </StyledIconButton>
-  )
+  if (innerText) {
+    return (
+      <Tooltip title={text}>
+        <StyledButton component={to ? Link : MuiButton} to={to} onClick={onClick} startIcon={icon} aria-label={text}>
+          {innerText}
+        </StyledButton>
+      </Tooltip>
+    )
+  }
 
   return (
     <Tooltip title={text}>
-      {to ? (
-        <Link to={to} aria-label={text}>
-          {Button}
-        </Link>
-      ) : (
-        Button
-      )}
+      <StyledIconButton component={to ? Link : IconButton} to={to} onClick={onClick} color='primary' aria-label={text}>
+        {icon}
+      </StyledIconButton>
     </Tooltip>
   )
 }


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Prevent header action item from being focused twice.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Use `component={Link}` instead of using `Button` and `Link` components

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Use the tab key to navigate through the app until the language selection and see that its only selected once.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: N/A

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
