### PR TITLE
Increase chip contrast

### DIFF
--- a/web/src/components/PoiFiltersOverlayButtons.tsx
+++ b/web/src/components/PoiFiltersOverlayButtons.tsx
@@ -30,6 +30,7 @@ const PoiFiltersOverlayButtons = ({
         label={t('adjustFilters')}
         icon={<EditLocationOutlinedIcon />}
         onClick={() => setShowFilterSelection(true)}
+        variant='outlined'
         clickable
       />
       {currentlyOpenFilter && (
@@ -38,6 +39,7 @@ const PoiFiltersOverlayButtons = ({
           icon={<AccessTimeIcon />}
           onDelete={() => setCurrentlyOpenFilter(false)}
           onClick={() => setCurrentlyOpenFilter(false)}
+          variant='outlined'
           clickable
         />
       )}
@@ -47,6 +49,7 @@ const PoiFiltersOverlayButtons = ({
           icon={<Svg src={poiCategory.icon} />}
           onClick={() => setPoiCategoryFilter(null)}
           onDelete={() => setPoiCategoryFilter(null)}
+          variant='outlined'
           clickable
         />
       )}

--- a/web/src/components/ThemeContainer.tsx
+++ b/web/src/components/ThemeContainer.tsx
@@ -76,7 +76,10 @@ const createTheme = (
         },
         MuiChip: {
           styleOverrides: {
-            filled: {
+            deleteIcon: {
+              color: isContrast ? 'inherit' : theme.palette.text.disabled,
+            },
+            outlined: {
               backgroundColor: theme.palette.background.accent,
 
               [`&.${chipClasses.clickable}`]: {


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Increase chip contrast on the map by using outlined variant and increasing delete button contrast.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Increase contrast on map by using outlined variant
- Increase delete button contrast

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

The style of the chips in pois is also different now.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
See the filter chips on the map and in the pois.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: N/A

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
