### PR TITLE
3678: Remove text transform for category tiles

### DIFF
--- a/web/src/components/Tile.tsx
+++ b/web/src/components/Tile.tsx
@@ -57,7 +57,7 @@ const Tile = ({ tile }: TileProps): ReactElement => {
       <Outline>
         <StyledImage alt='' src={data?.objectUrl} />
       </Outline>
-      <Typography variant='body1' textAlign='center'>
+      <Typography variant='body1' textAlign='center' textTransform='none'>
         {tile.title}
       </Typography>
     </StyledButton>


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Remove text transform for category tiles to avoid uppercasing of the tile titles.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Set `textTransform='none'` on tile titles

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Go to http://localhost:9000/testumgebung/de and check the category tile titles.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3678

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
