### PR TITLE
Correctly label search inputs for a11y

### DIFF
--- a/web/src/components/SearchInput.tsx
+++ b/web/src/components/SearchInput.tsx
@@ -47,6 +47,7 @@ const SearchInput = ({
   const { t } = useTranslation('common')
   return (
     <StyledTextField
+      id='search'
       placeholder={placeholderText}
       aria-label={placeholderText}
       value={filterText}


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
<!-- Make sure to correctly set PR labels if necessary: `native`/`web` for native/web only PRs and `maintenance` for non-user-facing changes. -->
This PR properly connects the search input fields with their helper texts for a11y by setting the recommended id (see [docs](https://mui.com/material-ui/react-text-field/#accessibility)).

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Add `id` to search inputs

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Verify that the search inputs are correctly labeled by the helper texts.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: N/A

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
