### PR TITLE
3686: Break tile titles

### DIFF
--- a/web/src/components/Tile.tsx
+++ b/web/src/components/Tile.tsx
@@ -45,6 +45,11 @@ const StyledImage = styled('img')(({ theme }) => ({
   }),
 }))
 
+const StyledTitle = styled(Typography)({
+  wordBreak: 'break-word',
+  hyphens: 'auto',
+})
+
 type TileProps = {
   tile: TileModel
 }
@@ -57,9 +62,9 @@ const Tile = ({ tile }: TileProps): ReactElement => {
       <Outline>
         <StyledImage alt='' src={data?.objectUrl} />
       </Outline>
-      <Typography variant='body1' textAlign='center' textTransform='none'>
+      <StyledTitle variant='body1' textAlign='center' textTransform='none'>
         {tile.title}
-      </Typography>
+      </StyledTitle>
     </StyledButton>
   )
 }


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
<!-- Make sure to correctly set PR labels if necessary: `native`/`web` for native/web only PRs and `maintenance` for non-user-facing changes. -->
Break and hyphenate tile tiles.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Break and hyphenate tile tiles

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
See issue.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3686

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
