### PR TITLE
3695: Update dimensions to fix wrong dimensions in theme

### DIFF
--- a/web/src/components/BottomNavigation.tsx
+++ b/web/src/components/BottomNavigation.tsx
@@ -3,7 +3,7 @@ import BottomNavigationAction, { bottomNavigationActionClasses } from '@mui/mate
 import Paper from '@mui/material/Paper'
 import Typography from '@mui/material/Typography'
 import { styled } from '@mui/material/styles'
-import React, { ReactElement, useEffect } from 'react'
+import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { CATEGORIES_ROUTE, EVENTS_ROUTE, NEWS_ROUTE, POIS_ROUTE } from 'shared'
@@ -11,6 +11,7 @@ import { CityModel } from 'shared/api'
 
 import useCityContentParams from '../hooks/useCityContentParams'
 import useDimensions from '../hooks/useDimensions'
+import useUpdateDimensions from '../hooks/useUpdateDimensions'
 import getNavigationItems from '../utils/navigationItems'
 import Link from './base/Link'
 
@@ -56,14 +57,11 @@ const BottomNavigation = ({ cityModel, languageCode }: BottomNavigationProps): R
   const { route } = useCityContentParams()
   const { t } = useTranslation('layout')
   const { xsmall } = useDimensions()
+  useUpdateDimensions()
 
   const navigationItems = getNavigationItems({ cityModel, languageCode })
   const validTabValues: string[] = [CATEGORIES_ROUTE, POIS_ROUTE, NEWS_ROUTE, EVENTS_ROUTE]
   const value = validTabValues.includes(route) ? route : false
-
-  useEffect(() => {
-    window.dispatchEvent(new Event('resize'))
-  }, [])
 
   if (!navigationItems) {
     return null

--- a/web/src/components/CityContentToolbar.tsx
+++ b/web/src/components/CityContentToolbar.tsx
@@ -4,6 +4,7 @@ import React, { ReactElement } from 'react'
 import { NEWS_ROUTE, RATING_NEGATIVE, RATING_POSITIVE } from 'shared'
 
 import useCityContentParams from '../hooks/useCityContentParams'
+import useUpdateDimensions from '../hooks/useUpdateDimensions'
 import FeedbackToolbarItem from './FeedbackToolbarItem'
 
 export const TOOLBAR_ELEMENT_ID = 'toolbar'
@@ -14,6 +15,7 @@ type CityContentToolbarProps = {
 
 const CityContentToolbar = ({ slug }: CityContentToolbarProps): ReactElement | null => {
   const { route } = useCityContentParams()
+  useUpdateDimensions()
 
   if (route === NEWS_ROUTE) {
     // Feedback is currently not supported for the news route

--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -5,6 +5,7 @@ import React, { ReactElement } from 'react'
 import buildConfig from '../constants/buildConfig'
 import { useRouteParams } from '../hooks/useCityContentParams'
 import useDimensions from '../hooks/useDimensions'
+import useUpdateDimensions from '../hooks/useUpdateDimensions'
 import getFooterLinks from '../utils/getFooterLinks'
 import FooterListItem from './FooterListItem'
 import List from './base/List'
@@ -28,6 +29,7 @@ const StyledList = styled(List)({
 const Footer = (): ReactElement | null => {
   const linkItems = getFooterLinks(useRouteParams())
   const { mobile } = useDimensions()
+  useUpdateDimensions()
 
   if (mobile) {
     return null

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -7,6 +7,7 @@ import React, { ReactElement, ReactNode } from 'react'
 import { LANDING_ROUTE, pathnameFromRouteInformation } from 'shared'
 
 import useElementRect from '../hooks/useElementRect'
+import useUpdateDimensions from '../hooks/useUpdateDimensions'
 import HeaderLogo from './HeaderLogo'
 import HeaderTitle from './HeaderTitle'
 
@@ -73,6 +74,8 @@ export const Header = ({
   onStickyTopChanged,
 }: HeaderProps): ReactElement => {
   const { rect: headerRect, ref } = useElementRect()
+  useUpdateDimensions()
+
   const height = headerRect?.height ?? 0
   const landingPath = pathnameFromRouteInformation({ route: LANDING_ROUTE, languageCode: language })
 

--- a/web/src/components/TtsPlayer.tsx
+++ b/web/src/components/TtsPlayer.tsx
@@ -11,6 +11,7 @@ import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import useDimensions from '../hooks/useDimensions'
+import useUpdateDimensions from '../hooks/useUpdateDimensions'
 
 export const TTS_PLAYER_ELEMENT_ID = 'tts-player'
 
@@ -96,6 +97,7 @@ const TtsPlayer = ({
 }: TtsPlayerProps): ReactElement => {
   const { visibleFooterHeight, bottomNavigationHeight } = useDimensions()
   const { t } = useTranslation('layout')
+  useUpdateDimensions()
 
   return (
     <StyledTtsPlayer id={TTS_PLAYER_ELEMENT_ID} bottom={bottomNavigationHeight ?? visibleFooterHeight}>

--- a/web/src/hooks/useUpdateDimensions.ts
+++ b/web/src/hooks/useUpdateDimensions.ts
@@ -1,0 +1,8 @@
+import { useEffect } from 'react'
+
+const useUpdateDimensions = (): void =>
+  useEffect(() => {
+    window.dispatchEvent(new Event('resize'))
+  }, [])
+
+export default useUpdateDimensions


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
<!-- Make sure to correctly set PR labels if necessary: `native`/`web` for native/web only PRs and `maintenance` for non-user-facing changes. -->
We currently sometimes have the problem that the dimensions (for example in the theme) are not correctly updated after e.g. the header finishes rendering. This PR fixes this by updating the dimensions after rendering is complete.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Create a reusable hook `useUpdateDimensions` to dispatch a `resize` event after layout/dimension-relevant components finish rendering
- Use this hook in layout/dimension-relevant components. Most are probably not necessary atm but I think its good to fix those already as well

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- If those components change their size after initial rendering completes (without window resizing), the dimensions will still be wrong.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Open e.g. http://localhost:9000/castrop-rauxel/de/news/tu-news/2074 via this link and directly click on language change.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3695

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
