### PR TITLE
Do not capitalize breadcrumbs

### DIFF
--- a/web/src/components/Breadcrumb.tsx
+++ b/web/src/components/Breadcrumb.tsx
@@ -10,6 +10,7 @@ import Link from './base/Link'
 
 const StyledButton = styled(Button)({
   width: '100%',
+  textTransform: 'none',
 }) as typeof Button
 
 const StyledTypography = styled(Typography)({


### PR DESCRIPTION
### Short Description

The breadcrumbs are currently capitalized as a side effect of buttons automatically being capitalized.

<!-- Describe this PR in one or two sentences. -->
<!-- Make sure to correctly set PR labels if necessary: `native`/`web` for native/web only PRs and `maintenance` for non-user-facing changes. -->

### Proposed Changes

Add `textTransform: none`  to the relevant buttons

### Side Effects

n/a

### Testing

Check breadcrumbs.

### Resolved Issues

n/a

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
