### PR TITLE
Enhance breadcrumbs

### DIFF
--- a/web/src/components/Breadcrumb.tsx
+++ b/web/src/components/Breadcrumb.tsx
@@ -2,9 +2,6 @@ import Button from '@mui/material/Button'
 import Typography from '@mui/material/Typography'
 import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
-import { useLocation } from 'react-router'
-
-import { normalizePath } from 'shared'
 
 import Link from './base/Link'
 
@@ -22,16 +19,13 @@ const StyledTypography = styled(Typography)({
 export type BreadcrumbProps = {
   title: string
   to: string
+  startIcon?: ReactElement
 }
 
-const Breadcrumb = ({ title, to }: BreadcrumbProps): ReactElement => {
-  const current = to === normalizePath(useLocation().pathname)
-
-  return (
-    <StyledButton component={Link} to={to} variant='text' color='inherit' aria-current={current ? 'page' : undefined}>
-      <StyledTypography>{title} </StyledTypography>
-    </StyledButton>
-  )
-}
+const Breadcrumb = ({ title, to, startIcon }: BreadcrumbProps): ReactElement => (
+  <StyledButton component={Link} to={to} variant='text' color='inherit' startIcon={startIcon}>
+    <StyledTypography>{title}</StyledTypography>
+  </StyledButton>
+)
 
 export default Breadcrumb

--- a/web/src/components/Breadcrumbs.tsx
+++ b/web/src/components/Breadcrumbs.tsx
@@ -1,7 +1,7 @@
 import HomeOutlinedIcon from '@mui/icons-material/HomeOutlined'
 import MoreHorizIcon from '@mui/icons-material/MoreHoriz'
 import MuiBreadcrumbs, { breadcrumbsClasses } from '@mui/material/Breadcrumbs'
-import IconButton, { iconButtonClasses } from '@mui/material/IconButton'
+import IconButton from '@mui/material/IconButton'
 import Menu from '@mui/material/Menu'
 import MenuItem from '@mui/material/MenuItem'
 import Stack from '@mui/material/Stack'
@@ -20,22 +20,19 @@ const StyledMuiBreadcrumbs = styled(MuiBreadcrumbs)`
     overflow: hidden;
   }
 
-  .${breadcrumbsClasses.li} {
-    overflow: hidden;
-
-    &:first-of-type {
-      overflow: visible;
-    }
-
-    ${props => props.theme.breakpoints.between('sm', 'md')} {
-      &:last-of-type {
-        max-width: 50%;
-      }
-    }
+  .${breadcrumbsClasses.separator} {
+    margin: 0 4px;
   }
 
-  & li:has(.${iconButtonClasses.root}) {
-    overflow: visible;
+  .${breadcrumbsClasses.li} {
+    overflow: hidden;
+    flex: 1;
+    max-width: max-content;
+    transition: flex 0.4s linear;
+
+    &:hover {
+      flex: 3;
+    }
   }
 `
 
@@ -51,32 +48,52 @@ const Breadcrumbs = ({ breadcrumbs }: BreadcrumbsProps): ReactElement | null => 
   const openMenu = (event: React.MouseEvent<HTMLButtonElement>) => setMenuAnchorElement(event.currentTarget)
   const closeMenu = () => setMenuAnchorElement(null)
 
-  const maxVisible = xsmall ? 1 : 2
-  const [home, ...rest] = breadcrumbs
-  const hiddenBreadcrumbs = rest.slice(0, -maxVisible)
-  const visibleBreadcrumbs = rest.slice(-maxVisible)
-
-  if (breadcrumbs.length < 2 || !home) {
+  const home = breadcrumbs[0]
+  if (breadcrumbs.length <= 1 || !home) {
     return <JsonLdBreadcrumbs breadcrumbs={breadcrumbs} />
   }
+
+  const breadcrumbsWithoutHomeAndCurrent = breadcrumbs.slice(1, -1)
+
+  const maxVisible = xsmall ? 1 : 2
+  const hiddenBreadcrumbs = breadcrumbsWithoutHomeAndCurrent.slice(0, -maxVisible)
+  const visibleBreadcrumbs = breadcrumbsWithoutHomeAndCurrent.slice(-maxVisible)
+  const collapseHomeButton = hiddenBreadcrumbs.length > 0 && xsmall
+
+  const homeButton =
+    breadcrumbsWithoutHomeAndCurrent.length > 0 ? (
+      <IconButton key='home' component={Link} to={home.to} aria-label={home.title} color='inherit'>
+        <HomeOutlinedIcon />
+      </IconButton>
+    ) : (
+      <Breadcrumb title={home.title} to={home.to} startIcon={<HomeOutlinedIcon />} />
+    )
 
   return (
     <Stack paddingBlock={1} overflow='hidden'>
       <JsonLdBreadcrumbs breadcrumbs={breadcrumbs} />
       <StyledMuiBreadcrumbs aria-label='Breadcrumb' separator='>'>
-        <IconButton key='home' component={Link} to={home.to} aria-label={home.title} color='inherit'>
-          <HomeOutlinedIcon />
-        </IconButton>
+        {collapseHomeButton ? null : homeButton}
         {hiddenBreadcrumbs.length > 0 && (
           <IconButton key='menu' onClick={openMenu} aria-label={t('showMore')} color='inherit'>
             <MoreHorizIcon />
           </IconButton>
         )}
         {visibleBreadcrumbs.map(breadcrumb => (
-          <Breadcrumb key={breadcrumb.title} title={breadcrumb.title} to={breadcrumb.to} />
+          <Breadcrumb key={breadcrumb.to} title={breadcrumb.title} to={breadcrumb.to} />
         ))}
+        {/* The following `span` ensures that a separator is shown after the last element.
+            This emphasizes that the last element is the parent of the current page. 
+            Since we show the current page's title directly below the breadcrumb, we
+            do not need to repeat it here. */}
+        <span />
       </StyledMuiBreadcrumbs>
       <Menu anchorEl={menuAnchorElement} open={!!menuAnchorElement} onClose={closeMenu}>
+        {collapseHomeButton ? (
+          <MenuItem key={home.to} component={Link} to={home.to}>
+            {home.title}
+          </MenuItem>
+        ) : null}
         {hiddenBreadcrumbs.map(item => (
           <MenuItem key={item.to} component={Link} to={item.to}>
             {item.title}

--- a/web/src/components/__tests__/Breadcrumbs.spec.tsx
+++ b/web/src/components/__tests__/Breadcrumbs.spec.tsx
@@ -6,11 +6,6 @@ import Breadcrumbs from '../Breadcrumbs'
 
 jest.mock('react-i18next')
 
-const homeBreadcrumb: BreadcrumbProps = {
-  title: 'Home',
-  to: '/',
-}
-
 const breadcrumb0: BreadcrumbProps = {
   title: 'Landkreis München',
   to: '/lkmuenchen/de',
@@ -26,13 +21,23 @@ const breadcrumb2: BreadcrumbProps = {
   to: '/lkmuenchen/de/ankommen-und-leben-in-deutschland/mobilitaet',
 }
 
+const breadcrumb3: BreadcrumbProps = {
+  title: 'Mobilitätsförderung',
+  to: '/lkmuenchen/de/ankommen-und-leben-in-deutschland/mobilitaet/foerderung',
+}
+
+const breadcrumb4: BreadcrumbProps = {
+  title: 'Mobilitätsförderungsdetails',
+  to: '/lkmuenchen/de/ankommen-und-leben-in-deutschland/mobilitaet/foerderung/details',
+}
+
 const render = (ancestors: BreadcrumbProps[], current: BreadcrumbProps) =>
   renderWithRouterAndTheme(<Breadcrumbs breadcrumbs={[...ancestors, current]} />)
 
 describe('Breadcrumbs', () => {
   it('should display correctly on the first level', () => {
     const ancestors = [breadcrumb0]
-    const { getAllByRole, queryByText } = render(ancestors, breadcrumb0)
+    const { getAllByRole, queryByText } = render(ancestors, breadcrumb1)
 
     const breadcrumbLink = getAllByRole('link', { name: breadcrumb0.title })
     expect(breadcrumbLink[0]?.getAttribute('href')).toBe(breadcrumb0.to)
@@ -41,24 +46,27 @@ describe('Breadcrumbs', () => {
 
   it('should display correctly on a lower level', () => {
     const ancestors = [breadcrumb0, breadcrumb1]
-    const { getAllByRole, getByRole, queryByText } = render(ancestors, breadcrumb2)
+    const { getAllByRole, queryByText } = render(ancestors, breadcrumb2)
 
-    expect(getAllByRole('link')[0]?.getAttribute('href')).toBe(breadcrumb0.to)
-    const breadcrumbLink = getByRole('link', { name: breadcrumb1.title })
-    expect(breadcrumbLink.getAttribute('href')).toBe(breadcrumb1.to)
-    expect(queryByText(breadcrumb2.title)).toBeTruthy()
+    const firstBreadcrumbLink = getAllByRole('link')[0]
+    expect(firstBreadcrumbLink?.getAttribute('href')).toBe(breadcrumb0.to)
+    expect(firstBreadcrumbLink).toHaveTextContent('')
+    const secondBreadcrumbLink = getAllByRole('link')[1]
+    expect(secondBreadcrumbLink?.getAttribute('href')).toBe(breadcrumb1.to)
+    expect(secondBreadcrumbLink).toHaveTextContent(breadcrumb1.title)
+    expect(queryByText(breadcrumb2.title)).toBeFalsy()
   })
 
-  it('should show menu button when there are more than 3 breadcrumbs', () => {
-    const ancestors = [homeBreadcrumb, breadcrumb0, breadcrumb1]
-    const { getByLabelText } = render(ancestors, breadcrumb2)
+  it('should show menu button when there are more than 4 breadcrumbs', () => {
+    const ancestors = [breadcrumb0, breadcrumb1, breadcrumb2, breadcrumb3]
+    const { getByLabelText } = render(ancestors, breadcrumb4)
 
     expect(getByLabelText('common:showMore')).toBeTruthy()
   })
 
   it('should show home icon for first breadcrumb when multiple exist', () => {
-    const ancestors = [homeBreadcrumb, breadcrumb0]
-    const { getByTestId } = render(ancestors, breadcrumb1)
+    const ancestors = [breadcrumb0, breadcrumb1]
+    const { getByTestId } = render(ancestors, breadcrumb2)
 
     expect(getByTestId('HomeOutlinedIcon')).toBeTruthy()
   })


### PR DESCRIPTION
Disclaimer: Please let me know if you like to proceed with the proposed design. If yes, I'll adjust the tests afterwards.

### Short Description

This PR allow breadcrumbs to be more useful without user interactions (especially on mobile, but also on desktop).

### Proposed Changes

Previously (on xsmall), only the title of the current page is displayed in the breadcrumbs (on desktop only the parent and the current page are displayed). This is unnecessary since the title is already displayed directly below.
Also this contradicts the function of a breadcrumb; breadcrumbs should show the hierarchical position of the current page.

Changes: 
* Replaces current page in breadcrumbs in favor of a terminating separator: The current page's title is shown directly below; a last terminator emphasizes that the last visible breadcrumb is the parent page (Note that [W3C](https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/) does not explicitly mandate that the current page is included in the breadcrumbs).
* If home is the parent page, the home button has text, otherwise not.
* On xsmall, only the parent page is displayed (and home if home is the grandparent); on desktop the parent and grand-parent are displayed (and the home button if home is the grand-grand-parent)
* If home is not displayed as a breadcrumb (on desktop, this is never the case for reasonably structured Integreat instances), it is shoved into the overflow menu to allow for more text of the parent breadcrumb.



-------
xsmall; level 1, before & after:
<img width="288" height="608" alt="Screen Shot 2025-11-09 at 14 13 59" src="https://github.com/user-attachments/assets/ff309642-d130-4129-b0cf-c57b95b6f5ab" /><img width="288" height="608" alt="Screen Shot 2025-11-09 at 14 11 46" src="https://github.com/user-attachments/assets/5b10b998-d1b2-4bd7-89c8-e1da82e83d64" />

-------
xsmall; level 2, before & after:
<img width="288" height="608" alt="Screen Shot 2025-11-09 at 14 15 15" src="https://github.com/user-attachments/assets/36970465-fc5c-4691-a99f-ff6fd53d74dc" /><img width="288" height="608" alt="Screen Shot 2025-11-09 at 14 14 58" src="https://github.com/user-attachments/assets/971dec5b-b866-4945-8b52-64502bd43612" />

------
xsmall; level 3, before & after:
<img width="288" height="608" alt="Screen Shot 2025-11-09 at 14 17 06" src="https://github.com/user-attachments/assets/5ac940d6-be1b-4bc4-bc43-e9113ce28a1d" /><img width="288" height="608" alt="Screen Shot 2025-11-09 at 14 16 13" src="https://github.com/user-attachments/assets/aa22eec6-b7fe-4146-818d-2335e90c4f4e" />

-----

-----
desktop; level 1; before & after
<img width="4800" height="2000" alt="Screen Shot 2025-11-09 at 14 19 16" src="https://github.com/user-attachments/assets/8ae210f1-0c39-4953-b4cc-d2a890bbf052" />
<img width="2400" height="1000" alt="Screen Shot 2025-11-09 at 14 20 04" src="https://github.com/user-attachments/assets/a0b3d4a5-0f1a-4418-bd2b-0a22e14ef052" />


-----
desktop; level 2; before & after
<img width="4800" height="2000" alt="Screen Shot 2025-11-09 at 14 20 35" src="https://github.com/user-attachments/assets/5d6176bd-b8c4-45df-8fb2-15f67a0fe1f0" />
<img width="2400" height="1000" alt="Screen Shot 2025-11-09 at 14 38 45" src="https://github.com/user-attachments/assets/8ef10658-dd42-43b6-b4e7-6fcb61fd04fc" />


-----
desktop; level 3; before & after
<img width="4800" height="2000" alt="Screen Shot 2025-11-09 at 14 40 00" src="https://github.com/user-attachments/assets/fff226cf-285f-49d4-9107-faca1ee72f41" />
<img width="2400" height="1000" alt="Screen Shot 2025-11-09 at 14 23 14" src="https://github.com/user-attachments/assets/2c7505b6-e652-40bd-a2f2-a49921c708ea" />


### Side Effects

n/a

### Testing

Test the breadcrumbs

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
