### PR TITLE
3692: Use inter normal font for city name

### DIFF
--- a/web/src/components/HeaderTitle.tsx
+++ b/web/src/components/HeaderTitle.tsx
@@ -13,6 +13,9 @@ import Link from './base/Link'
 const LONG_TITLE_LENGTH = 25
 
 const StyledTitle = styled(Typography)(({ theme }) => ({
+  fontFamily: theme.typography.fontFamily,
+  fontWeight: 'normal',
+
   [theme.breakpoints.down('sm')]: {
     wordWrap: 'break-word',
     hyphens: 'auto',


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
<!-- Make sure to correctly set PR labels if necessary: `native`/`web` for native/web only PRs and `maintenance` for non-user-facing changes. -->
Use inter normal font for city name instead of raleway bold.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Use inter normal font for city name

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Checkout the header title font.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3692

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
