### PR TITLE
3673: Replace custom dividers with react native paper

### DIFF
--- a/native/src/components/CalendarChoiceModal.tsx
+++ b/native/src/components/CalendarChoiceModal.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { FlatList, View } from 'react-native'
 import { Calendar } from 'react-native-calendar-events'
+import { Divider } from 'react-native-paper'
 import styled from 'styled-components/native'
 
 import Modal from './Modal'
@@ -28,12 +29,6 @@ const ButtonTitle = styled.Text`
 const ButtonDescription = styled.Text`
   font-family: ${props => props.theme.legacy.fonts.native.contentFontRegular};
   color: ${props => props.theme.legacy.colors.textSecondaryColor};
-`
-
-const Divider = styled.View`
-  background-color: ${props => props.theme.legacy.colors.textDecorationColor};
-  height: 1px;
-  margin: 8px 0;
 `
 
 const StyledText = styled.Text`

--- a/native/src/components/ConsentSection.tsx
+++ b/native/src/components/ConsentSection.tsx
@@ -1,9 +1,8 @@
 import React, { ReactElement } from 'react'
 import { View } from 'react-native'
-import { Switch } from 'react-native-paper'
+import { Divider, Switch } from 'react-native-paper'
 import styled from 'styled-components/native'
 
-import ItemSeparator from './base/ItemSeparator'
 import Text from './base/Text'
 
 const Container = styled(View)`
@@ -35,7 +34,7 @@ const ConsentSection = ({ title, description, allowed, onPress }: ConsentSection
       </TextContainer>
       <Switch onValueChange={onPress} value={allowed} />
     </Container>
-    <ItemSeparator />
+    <Divider />
   </>
 )
 

--- a/native/src/components/Contact.tsx
+++ b/native/src/components/Contact.tsx
@@ -1,17 +1,21 @@
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
+import { Divider } from 'react-native-paper'
 import styled from 'styled-components/native'
 
 import { ContactModel } from 'shared/api'
 
 import { ExternalLinkIcon, MailIcon, PhoneIcon, WebsiteIcon, MobilePhoneIcon } from '../assets'
-import HorizontalLine from './HorizontalLine'
 import PoiDetailRow from './PoiDetailRow'
 import Text from './base/Text'
 
 const StyledContactHeader = styled(Text)`
   margin-bottom: 6px;
   color: ${props => props.theme.legacy.colors.textColor};
+`
+
+const StyledDivider = styled(Divider)`
+  margin: 20px 0;
 `
 
 type ContactProps = {
@@ -56,7 +60,7 @@ const Contact = ({
       {!!email && (
         <PoiDetailRow externalUrl={`mailto:${email}`} accessibilityLabel={t('eMail')} text={email} Icon={MailIcon} />
       )}
-      {!isLastContact && <HorizontalLine />}
+      {!isLastContact && <StyledDivider />}
     </>
   )
 }

--- a/native/src/components/HorizontalLine.tsx
+++ b/native/src/components/HorizontalLine.tsx
@@ -1,8 +1,0 @@
-import styled from 'styled-components/native'
-
-const HorizontalLine = styled.View`
-  border-bottom-width: 1px;
-  border-color: ${props => props.theme.legacy.colors.textDisabledColor};
-  margin: 20px 0;
-`
-export default HorizontalLine

--- a/native/src/components/NewsListItem.tsx
+++ b/native/src/components/NewsListItem.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
+import { Divider } from 'react-native-paper'
 import styled from 'styled-components/native'
 
 import { LocalNewsModel, TunewsModel } from 'shared/api'
@@ -42,13 +43,9 @@ const StyledPressable = styled(Pressable)`
   flex-direction: column;
 `
 
-const Divider = styled.View<{ firstItem: boolean }>`
-  border-top-width: 0.5px;
-  border-top-color: ${props => props.theme.legacy.colors.textSecondaryColor};
-  width: 80%;
+const StyledDivider = styled(Divider)<{ firstItem: boolean }>`
   margin-top: ${props => (props.firstItem ? '0px' : '12px')};
   margin-bottom: 12px;
-  align-self: center;
 `
 export const Description = styled.View`
   flex-direction: column;
@@ -92,7 +89,7 @@ const NewsListItem = ({ index, newsItem, navigateToNews, isTunews }: NewsListIte
 
   return (
     <>
-      <Divider firstItem={index === 0} />
+      <StyledDivider horizontalInset firstItem={index === 0} />
       <ListItemWrapper>
         <StyledPressable onPress={navigateToNews} accessibilityLanguage={languageCode} role='link'>
           <Description>

--- a/native/src/components/OpeningHours.tsx
+++ b/native/src/components/OpeningHours.tsx
@@ -2,6 +2,7 @@ import { DateTime } from 'luxon'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Text } from 'react-native'
+import { Divider } from 'react-native-paper'
 import styled from 'styled-components/native'
 
 import { weekdays } from 'shared'
@@ -12,7 +13,6 @@ import { contentDirection } from '../constants/contentDirection'
 import useSnackbar from '../hooks/useSnackbar'
 import openExternalUrl from '../utils/openExternalUrl'
 import Collapsible from './Collapsible'
-import HorizontalLine from './HorizontalLine'
 import OpeningEntry from './OpeningEntry'
 import Icon from './base/Icon'
 
@@ -60,6 +60,10 @@ const Link = styled.Text`
 const StyledIcon = styled(Icon)`
   width: 16px;
   height: 16px;
+`
+
+const StyledDivider = styled(Divider)`
+  margin: 20px 0;
 `
 
 type OpeningHoursTitleProps = {
@@ -115,7 +119,7 @@ const OpeningHours = ({
           language={language}
         />
         {AppointmentLink}
-        <HorizontalLine />
+        <StyledDivider />
       </>
     )
   }
@@ -145,7 +149,7 @@ const OpeningHours = ({
         </Content>
       </Collapsible>
       {AppointmentLink}
-      <HorizontalLine />
+      <StyledDivider />
     </>
   )
 }

--- a/native/src/components/PoiDetails.tsx
+++ b/native/src/components/PoiDetails.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
+import { Divider } from 'react-native-paper'
 import styled from 'styled-components/native'
 
 import { PoiModel } from 'shared/api'
@@ -7,7 +8,6 @@ import { PoiModel } from 'shared/api'
 import AddressInfo from './AddressInfo'
 import Collapsible from './Collapsible'
 import Contact from './Contact'
-import HorizontalLine from './HorizontalLine'
 import OpeningHours from './OpeningHours'
 import Page from './Page'
 import PoiChips from './PoiChips'
@@ -44,6 +44,10 @@ const StyledContactsContainer = styled.View`
   margin-top: 12px;
 `
 
+const StyledDivider = styled(Divider)`
+  margin: 20px 0;
+`
+
 type PoiDetailsProps = {
   poi: PoiModel
   language: string
@@ -63,9 +67,9 @@ const PoiDetails = ({ poi, language, distance, onFocus }: PoiDetailsProps): Reac
       )}
       {!!poi.thumbnail && <Thumbnail source={poi.thumbnail} resizeMode='cover' />}
       <PoiChips poi={poi} />
-      <HorizontalLine />
+      <StyledDivider />
       <AddressInfo location={poi.location} language={language} />
-      <HorizontalLine />
+      <StyledDivider />
       {contacts.length > 0 && (
         <>
           <Collapsible headerContent={t('contacts')} language={language}>
@@ -82,7 +86,7 @@ const PoiDetails = ({ poi, language, distance, onFocus }: PoiDetailsProps): Reac
             </StyledContactsContainer>
           </Collapsible>
 
-          <HorizontalLine />
+          <StyledDivider />
         </>
       )}
       <OpeningHours
@@ -97,7 +101,7 @@ const PoiDetails = ({ poi, language, distance, onFocus }: PoiDetailsProps): Reac
           <Collapsible headerContent={t('description')} language={language}>
             <Page content={content} language={language} padding={false} accessible />
           </Collapsible>
-          <HorizontalLine />
+          <StyledDivider />
         </>
       )}
     </PoiDetailsContainer>

--- a/native/src/components/base/ItemSeparator.ts
+++ b/native/src/components/base/ItemSeparator.ts
@@ -1,9 +1,0 @@
-import { StyleSheet } from 'react-native'
-import styled from 'styled-components/native'
-
-const ItemSeparator = styled.View`
-  background-color: ${props => props.theme.legacy.colors.textDecorationColor};
-  height: ${StyleSheet.hairlineWidth}px;
-`
-
-export default ItemSeparator

--- a/native/src/routes/Consent.tsx
+++ b/native/src/routes/Consent.tsx
@@ -1,12 +1,12 @@
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
+import { Divider } from 'react-native-paper'
 import styled from 'styled-components/native'
 
 import Caption from '../components/Caption'
 import ConsentSection from '../components/ConsentSection'
 import Layout from '../components/Layout'
 import List from '../components/List'
-import ItemSeparator from '../components/base/ItemSeparator'
 import Text from '../components/base/Text'
 import buildConfig from '../constants/buildConfig'
 import { useAppContext } from '../hooks/useCityAppContext'
@@ -44,7 +44,7 @@ const Consent = (): ReactElement | null => {
           <>
             <Caption title={t('title')} />
             <Description>{t('descriptionNative')}</Description>
-            <ItemSeparator />
+            <Divider />
           </>
         }
         noItemsMessage={t('noSources')}

--- a/native/src/routes/Settings.tsx
+++ b/native/src/routes/Settings.tsx
@@ -1,13 +1,13 @@
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 import { FlatList } from 'react-native'
+import { Divider } from 'react-native-paper'
 
 import { SettingsRouteType } from 'shared'
 
 import Caption from '../components/Caption'
 import Layout from '../components/Layout'
 import SettingItem from '../components/SettingItem'
-import ItemSeparator from '../components/base/ItemSeparator'
 import { NavigationProps } from '../constants/NavigationTypes'
 import useCityAppContext from '../hooks/useCityAppContext'
 import useSnackbar from '../hooks/useSnackbar'
@@ -49,13 +49,13 @@ const Settings = ({ navigation }: SettingsProps): ReactElement => {
   return (
     <Layout>
       <Caption title={t('layout:settings')} />
-      <ItemSeparator />
+      <Divider />
       <FlatList
         data={sections}
         extraData={appContext.settings}
         renderItem={renderItem}
-        ItemSeparatorComponent={ItemSeparator}
-        ListFooterComponent={ItemSeparator}
+        ItemSeparatorComponent={Divider}
+        ListFooterComponent={Divider}
       />
     </Layout>
   )


### PR DESCRIPTION
### Short Description

- Just replaced custom dividers with react native paper one.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Removed the following:
   - `HorizontalLine.tsx`
   - `ItemSeparator.ts`
 
- For `HorizontalLine` it has vertical margin so I added it as `StyledDivider` to the affected components.
- Adjusted the divider at NewsListItem and used `horizontalInset` instead of `width: 80%`
### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- The `horizontalInset` at `NewsListItem` doesn't look exactly like the 80% width that it was. 


### Testing

- Test settings page.
- Check Poi details.
- Check opening hours at poi details.
- Check External sources.
- Check news list.


### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3673

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->