### PR TITLE
Fix double encoding of URLs

### DIFF
--- a/native/src/utils/__tests__/openExternalUrl.spec.ts
+++ b/native/src/utils/__tests__/openExternalUrl.spec.ts
@@ -92,6 +92,18 @@ describe('openExternalUrl', () => {
     expect(showSnackbar).not.toHaveBeenCalled()
   })
 
+  it('should not encode already encoded urls', async () => {
+    const url =
+      'https://example.com/Dienstleistungen/index.php?ModID=10&object=tx%2C3406.2.1&La=1&NavID=3406.2.1&ort=&FID=3406.175.1'
+    mocked(InAppBrowser.isAvailable).mockImplementation(async () => false)
+    await openExternalUrl(url, showSnackbar)
+    expect(InAppBrowser.open).not.toHaveBeenCalled()
+    expect(showSnackbar).not.toHaveBeenCalled()
+    expect(Linking.openURL).toHaveBeenLastCalledWith(
+      'https://example.com/Dienstleistungen/index.php?ModID=10&object=tx,3406.2.1&La=1&NavID=3406.2.1&ort=&FID=3406.175.1',
+    )
+  })
+
   it('should show snackbar for internal urls if inapp browser is not available', async () => {
     const url = 'https://integreat.app'
     mocked(InAppBrowser.isAvailable).mockImplementation(async () => false)

--- a/native/src/utils/openExternalUrl.ts
+++ b/native/src/utils/openExternalUrl.ts
@@ -11,7 +11,7 @@ import { reportError } from './sentry'
 
 const WAIT_UNTIL_IN_APP_BROWSER_CLOSED = 100
 const openExternalUrl = async (rawUrl: string, showSnackbar: (snackbar: SnackbarType) => void): Promise<void> => {
-  const encodedUrl = encodeURI(rawUrl)
+  const encodedUrl = encodeURI(decodeURIComponent(rawUrl))
   const { protocol } = new URL(encodedUrl)
   const internalLinkRegexp = new RegExp(buildConfig().internalUrlPattern)
 


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
<!-- Make sure to correctly set PR labels if necessary: `Native`/`Web` for native/web only PRs and `maintenance` for non-user-facing changes. -->
Fix double encoding of URLs by decoding first.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Decode URLs before encoding them

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

Hopefully none.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Go to https://integreat.app/ortenaukreis/de/antr%C3%A4ge/wohngeld-2 and check that the URL works as expected (the `Ort eintragen` field should be displayed).

Check that different URLs (e.g. with arabic chars) still work as expected.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: N/A

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
