### PR TITLE
3753: Fix tts to use app language for iOS

### DIFF
--- a/native/src/components/TtsContainer.tsx
+++ b/native/src/components/TtsContainer.tsx
@@ -20,10 +20,9 @@ const TTS_OPTIONS: Options = {
     KEY_PARAM_VOLUME: 0.6,
     KEY_PARAM_STREAM: 'STREAM_MUSIC',
   },
-  iosVoiceId: '',
   // This must not be 1 on iOS
   rate: 0.5,
-}
+} as Options
 
 export type TtsContextType = {
   enabled: boolean


### PR DESCRIPTION
### Short Description

-  iOS selects English voice despite app language set to German.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Just removed `iosVoiceId` from `TTS_OPTIONS` 😄 

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- I hope none

### Testing
On iOS:
- keep the system lang as english and in the app select german.
- Go to any content form the categories and open Read-Aloud from the side menu.
### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3753 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
