### PR TITLE
3759: Enable RTL on Android

### DIFF
--- a/native/android/app/src/main/java/tuerantuer/app/integreat/MainActivity.kt
+++ b/native/android/app/src/main/java/tuerantuer/app/integreat/MainActivity.kt
@@ -6,6 +6,7 @@ import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
 import com.facebook.react.defaults.DefaultReactActivityDelegate
+import com.facebook.react.modules.i18nmanager.I18nUtil
 
 import java.util.Locale
 
@@ -17,6 +18,7 @@ class MainActivity : ReactActivity() {
     // https://github.com/software-mansion/react-native-screens#android
     // https://reactnavigation.org/docs/getting-started/#installing-dependencies-into-a-bare-react-native-project
     super.onCreate(null)
+    I18nUtil.getInstance().allowRTL(applicationContext, true)
     currentLocale = getResources().configuration.locale
   }
 


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
<!-- Make sure to correctly set PR labels if necessary: `Native`/`Web` for native/web only PRs and `maintenance` for non-user-facing changes. -->
While working on the redesign, @bahaaTuffaha and I figured out that flipping the production app on devices set to an RTL language doesn't seem to work on Android devices. I managed to find a [blog post from 2016](https://reactnative.dev/blog/2016/08/19/right-to-left-support-for-react-native-apps#making-an-app-rtl-ready) that is still linked in the [`react-native` code](https://github.com/facebook/react-native/blob/253fdf475365f6ad7c7c7ba17098589cf18a5c3e/packages/react-native/Libraries/ReactNative/I18nManager.d.ts#L23) that describes enabling RTL in the `MainActivity.java`. I updated it for our Kotlin file.

There is also a description for enabling RTL on iOS that we don't have in our code, but the direction reversal works on iOS, so I'm inclined to not touch it.

### Proposed Changes

<!-- Describe this PR in more detail. -->
- Enable RTL in the `MainActivity.kt`

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Please test this on a real Android device, I have only tested on an emulator so far!

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3759 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
