### PR TITLE
Hotfix: Update CircleCI to use older Android image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -226,6 +226,7 @@ jobs:
             - image: cimg/android:2025.10.1-node
         environment:
             FASTLANE_SKIP_UPDATE_CHECK: true
+            GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx2048m" -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2
             TOTAL_CPUS: 4
         parameters:
             build_config_name:
@@ -963,29 +964,8 @@ workflows:
             - bump_version:
                 context:
                     - deliverino
-                prepare_delivery: true
+                prepare_delivery: false
             - check
-            - e2e_web:
-                requires:
-                    - bump_version
-            - build_web:
-                matrix:
-                    parameters:
-                        build_config_name:
-                            - integreat
-                            - malte
-                            - aschaffenburg
-                            - obdach
-                requires:
-                    - bump_version
-            - deliver_web:
-                context:
-                    - sentry
-                delivery: beta
-                requires:
-                    - check
-                    - e2e_web
-                    - build_web
             - build_android:
                 context:
                     - credentials-repo
@@ -1004,64 +984,6 @@ workflows:
                     - browserstack
                 requires:
                     - build_android-integreat-e2e
-            - deliver_android:
-                context:
-                    - tuerantuer-google-play
-                    - sentry
-                    - browserstack
-                matrix:
-                    parameters:
-                        build_config_name:
-                            - integreat
-                            - malte
-                            - aschaffenburg
-                production_delivery: false
-                requires:
-                    - check
-                    - e2e_android
-                    - build_android-<< matrix.build_config_name >>
-            - build_ios:
-                context:
-                    - tuerantuer-apple
-                    - fastlane-match
-                matrix:
-                    parameters:
-                        build_config_name:
-                            - integreat-e2e
-                            - integreat
-                            - malte
-                            - aschaffenburg
-                requires:
-                    - bump_version
-            - e2e_ios:
-                context:
-                    - browserstack
-                requires:
-                    - build_ios-integreat-e2e
-            - deliver_ios:
-                context:
-                    - tuerantuer-apple
-                    - sentry
-                    - browserstack
-                matrix:
-                    parameters:
-                        build_config_name:
-                            - integreat
-                            - malte
-                            - aschaffenburg
-                production_delivery: false
-                requires:
-                    - check
-                    - e2e_ios
-                    - build_ios-<< matrix.build_config_name >>
-            - notify_release:
-                context:
-                    - deliverino
-                production_delivery: false
-                requires:
-                    - deliver_android
-                    - deliver_ios
-                    - deliver_web
         when:
             equal:
                 - << pipeline.parameters.workflow_type >>

--- a/.circleci/src/jobs/build_android.yml
+++ b/.circleci/src/jobs/build_android.yml
@@ -9,6 +9,7 @@ resource_class: xlarge
 environment:
   TOTAL_CPUS: 4 # For resource_class large, used in metro.config.ci.js. For memory estimations see IGAPP-557
   FASTLANE_SKIP_UPDATE_CHECK: true
+  GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m" -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2'
 shell: /bin/bash -eo pipefail
 steps:
   - checkout

--- a/.circleci/src/workflows/delivery.yml
+++ b/.circleci/src/workflows/delivery.yml
@@ -2,28 +2,28 @@ when:
   equal: [<< pipeline.parameters.workflow_type >>, delivery]
 jobs:
   - bump_version:
-      prepare_delivery: true
+      prepare_delivery: false
       context:
         - deliverino
   - check
 
-  - e2e_web:
-      requires:
-        - bump_version
-  - build_web:
-      matrix:
-        parameters:
-          build_config_name: [integreat, malte, aschaffenburg, obdach]
-      requires:
-        - bump_version
-  - deliver_web:
-      delivery: beta
-      context:
-        - sentry
-      requires:
-        - check
-        - e2e_web
-        - build_web
+  #  - e2e_web:
+  #      requires:
+  #        - bump_version
+  #  - build_web:
+  #      matrix:
+  #        parameters:
+  #          build_config_name: [integreat, malte, aschaffenburg, obdach]
+  #      requires:
+  #        - bump_version
+  #  - deliver_web:
+  #      delivery: beta
+  #      context:
+  #        - sentry
+  #      requires:
+  #        - check
+  #        - e2e_web
+  #        - build_web
 
   - build_android:
       matrix:
@@ -39,53 +39,53 @@ jobs:
         - browserstack
       requires:
         - build_android-integreat-e2e
-  - deliver_android:
-      production_delivery: false
-      matrix:
-        parameters:
-          build_config_name: [integreat, malte, aschaffenburg]
-      context:
-        - tuerantuer-google-play
-        - sentry
-        - browserstack
-      requires:
-        - check
-        - e2e_android
-        - build_android-<< matrix.build_config_name >>
+#  - deliver_android:
+#      production_delivery: false
+#      matrix:
+#        parameters:
+#          build_config_name: [integreat, malte, aschaffenburg]
+#      context:
+#        - tuerantuer-google-play
+#        - sentry
+#        - browserstack
+#      requires:
+#        - check
+#        - e2e_android
+#        - build_android-<< matrix.build_config_name >>
 
-  - build_ios:
-      matrix:
-        parameters:
-          build_config_name: [integreat-e2e, integreat, malte, aschaffenburg]
-      context:
-        - tuerantuer-apple
-        - fastlane-match
-      requires:
-        - bump_version
-  - e2e_ios:
-      context:
-        - browserstack
-      requires:
-        - build_ios-integreat-e2e
-  - deliver_ios:
-      production_delivery: false
-      matrix:
-        parameters:
-          build_config_name: [integreat, malte, aschaffenburg]
-      context:
-        - tuerantuer-apple
-        - sentry
-        - browserstack
-      requires:
-        - check
-        - e2e_ios
-        - build_ios-<< matrix.build_config_name >>
-
-  - notify_release:
-      production_delivery: false
-      context:
-        - deliverino
-      requires:
-        - deliver_android
-        - deliver_ios
-        - deliver_web
+#  - build_ios:
+#      matrix:
+#        parameters:
+#          build_config_name: [integreat-e2e, integreat, malte, aschaffenburg]
+#      context:
+#        - tuerantuer-apple
+#        - fastlane-match
+#      requires:
+#        - bump_version
+#  - e2e_ios:
+#      context:
+#        - browserstack
+#      requires:
+#        - build_ios-integreat-e2e
+#  - deliver_ios:
+#      production_delivery: false
+#      matrix:
+#        parameters:
+#          build_config_name: [integreat, malte, aschaffenburg]
+#      context:
+#        - tuerantuer-apple
+#        - sentry
+#        - browserstack
+#      requires:
+#        - check
+#        - e2e_ios
+#        - build_ios-<< matrix.build_config_name >>
+#
+#  - notify_release:
+#      production_delivery: false
+#      context:
+#        - deliverino
+#      requires:
+#        - deliver_android
+#        - deliver_ios
+#        - deliver_web


### PR DESCRIPTION
### Short Description

Build android is flaky and crashes

### Proposed Changes

- Change resource_class for `deliver_android` to large.
- Changed all docker android images to `cimg/android:2025.04.1-node`

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

-

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
