### PR TITLE
Use object-fit: contain for event thumbnails

### DIFF
--- a/web/src/components/EventListItem.tsx
+++ b/web/src/components/EventListItem.tsx
@@ -39,6 +39,7 @@ export const Icon = styled('img')(({ theme }) => ({
   marginTop: 8,
   width: 96,
   height: 96,
+  objectFit: 'contain',
 
   [theme.breakpoints.down('sm')]: {
     width: 64,


### PR DESCRIPTION
### Short Description

Add `object-fit: contain` for event thumbnails.

### Proposed Changes

Before:
<img width="1127" height="885" alt="image" src="https://github.com/user-attachments/assets/14e6f777-7a6d-4c93-9827-b2ea6f8b36f6" />

After:
<img width="1127" height="885" alt="image" src="https://github.com/user-attachments/assets/d883898a-1377-4e89-b193-85b293c1d9c4" />



### Side Effects

n/a

### Testing

Open events page, check thumbnails.

### Resolved Issues

n/a