### PR TITLE
3809: Fix header title in category detail when language changes

### DIFF
--- a/native/src/components/Header.tsx
+++ b/native/src/components/Header.tsx
@@ -105,10 +105,11 @@ const Header = ({
   const theme = useTheme()
   const showSnackbar = useSnackbar()
   // Save route/canGoBack to state to prevent it from changing during navigating which would lead to flickering of the title and back button
-  const [previousRoute] = useState(() => {
+  const [previousRouteKey] = useState(() => {
     const { routes } = navigation.getState()
-    return routes[routes.findIndex(navRoute => navRoute.key === route.key) - 1]
+    return routes[routes.findIndex(navRoute => navRoute.key === route.key) - 1]?.key
   })
+  const previousRoute = navigation.getState().routes.find(route => route.key === previousRouteKey)
   const { enabled: isTtsEnabled, showTtsPlayer } = useTtsPlayer()
   const isLanding = route.name === LANDING_ROUTE
   const currentLanguageName = languages?.find(it => it.code === languageCode)?.name
@@ -240,11 +241,6 @@ const Header = ({
       ]
     : []
 
-  const getCurrentRouteParams = () => {
-    const currentRoute = navigation.getState().routes.find(route => route.key === previousRoute?.key)
-    return currentRoute?.params as { title?: string } | undefined
-  }
-
   const isSinglePoiFromPoisRoute = (): boolean => {
     const poisRouteParams = route.params as RoutesParamsType[PoisRouteType] | undefined
     const isSinglePoi = !!poisRouteParams?.slug || poisRouteParams?.multipoi !== undefined
@@ -269,7 +265,7 @@ const Header = ({
       return { text: t('events'), language: undefined } // system language
     }
 
-    const previousRouteTitle = getCurrentRouteParams()?.title
+    const previousRouteTitle = (previousRoute.params as { title?: string } | undefined)?.title
     if (previousRouteTitle) {
       return { text: previousRouteTitle, language: languageCode }
     }


### PR DESCRIPTION
### Short Description
This PR fixes the issue where header title of a detail page in categories and maps are not translated to the chosen language when a user changes the language.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Access current route params instead of the frozen state of route params to get the title
- Simplify complex method from codscene report 

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- should be none

### Testing

Go to any category detail and see that header title change on language change

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3809 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
