### PR TITLE
3883: Fix language list at languageFailure

### DIFF
--- a/web/src/components/LanguageFailure.tsx
+++ b/web/src/components/LanguageFailure.tsx
@@ -24,7 +24,7 @@ const LanguageFailure = ({ cityModel, languageCode, languageChangePaths }: Langu
     <>
       <H1>{cityModel.name}</H1>
       <ChooseLanguage>{t('notFound.language')}</ChooseLanguage>
-      <LanguageList languageCode={languageCode} languageChangePaths={languageChangePaths} availableOnly />
+      <LanguageList languageCode={languageCode} languageChangePaths={languageChangePaths} availableOnly asList />
     </>
   )
 }

--- a/web/src/components/LanguageList.tsx
+++ b/web/src/components/LanguageList.tsx
@@ -46,6 +46,7 @@ type LanguageListProps = {
   languageCode: string
   close?: () => void
   availableOnly?: boolean
+  asList?: boolean
 }
 
 export const filterLanguageChangePath = (
@@ -70,6 +71,7 @@ const LanguageList = ({
   languageCode,
   close,
   availableOnly = false,
+  asList = false,
 }: LanguageListProps): ReactElement => {
   const { t } = useTranslation('layout')
   const { mobile } = useDimensions()
@@ -90,7 +92,7 @@ const LanguageList = ({
     )
   }, [languageChangePaths, query, languageCode])
 
-  if (mobile) {
+  if (mobile || asList) {
     return (
       <MobileContainer>
         <SearchInput placeholderText={currentLanguage?.name ?? ''} filterText={query} onFilterTextChange={setQuery} />


### PR DESCRIPTION
### Short Description

If the selected language is not available for a region it will show the languageList incorrectly. 

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Added a prop called `asList` for `LanguageList` it should show a list for both mobile and desktop

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none.

### Testing

- Go to any region and replace the language code for example `/de` to anything even if it doesn't exist like `/oo`.
- Test the languageFailure screen on small devices.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3883

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
