### PR TITLE
3896: Fix filters chip flickering

### DIFF
--- a/native/src/components/MapView.tsx
+++ b/native/src/components/MapView.tsx
@@ -32,9 +32,15 @@ import {
 
 import { clusterCountLayer, clusterLayer, markerLayer } from '../constants/layers'
 import useUserLocation from '../hooks/useUserLocation'
+import { conditionalA11yProps } from '../utils/helpers'
 import MapAttribution from './MapsAttribution'
 import Icon from './base/Icon'
 import IconButton from './base/IconButton'
+
+const OuterWrapper = styled.View`
+  flex: 1;
+  position: relative;
+`
 
 const MapContainer = styled.View`
   flex: 1;
@@ -46,7 +52,9 @@ const StyledMap = styled(MapLibreMapView)`
   width: 100%;
 `
 
-const StyledIcon = styled(IconButton)<{ position: number | string }>`
+const StyledIcon = styled(IconButton)<{
+  position: number | string
+}>`
   position: absolute;
   right: 0;
   bottom: ${props => props.position}${props => (typeof props.position === 'number' ? 'px' : '')};
@@ -184,55 +192,52 @@ const MapView = ({
   const locationPermissionIcon = userLocation ? locationPermissionGrantedIcon : 'crosshairs-off'
 
   return (
-    <MapContainer importantForAccessibility='no' accessibilityElementsHidden>
-      <StyledMap
-        mapStyle={mapConfig.styleJSON}
-        zoomEnabled
-        onPress={onPress}
-        ref={mapRef}
-        attributionEnabled={false}
-        logoEnabled={false}>
-        <UserLocation visible={!!userLocation} onUpdate={updateUserLocation} />
-        <ShapeSource
-          id='location-pois'
-          shape={embedInCollection(features.filter(feature => feature !== selectedFeature))}
-          cluster
-          clusterRadius={clusterRadius}>
-          <CircleLayer {...clusterLayer(theme)} />
-          <SymbolLayer {...clusterCountLayer} />
-          <SymbolLayer {...markerLayer(null)} />
-        </ShapeSource>
-        {selectedFeature && (
-          <ShapeSource id='selected-feature' shape={embedInCollection([selectedFeature])}>
-            <SymbolLayer {...markerLayer(selectedFeature)} id='selected-marker' />
+    <OuterWrapper>
+      <MapContainer importantForAccessibility='no' accessibilityElementsHidden>
+        <StyledMap
+          {...conditionalA11yProps({ hidden: bottomSheetFullscreen })}
+          mapStyle={mapConfig.styleJSON}
+          zoomEnabled
+          onPress={onPress}
+          ref={mapRef}
+          attributionEnabled={false}
+          logoEnabled={false}>
+          <UserLocation visible={!!userLocation} onUpdate={updateUserLocation} />
+          <ShapeSource
+            id='location-pois'
+            shape={embedInCollection(features.filter(feature => feature !== selectedFeature))}
+            cluster
+            clusterRadius={clusterRadius}>
+            <CircleLayer {...clusterLayer(theme)} />
+            <SymbolLayer {...clusterCountLayer} />
+            <SymbolLayer {...markerLayer(null)} />
           </ShapeSource>
-        )}
-        <Camera
-          {...cameraSettings}
-          followUserMode={UserTrackingMode.Follow}
-          animationDuration={animationDuration}
-          animationMode='easeTo'
-          padding={{ paddingBottom: bottomSheetHeight }}
-        />
-      </StyledMap>
-      {Boolean(!bottomSheetFullscreen) && (
-        <>
-          <OverlayContainer>{Overlay}</OverlayContainer>
-          <MapAttribution />
-          <StyledIcon
-            icon={
-              <Icon
-                color={theme.dark ? theme.colors.background : theme.colors.onSurface}
-                source={locationPermissionIcon}
-              />
-            }
-            onPress={onRequestLocation}
-            position={bottomSheetFullscreen ? 0 : bottomSheetHeight}
-            accessibilityLabel={t('showOwnLocation')}
+          {selectedFeature && (
+            <ShapeSource id='selected-feature' shape={embedInCollection([selectedFeature])}>
+              <SymbolLayer {...markerLayer(selectedFeature)} id='selected-marker' />
+            </ShapeSource>
+          )}
+          <Camera
+            {...cameraSettings}
+            followUserMode={UserTrackingMode.Follow}
+            animationDuration={animationDuration}
+            animationMode='easeTo'
+            padding={{ paddingBottom: bottomSheetHeight }}
           />
-        </>
-      )}
-    </MapContainer>
+        </StyledMap>
+      </MapContainer>
+      <OverlayContainer {...conditionalA11yProps({ hidden: bottomSheetFullscreen })}>{Overlay}</OverlayContainer>
+      <MapAttribution accessible={bottomSheetFullscreen} />
+      <StyledIcon
+        {...conditionalA11yProps({ hidden: bottomSheetFullscreen })}
+        icon={
+          <Icon color={theme.dark ? theme.colors.background : theme.colors.onSurface} source={locationPermissionIcon} />
+        }
+        onPress={onRequestLocation}
+        position={bottomSheetHeight}
+        accessibilityLabel={t('showOwnLocation')}
+      />
+    </OuterWrapper>
   )
 }
 

--- a/native/src/components/MapsAttribution.tsx
+++ b/native/src/components/MapsAttribution.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components/native'
 
 import { openStreeMapCopyright } from 'shared'
 
+import { conditionalA11yProps } from '../utils/helpers'
 import Link from './Link'
 import Text from './base/Text'
 
@@ -39,7 +40,11 @@ const styles = StyleSheet.create({
   },
 })
 
-const MapAttribution = (): ReactElement => {
+type MapAttributionProps = {
+  accessible: boolean
+}
+
+const MapAttribution = ({ accessible }: MapAttributionProps): ReactElement => {
   const { url, label, linkText, icon } = openStreeMapCopyright
   const [expanded, setExpanded] = useState<boolean>(false)
   return (
@@ -47,7 +52,8 @@ const MapAttribution = (): ReactElement => {
       borderless
       onPress={() => setExpanded(!expanded)}
       role='button'
-      style={[styles.attributionContainer, expanded && styles.expanded]}>
+      style={[styles.attributionContainer, expanded && styles.expanded]}
+      {...conditionalA11yProps({ hidden: accessible })}>
       <Attribution>
         <Text
           variant='body2'

--- a/native/src/components/Modal.tsx
+++ b/native/src/components/Modal.tsx
@@ -1,7 +1,7 @@
 import { ThemeProvider as NavigationThemeProvider } from '@react-navigation/native'
 import React, { ReactElement, ReactNode } from 'react'
-import { ScrollView, StyleSheet, View } from 'react-native'
-import { Modal as PaperModal, Portal } from 'react-native-paper'
+import { ScrollView, StyleSheet, View, Modal as RNModal, Platform } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useTheme } from 'styled-components/native'
 
 import dimensions from '../constants/dimensions'
@@ -45,15 +45,12 @@ const Modal = ({
 }: ModalProps): ReactElement => {
   const theme = useTheme()
   const navigationTheme = useNavigationTheme()
+  const insets = useSafeAreaInsets()
 
   return (
-    <Portal>
-      <NavigationThemeProvider value={navigationTheme}>
-        <PaperModal
-          visible={modalVisible}
-          onDismiss={closeModal}
-          style={styles.modalStyle}
-          contentContainerStyle={styles.modalStyle}>
+    <RNModal visible={modalVisible} transparent onRequestClose={closeModal} style={styles.modalStyle}>
+      <View style={{ flex: 1, paddingTop: Platform.OS === 'ios' ? insets.top : 0 }}>
+        <NavigationThemeProvider value={navigationTheme}>
           <View style={{ flex: 1, backgroundColor: theme.colors.background }}>
             <View style={styles.header}>
               <HeaderBox goBack={closeModal} text={headerTitle} />
@@ -70,9 +67,9 @@ const Modal = ({
               </View>
             )}
           </View>
-        </PaperModal>
-      </NavigationThemeProvider>
-    </Portal>
+        </NavigationThemeProvider>
+      </View>
+    </RNModal>
   )
 }
 

--- a/native/src/components/OpeningHoursListItem.tsx
+++ b/native/src/components/OpeningHoursListItem.tsx
@@ -44,7 +44,7 @@ const OpeningEntry = ({ openingHours, weekday, isCurrentDay, appointmentUrl }: O
   const [overlayOpen, setOverlayOpen] = useState<boolean>(false)
 
   return (
-    <EntryContainer weekday={weekday}>
+    <EntryContainer weekday={weekday} accessible>
       <Text variant={isCurrentDay ? 'h6' : 'body2'}>{weekday}</Text>
       <View style={{ flexDirection: 'row', alignItems: 'center' }}>
         {(openingHours.openAllDay as boolean) && <Text variant={isCurrentDay ? 'h6' : 'body2'}>{t('allDay')}</Text>}

--- a/native/src/components/__tests__/MapAttribution.spec.tsx
+++ b/native/src/components/__tests__/MapAttribution.spec.tsx
@@ -11,7 +11,7 @@ jest.mock('../../utils/openExternalUrl')
 
 describe('MapAttribution', () => {
   it('should be displayed and opened', () => {
-    const { getByText } = renderWithTheme(<MapAttribution />)
+    const { getByText } = renderWithTheme(<MapAttribution accessible={false} />)
     fireEvent.press(getByText(openStreeMapCopyright.icon))
     fireEvent.press(getByText(openStreeMapCopyright.linkText))
     expect(openExternalUrl).toHaveBeenCalledTimes(1)

--- a/native/src/routes/__tests__/Pois.spec.tsx
+++ b/native/src/routes/__tests__/Pois.spec.tsx
@@ -176,8 +176,9 @@ describe('Pois', () => {
     expect(getAllByText('Dienstleistung')).toHaveLength(2)
 
     fireEvent.press(getByRole('switch', { name: 'Dienstleistung' }))
+    fireEvent.press(getByText('showPois'))
 
-    expect(getAllByText('Dienstleistung')).toHaveLength(3)
+    expect(getAllByText('Dienstleistung')).toHaveLength(2)
     expect(getByText(poi1.title)).toBeTruthy()
     expect(queryByText(poi0.title)).toBeFalsy()
     expect(queryByText(poi2.title)).toBeFalsy()

--- a/native/src/utils/helpers.ts
+++ b/native/src/utils/helpers.ts
@@ -11,6 +11,16 @@ import { log } from './sentry'
 
 export const ANDROID_FILE_PREFIX = 'file://'
 
+type ConditionalA11yProps = {
+  accessibilityElementsHidden: boolean
+  importantForAccessibility: 'auto' | 'yes' | 'no' | 'no-hide-descendants'
+}
+
+export const conditionalA11yProps = ({ hidden }: { hidden: boolean }): ConditionalA11yProps => ({
+  importantForAccessibility: hidden ? 'no-hide-descendants' : 'auto',
+  accessibilityElementsHidden: hidden,
+})
+
 // Android throws an error if attempting to delete non existing directories/files
 // https://github.com/joltup/rn-fetch-blob/issues/333
 export const deleteIfExists = async (path: string): Promise<void> => {


### PR DESCRIPTION
### Short Description

This PR fixes flickering of the filters chip in maps when the bottom sheet expands and contracts to previous state. Also added `accessible` prop to OpeningHoursListitem.ts to wrap weekdays with hours for screenreader, without it they are read separetely

### Proposed Changes

<!-- Describe this PR in more detail. -->

- [x] remove unmounting condition which was before used to hide the children from the screen reader focusing on them when the bottom sheet expanded. Always keep them mounted.
- [x]  fix accessibility issue when using keyboard with screen reader available by hiding it from screen reader when the modal appears and the bottom sheet expands 
- [x] add accessible prop to weekdays and hours container

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- I hope none

### Testing

1. Go to the maps
2. Expand and contract the bottom sheet
3. See that the filters chip is not flickering (try with additional chips)
4. Also check with screen reader also using the keyboard whether it reads out the children in MapView when the filters modal appear or when the bottom sheet expands

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3896 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
