### PR TITLE
[Android] 3827: Prevent tts from reading Uhr twice

### DIFF
--- a/native/src/components/TtsContainer.tsx
+++ b/native/src/components/TtsContainer.tsx
@@ -19,6 +19,7 @@ import { AppContext } from '../contexts/AppContextProvider'
 import useAppStateListener from '../hooks/useAppStateListener'
 import useSnackbar from '../hooks/useSnackbar'
 import { log, reportError } from '../utils/sentry'
+import { prepareText } from '../utils/tts'
 import TtsPlayer from './TtsPlayer'
 
 export type TtsContextType = {
@@ -174,7 +175,7 @@ const TtsContainer = ({ children }: TtsContainerProps): ReactElement => {
             setIsPlaying(true)
             setSentenceIndex(safeIndex)
 
-            await Speech.speak(sentence, getTtsOptions(languageCode))
+            await Speech.speak(prepareText(sentence), getTtsOptions(languageCode))
           }
         } catch (error) {
           reportError(error)

--- a/native/src/utils/__tests__/tts.spec.ts
+++ b/native/src/utils/__tests__/tts.spec.ts
@@ -1,0 +1,28 @@
+import { Platform } from 'react-native'
+
+import { prepareText } from '../tts'
+
+describe('tts', () => {
+  it('should correctly strip Uhr from tts sentences on android', () => {
+    Platform.OS = 'android'
+    expect(prepareText('Dies ist mein Text, geschrieben um 12Uhr und später')).toEqual(
+      'Dies ist mein Text, geschrieben um 12 und später',
+    )
+    expect(prepareText('12:30 Uhr')).toEqual('12:30')
+    expect(prepareText('3 Uhr')).toEqual('3')
+  })
+
+  it('should not strip Uhr from other sentences', () => {
+    Platform.OS = 'android'
+    expect(prepareText('Die 12 Uhrzeiten')).toEqual('Die 12 Uhrzeiten')
+    expect(prepareText('Die Uhr ist rund')).toEqual('Die Uhr ist rund')
+    expect(prepareText('Es ist 12, das ist auf der Uhr oben.')).toEqual('Es ist 12, das ist auf der Uhr oben.')
+  })
+
+  it('should not strip Uhr from tts sentences on ios', () => {
+    Platform.OS = 'ios'
+    expect(prepareText('Dies ist mein Text, geschrieben um 12Uhr und später')).toEqual(
+      'Dies ist mein Text, geschrieben um 12Uhr und später',
+    )
+  })
+})

--- a/native/src/utils/tts.ts
+++ b/native/src/utils/tts.ts
@@ -1,0 +1,5 @@
+import { Platform } from 'react-native'
+
+// Strips 'Uhr' from strings like '12 Uhr' or '11:30Uhr' since it is automatically added by tts on android
+export const prepareText = (text: string): string =>
+  Platform.OS === 'android' ? text.replace(/(\d+)\s?Uhr(\W|$)/g, (_, time, suffix) => `${time}${suffix}`) : text

--- a/release-notes/unreleased/3827-tts-uhr-duplicate.yml
+++ b/release-notes/unreleased/3827-tts-uhr-duplicate.yml
@@ -1,0 +1,6 @@
+issue_key: 3827
+show_in_stores: true
+platforms:
+  - android
+en: Prevent read aloud from reading Uhr twice
+de: Die Vorlesefunktion liest Uhr nicht mehr doppelt vor


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
<!-- Make sure to correctly set PR labels if necessary: `Native`/`Web` for native/web only PRs and `maintenance` for non-user-facing changes. -->
TTS on android is automatically adding "Uhr" to times in German. Prevent reading this twice by removing "Uhr" from texts before passing it to tts.

I am not very sure if this small bug is worth this workaround, I think we could also just close this issue and except it as a limitation.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Use a regex to remove "Uhr" after times only (only on android)

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

If the TTS behavior on android ever changes, no "Uhr" will be included anymore

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Go to testumgebung/de/test-tts-uhr (test cms) and use the tts function. Verify that "Uhr" is read max once.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3827

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
