### PR TITLE
3932: Fix location change button disappearing after tab switch

### DIFF
--- a/native/src/components/__tests__/Header.spec.tsx
+++ b/native/src/components/__tests__/Header.spec.tsx
@@ -151,21 +151,10 @@ describe('Header', () => {
 
   it('should show location change button even when tab history exists', () => {
     mockPreviousRoute(false)
-    const tabNavigationMock = {
-      getState: jest.fn(() => ({
-        history: [{ key: 'tab-key-0' }, { key: 'tab-key-1' }],
-        index: 1,
-        routes: [],
-        key: 'tab-key',
-        routeNames: [],
-        type: 'tab' as const,
-        stale: false as const,
-      })),
-      getParent: jest.fn(() => ({
-        getState: jest.fn(() => ({ index: 0 })),
-      })),
-    }
-    mocked(navigation.getParent).mockReturnValue(tabNavigationMock as never)
+    mocked(navigation.getParent).mockReturnValue({
+      getState: jest.fn(() => ({ history: [{ key: 'tab-key-0' }, { key: 'tab-key-1' }] })),
+      getParent: jest.fn(() => {}),
+    } as never)
     const { getByLabelText } = renderHeader({})
     expect(getByLabelText(/changeLocation/)).toBeTruthy()
   })

--- a/release-notes/unreleased/3932.yml
+++ b/release-notes/unreleased/3932.yml
@@ -1,7 +1,0 @@
-issue_key: 3932
-show_in_stores: true
-platforms:
-  - android
-  - ios
-en: Fixed location change button disappearing after switching tabs
-de: Stadtauswahl-Schaltfläche verschwindet nicht mehr nach dem Wechsel zwischen Tabs


### PR DESCRIPTION
### Short Description

Fixes the location change button disappearing from the header after switching tabs. Tab history no longer affects the visibility of the location button.

### Proposed Changes

- Separated tab history (`hasTabHistory`) from stack navigation in the `landingPath` check
- `landingPath` now only hides the location button when there is actual stack navigation (`previousRoute`) or a root-level overlay (`hasRootHistory`)

### Side Effects

-

### Testing

- Open the app on the Information (Categories) tab — location change button is visible
- Switch to another tab (e.g. Map/POIs), then switch back to Information — location change button is still visible and tappable
- Navigate into a category detail page — location button is not shown (back button takes its place)
- Regression test covers the tab history case

### Resolved Issues

Fixes: #3932