### PR TITLE
3914: Fix initial screen after complex tab navigation

### DIFF
--- a/native/src/navigation/BottomTabNavigation.tsx
+++ b/native/src/navigation/BottomTabNavigation.tsx
@@ -131,27 +131,48 @@ const BottomTabNavigation = ({ navigation }: BottomTabNavigationProps): ReactEle
 
   const Tabs = [
     <Tab.Screen
-      name={CATEGORIES_ROUTE}
+      name={CATEGORIES_TAB_ROUTE}
       component={CategoriesStackScreen}
       options={{ tabBarLabel: createTabLabel(theme, t('localInformationLabel')), tabBarIcon: CategoriesIcon }}
+      listeners={({ navigation }) => ({
+        // Adjusting the history so now it has the categories top for current screen, at the end for last screen and rest of the history in between.
+        tabPress: e => {
+          e.preventDefault()
+          const state = navigation.getState()
+          const categoriesRoute = state.routes.find(route => route.name === CATEGORIES_TAB_ROUTE)
+          if (!categoriesRoute) {
+            return
+          }
+          const categoriesTabEntry = { key: categoriesRoute.key, type: 'route' as const }
+          navigation.reset({
+            ...state,
+            index: state.routes.indexOf(categoriesRoute),
+            history: [
+              categoriesTabEntry,
+              ...state.history.filter(entry => entry.key !== categoriesRoute.key),
+              categoriesTabEntry,
+            ],
+          })
+        },
+      })}
     />,
     featureFlags.pois && cachedData.city.poisEnabled && (
       <Tab.Screen
-        name={POIS_ROUTE}
+        name={POIS_TAB_ROUTE}
         component={PoisStackScreen}
         options={{ tabBarLabel: createTabLabel(theme, t('locations')), tabBarIcon: createTabIcon('map-outline') }}
       />
     ),
     isNewsEnabled && (
       <Tab.Screen
-        name={NEWS_ROUTE}
+        name={NEWS_TAB_ROUTE}
         component={NewsStackScreen}
         options={{ tabBarLabel: createTabLabel(theme, t('news')), tabBarIcon: createTabIcon('newspaper') }}
       />
     ),
     cachedData.city.eventsEnabled && (
       <Tab.Screen
-        name={EVENTS_ROUTE}
+        name={EVENTS_TAB_ROUTE}
         component={EventsStackScreen}
         options={{
           tabBarLabel: createTabLabel(theme, t('events')),


### PR DESCRIPTION
### Short Description

if you navigated to the following:
info > news > events > info > events > then keep going back to last screen by the backbutton. it will get back to news as the first page (because we went to info in the middle of history).

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Added a listener for the categories/info tab to adjust history and move the `categoriesTabEntry` to last screen and current (top screen).
- Fixed the search functionality by using `*_TAB_ROUTE` names.

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- N/A

### Testing

- Test the tab navigation I mention in the description.
- Test the search (should navigate to searched pages)
- Test deeplinking `npx uri-scheme open "integreat://integreat.app/lkaugsburg/de/willkommen-lkaugsburg/willkommen" --android` keep in mind any mismatch with lang or region it will show in the webView(also test while the app is closed).
- Test iOS.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3914

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
