### PR TITLE
3930: Add language change to chat

### DIFF
--- a/web/src/components/ChatContainer.tsx
+++ b/web/src/components/ChatContainer.tsx
@@ -6,13 +6,15 @@ import { styled } from '@mui/material/styles'
 import React, { ReactElement, useContext, useEffect, useState } from 'react'
 import { useSearchParams } from 'react-router'
 
-import { getChatName, CHAT_QUERY_KEY, parseQueryParams } from 'shared'
+import { getChatName, CHAT_QUERY_KEY, parseQueryParams, toQueryParams } from 'shared'
 import { CityModel } from 'shared/api'
 
 import buildConfig from '../constants/buildConfig'
 import useDimensions from '../hooks/useDimensions'
 import useLockedBody from '../hooks/useLockedBody'
 import ChatController from './ChatController'
+import HeaderLanguageSelectorItem from './HeaderLanguageSelectorItem'
+import { LanguageChangePath } from './LanguageList'
 import { TtsContext } from './TtsContainer'
 import Dialog from './base/Dialog'
 
@@ -36,10 +38,11 @@ const StyledDialog = styled(Dialog)({
 
 type ChatContainerProps = {
   city: CityModel
-  language: string
+  languageCode: string
+  languageChangePaths: LanguageChangePath[] | null
 }
 
-const ChatContainer = ({ city, language }: ChatContainerProps): ReactElement | null => {
+const ChatContainer = ({ city, languageCode, languageChangePaths }: ChatContainerProps): ReactElement | null => {
   const [queryParams, setQueryParams] = useSearchParams()
   const initialChatVisibility = parseQueryParams(queryParams).chat ?? false
   const [chatVisible, setChatVisible] = useState(initialChatVisibility)
@@ -63,9 +66,28 @@ const ChatContainer = ({ city, language }: ChatContainerProps): ReactElement | n
   }
 
   if (chatVisible) {
+    const chatQuery = toQueryParams({ chat: true }).toString()
+    const chatLanguageChangePaths =
+      languageChangePaths?.map(({ path, ...rest }) => ({
+        ...rest,
+        path: path ? `${path}?${chatQuery}` : null,
+      })) ?? []
     return (
-      <StyledDialog title={chatName} close={() => setChatVisible(false)}>
-        <ChatController city={city} language={language} />
+      <StyledDialog
+        title={chatName}
+        close={() => setChatVisible(false)}
+        actions={
+          languageChangePaths
+            ? [
+                <HeaderLanguageSelectorItem
+                  key='languageChange'
+                  languageChangePaths={chatLanguageChangePaths}
+                  languageCode={languageCode}
+                />,
+              ]
+            : null
+        }>
+        <ChatController city={city} languageCode={languageCode} />
       </StyledDialog>
     )
   }

--- a/web/src/components/ChatContainer.tsx
+++ b/web/src/components/ChatContainer.tsx
@@ -3,7 +3,7 @@ import { dialogContentClasses } from '@mui/material/DialogContent'
 import Fab from '@mui/material/Fab'
 import Typography from '@mui/material/Typography'
 import { styled } from '@mui/material/styles'
-import React, { ReactElement, useContext, useEffect, useState } from 'react'
+import React, { ReactElement, useContext } from 'react'
 import { useSearchParams } from 'react-router'
 
 import { getChatName, CHAT_QUERY_KEY, parseQueryParams, toQueryParams } from 'shared'
@@ -44,8 +44,7 @@ type ChatContainerProps = {
 
 const ChatContainer = ({ city, languageCode, languageChangePaths }: ChatContainerProps): ReactElement | null => {
   const [queryParams, setQueryParams] = useSearchParams()
-  const initialChatVisibility = parseQueryParams(queryParams).chat ?? false
-  const [chatVisible, setChatVisible] = useState(initialChatVisibility)
+  const chatVisible = parseQueryParams(queryParams).chat ?? false
   const { desktop, xsmall, visibleFooterHeight, bottomNavigationHeight } = useDimensions()
   const { visible: ttsPlayerVisible } = useContext(TtsContext)
   const chatName = getChatName(buildConfig().appName)
@@ -53,13 +52,17 @@ const ChatContainer = ({ city, languageCode, languageChangePaths }: ChatContaine
 
   const hideChatButton = xsmall && ttsPlayerVisible
 
-  useEffect(() => {
-    if (queryParams.has(CHAT_QUERY_KEY)) {
-      const newQueryParams = queryParams
-      queryParams.delete(CHAT_QUERY_KEY)
-      setQueryParams(newQueryParams, { replace: true })
-    }
-  }, [queryParams, setQueryParams])
+  const open = () => {
+    const newQueryParams = queryParams
+    newQueryParams.set(CHAT_QUERY_KEY, 'true')
+    setQueryParams(newQueryParams)
+  }
+
+  const close = () => {
+    const newQueryParams = queryParams
+    newQueryParams.delete(CHAT_QUERY_KEY)
+    setQueryParams(newQueryParams)
+  }
 
   if (hideChatButton) {
     return null
@@ -75,7 +78,7 @@ const ChatContainer = ({ city, languageCode, languageChangePaths }: ChatContaine
     return (
       <StyledDialog
         title={chatName}
-        close={() => setChatVisible(false)}
+        close={close}
         actions={
           languageChangePaths
             ? [
@@ -94,7 +97,7 @@ const ChatContainer = ({ city, languageCode, languageChangePaths }: ChatContaine
 
   return (
     <ChatButtonContainer bottom={bottomNavigationHeight ?? visibleFooterHeight}>
-      <Fab onClick={() => setChatVisible(true)} color='primary' aria-label={chatName}>
+      <Fab onClick={open} color='primary' aria-label={chatName}>
         <QuestionAnswerOutlinedIcon fontSize='large' />
       </Fab>
       {desktop && (

--- a/web/src/components/ChatController.tsx
+++ b/web/src/components/ChatController.tsx
@@ -16,7 +16,7 @@ import Chat from './Chat'
 
 type ChatControllerProps = {
   city: CityModel
-  language: string
+  languageCode: string
 }
 
 const LOCAL_STORAGE_ITEM_CHAT_MESSAGES = 'Chat-Device-Id'
@@ -24,7 +24,7 @@ const LOCAL_STORAGE_ITEM_CHAT_PRIVACY_POLICIES = 'Chat-Privacy-Policies'
 const DEFAULT_POLLING_INTERVAL = 15000
 const TYPING_POLLING_INTERVAL = 3000
 
-const ChatController = ({ city, language }: ChatControllerProps): ReactElement => {
+const ChatController = ({ city, languageCode }: ChatControllerProps): ReactElement => {
   const cityCode = city.code
   const [sendingStatus, setSendingStatus] = useState<SendingStatusType>('idle')
   const isBrowserTabActive = useIsTabActive()
@@ -39,7 +39,7 @@ const ChatController = ({ city, language }: ChatControllerProps): ReactElement =
     error,
     loading,
     setData,
-  } = useLoadFromEndpoint(createChatMessagesEndpoint, cmsApiBaseUrl, { cityCode, language, deviceId })
+  } = useLoadFromEndpoint(createChatMessagesEndpoint, cmsApiBaseUrl, { cityCode, language: languageCode, deviceId })
   const botTyping = chatMessagesReturn?.botTyping
   const messageCount = chatMessagesReturn?.messages.length ?? 0
 
@@ -62,7 +62,7 @@ const ChatController = ({ city, language }: ChatControllerProps): ReactElement =
     setSendingStatus('sending')
     const { data, error } = await createSendChatMessageEndpoint(cmsApiBaseUrl).request({
       cityCode,
-      language,
+      language: languageCode,
       message,
       deviceId,
     })
@@ -88,7 +88,7 @@ const ChatController = ({ city, language }: ChatControllerProps): ReactElement =
       isTyping={botTyping ?? false}
       privacyPolicyAccepted={privacyPolicyAccepted}
       acceptPrivacyPolicy={acceptCustomPrivacyPolicy}
-      languageCode={language}
+      languageCode={languageCode}
     />
   )
 }

--- a/web/src/components/CityContentLayout.tsx
+++ b/web/src/components/CityContentLayout.tsx
@@ -62,7 +62,9 @@ const CityContentLayout = ({
       footer={
         <>
           {footerVisible && <Footer />}
-          {chatVisible && <ChatContainer city={city} language={languageCode} />}
+          {chatVisible && (
+            <ChatContainer city={city} languageCode={languageCode} languageChangePaths={languageChangePaths} />
+          )}
           {mobile && <BottomNavigation cityModel={city} languageCode={languageCode} />}
         </>
       }

--- a/web/src/components/HeaderActionItem.tsx
+++ b/web/src/components/HeaderActionItem.tsx
@@ -19,7 +19,7 @@ type HeaderActionItemLinkProps = {
   text: string
   icon: ReactElement
   innerText?: string
-} & ({ to: string; onClick?: never } | { to?: never; onClick: () => void })
+} & ({ to: string; onClick?: never } | { to?: never; onClick: (event: React.MouseEvent<HTMLButtonElement>) => void })
 
 const HeaderActionItem = ({ to, text, icon, onClick, innerText }: HeaderActionItemLinkProps): ReactElement => {
   if (innerText) {

--- a/web/src/components/HeaderLanguageSelectorItem.tsx
+++ b/web/src/components/HeaderLanguageSelectorItem.tsx
@@ -1,17 +1,12 @@
 import TranslateOutlinedIcon from '@mui/icons-material/TranslateOutlined'
-import { styled } from '@mui/material/styles'
-import React, { ReactElement, useRef, useState } from 'react'
+import Popover from '@mui/material/Popover'
+import React, { ReactElement, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import useDimensions from '../hooks/useDimensions'
-import useOnClickOutside from '../hooks/useOnClickOutside'
 import HeaderActionItem from './HeaderActionItem'
 import LanguageList, { LanguageChangePath } from './LanguageList'
 import Sidebar from './Sidebar'
-
-const Wrapper = styled('div')`
-  display: contents;
-`
 
 type HeaderLanguageSelectorItemProps = {
   languageChangePaths: LanguageChangePath[]
@@ -24,19 +19,21 @@ const HeaderLanguageSelectorItem = ({
   languageCode,
   forceText = false,
 }: HeaderLanguageSelectorItemProps): ReactElement => {
-  const [open, setOpen] = useState(false)
+  const [anchorElement, setAnchorElement] = useState<HTMLButtonElement | null>(null)
   const { mobile, desktop } = useDimensions()
   const { t } = useTranslation('layout')
-  const wrapperRef = useRef<HTMLDivElement | null>(null)
-  useOnClickOutside(wrapperRef, () => setOpen(false))
+
+  const open = (event: React.MouseEvent<HTMLButtonElement>) => setAnchorElement(event.currentTarget)
+  const close = () => setAnchorElement(null)
+  const isOpen = anchorElement !== null
 
   const currentLanguageName = languageChangePaths.find(item => item.code === languageCode)?.name
 
   const ChangeLanguageButton = (
     <HeaderActionItem
       key='languageChange'
-      onClick={() => setOpen(open => !open)}
-      text={open ? '' : t('changeLanguage') /* to not cover the dropdown with the tooltip */}
+      onClick={open}
+      text={isOpen ? '' : t('changeLanguage') /* to not cover the dropdown with the tooltip */}
       icon={<TranslateOutlinedIcon />}
       innerText={forceText || desktop ? currentLanguageName : undefined}
     />
@@ -44,27 +41,35 @@ const HeaderLanguageSelectorItem = ({
 
   if (mobile) {
     return (
-      <Sidebar OpenButton={ChangeLanguageButton} setOpen={setOpen} open={open}>
-        <LanguageList
-          languageChangePaths={languageChangePaths}
-          languageCode={languageCode}
-          close={() => setOpen(false)}
-        />
+      <Sidebar OpenButton={ChangeLanguageButton} setOpen={() => setAnchorElement(null)} open={isOpen}>
+        <LanguageList languageChangePaths={languageChangePaths} languageCode={languageCode} close={close} />
       </Sidebar>
     )
   }
 
   return (
-    <Wrapper ref={wrapperRef}>
+    <>
       {ChangeLanguageButton}
-      {open && (
-        <LanguageList
-          languageChangePaths={languageChangePaths}
-          languageCode={languageCode}
-          close={() => setOpen(false)}
-        />
-      )}
-    </Wrapper>
+      <Popover
+        open={isOpen}
+        onClose={close}
+        anchorEl={anchorElement}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'center',
+        }}
+        transformOrigin={{
+          vertical: -16,
+          horizontal: 'center',
+        }}
+        slotProps={{
+          paper: {
+            sx: { boxShadow: 'none', overflow: 'visible' },
+          },
+        }}>
+        <LanguageList languageChangePaths={languageChangePaths} languageCode={languageCode} close={close} />
+      </Popover>
+    </>
   )
 }
 

--- a/web/src/components/HeaderLanguageSelectorItem.tsx
+++ b/web/src/components/HeaderLanguageSelectorItem.tsx
@@ -1,5 +1,7 @@
 import TranslateOutlinedIcon from '@mui/icons-material/TranslateOutlined'
+import { drawerClasses } from '@mui/material/Drawer'
 import Popover from '@mui/material/Popover'
+import { styled } from '@mui/material/styles'
 import React, { ReactElement, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -7,6 +9,13 @@ import useDimensions from '../hooks/useDimensions'
 import HeaderActionItem from './HeaderActionItem'
 import LanguageList, { LanguageChangePath } from './LanguageList'
 import Sidebar from './Sidebar'
+
+const StyledSidebar = styled(Sidebar)({
+  [`&.${drawerClasses.root}`]: {
+    // Position sidebar above chat modal
+    zIndex: 1500,
+  },
+})
 
 type HeaderLanguageSelectorItemProps = {
   languageChangePaths: LanguageChangePath[]
@@ -41,9 +50,9 @@ const HeaderLanguageSelectorItem = ({
 
   if (mobile) {
     return (
-      <Sidebar OpenButton={ChangeLanguageButton} setOpen={() => setAnchorElement(null)} open={isOpen}>
+      <StyledSidebar OpenButton={ChangeLanguageButton} setOpen={() => setAnchorElement(null)} open={isOpen}>
         <LanguageList languageChangePaths={languageChangePaths} languageCode={languageCode} close={close} />
-      </Sidebar>
+      </StyledSidebar>
     )
   }
 

--- a/web/src/components/LanguageList.tsx
+++ b/web/src/components/LanguageList.tsx
@@ -1,6 +1,6 @@
 import Autocomplete from '@mui/material/Autocomplete'
-import Box from '@mui/material/Box'
 import List from '@mui/material/List'
+import Stack from '@mui/material/Stack'
 import TextField from '@mui/material/TextField'
 import { styled } from '@mui/material/styles'
 import React, { ReactElement, useMemo, useState } from 'react'
@@ -13,40 +13,24 @@ import useDimensions from '../hooks/useDimensions'
 import LanguageListItem from './LanguageListItem'
 import SearchInput from './SearchInput'
 
-const MobileContainer = styled('div')`
-  display: flex;
-  flex-direction: column;
-  gap: ${props => props.theme.spacing(2)};
-`
-
 const StyledAutocomplete = styled(Autocomplete)`
   ${props => props.theme.breakpoints.up('md')} {
-    width: 200px;
-    position: absolute;
-    top: 72px;
-    z-index: 10;
     background-color: ${props => props.theme.palette.background.paper};
+    width: 200px;
+    border-radius: 4px;
   }
 ` as typeof Autocomplete
 
-const StyledTextField = styled(TextField)`
-  legend {
-    letter-spacing: 0;
-  }
-` as typeof TextField
+const StyledTextField = styled(TextField)({
+  legend: {
+    letterSpacing: 0,
+  },
+})
 
 export type LanguageChangePath = {
   code: string
   path: string | null
   name: string
-}
-
-type LanguageListProps = {
-  languageChangePaths: LanguageChangePath[]
-  languageCode: string
-  close?: () => void
-  availableOnly?: boolean
-  asList?: boolean
 }
 
 export const filterLanguageChangePath = (
@@ -66,6 +50,14 @@ export const filterLanguageChangePath = (
   )
 }
 
+type LanguageListProps = {
+  languageChangePaths: LanguageChangePath[]
+  languageCode: string
+  close?: () => void
+  availableOnly?: boolean
+  asList?: boolean
+}
+
 const LanguageList = ({
   languageChangePaths,
   languageCode,
@@ -73,9 +65,9 @@ const LanguageList = ({
   availableOnly = false,
   asList = false,
 }: LanguageListProps): ReactElement => {
+  const [query, setQuery] = useState('')
   const { t } = useTranslation('layout')
   const { mobile } = useDimensions()
-  const [query, setQuery] = useState('')
 
   const allOptions = useMemo(
     () => languageChangePaths.filter(item => !availableOnly || !!item.path),
@@ -94,11 +86,11 @@ const LanguageList = ({
 
   if (mobile || asList) {
     return (
-      <MobileContainer>
+      <Stack gap={2}>
         <SearchInput placeholderText={currentLanguage?.name ?? ''} filterText={query} onFilterTextChange={setQuery} />
         <>
           {filteredLanguageChangePaths.length === 0 ? (
-            <Box sx={{ p: 2 }}>{t('noLanguageFound')}</Box>
+            t('noLanguageFound')
           ) : (
             <List disablePadding>
               {filteredLanguageChangePaths.map(language => (
@@ -114,7 +106,7 @@ const LanguageList = ({
             </List>
           )}
         </>
-      </MobileContainer>
+      </Stack>
     )
   }
 
@@ -130,7 +122,7 @@ const LanguageList = ({
       inputValue={query}
       onInputChange={(_, value) => setQuery(value)}
       forcePopupIcon={false}
-      getOptionLabel={(option: LanguageChangePath) => option.name}
+      getOptionLabel={option => option.name}
       renderOption={(_, language) => (
         <LanguageListItem
           code={language.code}
@@ -145,11 +137,17 @@ const LanguageList = ({
       disablePortal
       slotProps={{
         popper: {
-          placement: 'bottom-start',
+          placement: 'bottom',
           modifiers: [
             {
               name: 'flip',
               enabled: false,
+            },
+            {
+              name: 'offset',
+              options: {
+                offset: [0, 1],
+              },
             },
           ],
         },

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -36,9 +36,10 @@ type SidebarProps = {
   setOpen: (show: boolean) => void
   Footer?: ReactNode
   OpenButton?: ReactElement
+  className?: string
 }
 
-const Sidebar = ({ children, open, setOpen, Footer, OpenButton }: SidebarProps): ReactElement | null => {
+const Sidebar = ({ children, open, setOpen, Footer, OpenButton, className }: SidebarProps): ReactElement | null => {
   const { headerHeight } = useDimensions()
   const { t } = useTranslation('layout')
   useLockedBody(open)
@@ -57,6 +58,7 @@ const Sidebar = ({ children, open, setOpen, Footer, OpenButton }: SidebarProps):
         open={open}
         onClose={() => setOpen(false)}
         container={drawerContainer}
+        className={className}
         anchor='right'
         // Locking scroll causes the headroom to disappear when opening the drawer if scrolled down
         disableScrollLock

--- a/web/src/components/__tests__/ChatContainer.spec.tsx
+++ b/web/src/components/__tests__/ChatContainer.spec.tsx
@@ -36,20 +36,31 @@ describe('ChatContainer', () => {
   ]
 
   it('should open chat dialog and show content on chat button click', () => {
-    const { getByText, getByLabelText } = renderRoute(
+    const { getByText, queryByText, getByLabelText, router } = renderRoute(
       <ChatContainer city={city} languageCode='de' languageChangePaths={languageChangePaths} />,
       {
         pathname,
         routePattern,
+        searchParams: '?test=asdf',
       },
     )
     const chatButtonContainer = getByLabelText(getChatName('IntegreatTestCms'))
     expect(chatButtonContainer).toBeTruthy()
 
+    expect(router.state.location.search).toBe('?test=asdf')
+
     fireEvent.click(chatButtonContainer)
+
+    expect(router.state.location.search).toBe('?test=asdf&chat=true')
 
     expect(getByText('chat:conversationText')).toBeTruthy()
     expect(getByText('chat:conversationHelperText')).toBeTruthy()
+
+    fireEvent.click(getByLabelText('layout:common:close'))
+
+    expect(router.state.location.search).toBe('?test=asdf')
+
+    expect(queryByText('chat:conversationText')).toBeFalsy()
   })
 
   it('should close chat if close button was clicked', () => {
@@ -84,10 +95,10 @@ describe('ChatContainer', () => {
     )
     expect(getByText('chat:conversationText')).toBeTruthy()
     expect(getByText('chat:conversationHelperText')).toBeTruthy()
-    expect(router.state.location.search).toBe('?test=asdf')
+    expect(router.state.location.search).toBe('?chat=true&test=asdf')
   })
 
-  it('should only update query params if open chat query param is set', () => {
+  it('should correctly update query params', () => {
     const { getAllByText, router } = renderRoute(
       <ChatContainer city={city} languageCode='de' languageChangePaths={languageChangePaths} />,
       {
@@ -98,5 +109,22 @@ describe('ChatContainer', () => {
     )
     expect(getAllByText(getChatName('IntegreatTestCms'))).toHaveLength(1)
     expect(router.state.location.search).toBe('?')
+  })
+
+  it('should switch the language', () => {
+    const { getByText, getByLabelText, router } = renderRoute(
+      <ChatContainer city={city} languageCode='de' languageChangePaths={languageChangePaths} />,
+      {
+        pathname,
+        routePattern,
+      },
+    )
+    const chatButtonContainer = getByLabelText(getChatName('IntegreatTestCms'))
+    fireEvent.click(chatButtonContainer!)
+    expect(router.state.location.pathname).toBe(`/${city.code}/de`)
+    fireEvent.click(getByText('Deutsch'))
+    fireEvent.click(getByText('English'))
+    expect(router.state.location.pathname).toBe(`/${city.code}/en`)
+    expect(router.state.location.search).toBe('?chat=true')
   })
 })

--- a/web/src/components/__tests__/ChatContainer.spec.tsx
+++ b/web/src/components/__tests__/ChatContainer.spec.tsx
@@ -30,12 +30,19 @@ describe('ChatContainer', () => {
   const routePattern = '/:cityCode/:languageCode'
   const city = new CityModelBuilder(1).build()[0]!
   const pathname = `/${city.code}/de`
+  const languageChangePaths = [
+    { code: 'de', name: 'Deutsch', path: '/augsburg/de' },
+    { code: 'en', name: 'English', path: '/augsburg/en' },
+  ]
 
   it('should open chat dialog and show content on chat button click', () => {
-    const { getByText, getByLabelText } = renderRoute(<ChatContainer city={city} language='de' />, {
-      pathname,
-      routePattern,
-    })
+    const { getByText, getByLabelText } = renderRoute(
+      <ChatContainer city={city} languageCode='de' languageChangePaths={languageChangePaths} />,
+      {
+        pathname,
+        routePattern,
+      },
+    )
     const chatButtonContainer = getByLabelText(getChatName('IntegreatTestCms'))
     expect(chatButtonContainer).toBeTruthy()
 
@@ -46,10 +53,13 @@ describe('ChatContainer', () => {
   })
 
   it('should close chat if close button was clicked', () => {
-    const { getByLabelText, queryByText } = renderRoute(<ChatContainer city={city} language='de' />, {
-      pathname,
-      routePattern,
-    })
+    const { getByLabelText, queryByText } = renderRoute(
+      <ChatContainer city={city} languageCode='de' languageChangePaths={languageChangePaths} />,
+      {
+        pathname,
+        routePattern,
+      },
+    )
     const chatButtonContainer = getByLabelText(getChatName('IntegreatTestCms'))
     expect(chatButtonContainer).toBeTruthy()
 
@@ -64,22 +74,28 @@ describe('ChatContainer', () => {
   })
 
   it('should open chat if query param is set', () => {
-    const { getByText, router } = renderRoute(<ChatContainer city={city} language='de' />, {
-      pathname,
-      routePattern,
-      searchParams: '?chat=true&test=asdf',
-    })
+    const { getByText, router } = renderRoute(
+      <ChatContainer city={city} languageCode='de' languageChangePaths={languageChangePaths} />,
+      {
+        pathname,
+        routePattern,
+        searchParams: '?chat=true&test=asdf',
+      },
+    )
     expect(getByText('chat:conversationText')).toBeTruthy()
     expect(getByText('chat:conversationHelperText')).toBeTruthy()
     expect(router.state.location.search).toBe('?test=asdf')
   })
 
   it('should only update query params if open chat query param is set', () => {
-    const { getAllByText, router } = renderRoute(<ChatContainer city={city} language='de' />, {
-      pathname,
-      routePattern,
-      searchParams: '?',
-    })
+    const { getAllByText, router } = renderRoute(
+      <ChatContainer city={city} languageCode='de' languageChangePaths={languageChangePaths} />,
+      {
+        pathname,
+        routePattern,
+        searchParams: '?',
+      },
+    )
     expect(getAllByText(getChatName('IntegreatTestCms'))).toHaveLength(1)
     expect(router.state.location.search).toBe('?')
   })

--- a/web/src/components/__tests__/ChatController.spec.tsx
+++ b/web/src/components/__tests__/ChatController.spec.tsx
@@ -30,7 +30,7 @@ describe('ChatContainer', () => {
   it('should show privacy policy if not accepted yet', () => {
     const value = { testumgebung: true }
     mocked(useLocalStorage<Record<string, boolean>>).mockImplementation(() => ({ value, updateLocalStorageItem }))
-    const { getByText, queryByText } = renderWithTheme(<ChatController city={city} language='de' />)
+    const { getByText, queryByText } = renderWithTheme(<ChatController city={city} languageCode='de' />)
     expect(queryByText('conversationText')).toBeFalsy()
     expect(queryByText('conversationHelperText')).toBeFalsy()
     expect(getByText('privacyPolicyInformation')).toBeTruthy()
@@ -42,7 +42,7 @@ describe('ChatContainer', () => {
   it('should directly show chat if privacy policy already accepted', () => {
     const value = { testumgebung: true, augsburg: true }
     mocked(useLocalStorage<Record<string, boolean>>).mockImplementation(() => ({ value, updateLocalStorageItem }))
-    const { getByText, queryByText } = renderWithTheme(<ChatController city={city} language='de' />)
+    const { getByText, queryByText } = renderWithTheme(<ChatController city={city} languageCode='de' />)
     expect(queryByText('privacyPolicyInformation')).toBeFalsy()
     expect(getByText('conversationText')).toBeTruthy()
     expect(getByText('conversationHelperText')).toBeTruthy()

--- a/web/src/components/base/Dialog.tsx
+++ b/web/src/components/base/Dialog.tsx
@@ -24,19 +24,26 @@ const StyledMuiDialog = styled(MuiDialog)(({ theme }) => ({
   },
 }))
 
+const StyledDialogTitle = styled(DialogTitle)({
+  flex: '1 1 0',
+}) as typeof DialogTitle
+
 type DialogProps = {
   title: string
+  actions?: ReactElement[] | null
   close: () => void
   children: ReactElement | ReactElement[]
   className?: string
 }
 
-const Dialog = ({ title, close, children, className }: DialogProps): ReactElement => {
+const Dialog = ({ title, close, children, className, actions }: DialogProps): ReactElement => {
   const { mobile, desktop } = useDimensions()
   const { t } = useTranslation('layout')
 
   // This is necessary to ensure the theme is correctly applied to the drawer content
   const dialogContainer = document.getElementById(LAYOUT_ELEMENT_ID)
+
+  const Actions = <Stack marginInline={1}>{actions}</Stack>
 
   return (
     <StyledMuiDialog onClose={close} container={dialogContainer} fullScreen={mobile} className={className} open>
@@ -48,9 +55,11 @@ const Dialog = ({ title, close, children, className }: DialogProps): ReactElemen
         <IconButton aria-label={t('common:close')} onClick={close}>
           {desktop ? <CloseIcon /> : <DirectionDependentBackIcon />}
         </IconButton>
-        <DialogTitle component='h2' variant='h4'>
+        {desktop && Actions}
+        <StyledDialogTitle component='h2' variant='h4' textOverflow='ellipsis' whiteSpace='nowrap' overflow='hidden'>
           {title}
-        </DialogTitle>
+        </StyledDialogTitle>
+        {mobile && Actions}
       </Stack>
       <DialogContent>{children}</DialogContent>
     </StyledMuiDialog>


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
<!-- Make sure to correctly set PR labels if necessary: `Native`/`Web` for native/web only PRs and `maintenance` for non-user-facing changes. -->
Add a language change button directly inside the chat.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Add language change directly to the chat
- Use popover for the languages dropdown
-  Use query param for chat state to keep chat open after language change

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- The query param `chat=true` is now added per default to the URL and not removed on mount anymore. This allows consistent state behavior, navigating back and forth to open/close the chat as well as keeping the chat open on language change.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Check the normal language change on both mobile and desktop.
Check the chat and switch the language on both mobile and desktop.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3930

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
