### PR TITLE
3759: [Android] Fix rtl on android (workaround)

### DIFF
--- a/native/android/app/src/main/java/tuerantuer/app/integreat/MainActivity.kt
+++ b/native/android/app/src/main/java/tuerantuer/app/integreat/MainActivity.kt
@@ -17,7 +17,9 @@ class MainActivity : ReactActivity() {
   private lateinit var currentLocale: Locale
 
   override fun onCreate(savedInstanceState: Bundle?) {
-    // Workaround to fix the rtl issue caused seemingly by https://github.com/facebook/react-native/pull/53417
+    // Workaround for the layout not being RTL for RTL languages
+    // https://github.com/facebook/react-native/pull/53417
+    // https://github.com/digitalfabrik/integreat-app/issues/3759
     val locale = resources.configuration.locales[0]
     val isRTL = TextUtilsCompat.getLayoutDirectionFromLocale(locale) == View.LAYOUT_DIRECTION_RTL
 

--- a/native/android/app/src/main/java/tuerantuer/app/integreat/MainActivity.kt
+++ b/native/android/app/src/main/java/tuerantuer/app/integreat/MainActivity.kt
@@ -6,6 +6,7 @@ import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
 import com.facebook.react.defaults.DefaultReactActivityDelegate
+import com.facebook.react.modules.i18nmanager.I18nUtil
 
 import java.util.Locale
 
@@ -14,6 +15,13 @@ class MainActivity : ReactActivity() {
   private lateinit var currentLocale: Locale
 
   override fun onCreate(savedInstanceState: Bundle?) {
+    // Workaround to fix the rtl issue before this issue is resolved https://github.com/facebook/react-native/pull/54986
+    // Reads the device locale directly and sets the direction before initialization
+    val rtlLanguages = setOf("ar", "ckb", "pes", "prs", "ps", "id", "ur")
+    val isRTL = rtlLanguages.contains(Locale.getDefault().language)
+
+    I18nUtil.instance.allowRTL(this, true)
+    I18nUtil.instance.forceRTL(this, isRTL)
     // https://github.com/software-mansion/react-native-screens#android
     // https://reactnavigation.org/docs/getting-started/#installing-dependencies-into-a-bare-react-native-project
     super.onCreate(null)

--- a/native/android/app/src/main/java/tuerantuer/app/integreat/MainActivity.kt
+++ b/native/android/app/src/main/java/tuerantuer/app/integreat/MainActivity.kt
@@ -2,6 +2,8 @@ package tuerantuer.app.integreat
 
 import android.content.res.Configuration
 import android.os.Bundle
+import android.view.View
+import androidx.core.text.TextUtilsCompat
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
@@ -15,10 +17,9 @@ class MainActivity : ReactActivity() {
   private lateinit var currentLocale: Locale
 
   override fun onCreate(savedInstanceState: Bundle?) {
-    // Workaround to fix the rtl issue before this issue is resolved https://github.com/facebook/react-native/pull/54986
-    // Reads the device locale directly and sets the direction before initialization
-    val rtlLanguages = setOf("ar", "ckb", "pes", "prs", "ps", "id", "ur")
-    val isRTL = rtlLanguages.contains(Locale.getDefault().language)
+    // Workaround to fix the rtl issue caused seemingly by https://github.com/facebook/react-native/pull/53417
+    val locale = resources.configuration.locales[0]
+    val isRTL = TextUtilsCompat.getLayoutDirectionFromLocale(locale) == View.LAYOUT_DIRECTION_RTL
 
     I18nUtil.instance.allowRTL(this, true)
     I18nUtil.instance.forceRTL(this, isRTL)


### PR DESCRIPTION
### Short Description

This is just a partial workaround PR which solves for now the issue of not getting the direction based on the device language because rtl  layout direction always is `false` on Android when device locale is set to an rtl language. See the open PR which should solve it later https://github.com/facebook/react-native/pull/54986

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Add function which detects the device language direction based on the set of rtl languages used and which forces the correct direction

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- hope none

### Testing

Test with setting the device language to any rtl language on iOS and android

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3759 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
