### PR TITLE
Fix radio buttons accessibility in malte help form

### DIFF
--- a/native/src/components/form/FormRadioButtons.tsx
+++ b/native/src/components/form/FormRadioButtons.tsx
@@ -39,7 +39,11 @@ const FormRadioButtons = <T extends FieldValues>({ name, control, values }: Form
               accessibilityState={{ checked: value === key }}
               importantForAccessibility='yes'>
               <Wrapper>
-                <RadioButton.Android value={key} />
+                <RadioButton.Android
+                  value={key}
+                  accessibilityElementsHidden
+                  importantForAccessibility='no-hide-descendants'
+                />
                 <Text variant='bodySmall'>{label}</Text>
               </Wrapper>
             </TouchableRipple>

--- a/native/src/components/form/FormRadioButtons.tsx
+++ b/native/src/components/form/FormRadioButtons.tsx
@@ -1,9 +1,16 @@
 import React, { ReactElement } from 'react'
 import { Control, Controller, FieldValues, Path } from 'react-hook-form'
 import { View } from 'react-native'
-import { RadioButton } from 'react-native-paper'
+import { RadioButton, TouchableRipple } from 'react-native-paper'
+import styled from 'styled-components/native'
 
+import Text from '../base/Text'
 import FormInput from './FormInput'
+
+const Wrapper = styled.View`
+  flex-direction: row;
+  align-items: center;
+`
 
 type RadioButtonType<T extends FieldValues> = {
   key: string
@@ -25,7 +32,17 @@ const FormRadioButtons = <T extends FieldValues>({ name, control, values }: Form
       <RadioButton.Group onValueChange={onChange} value={value}>
         {values.map(({ key, label, inputName }) => (
           <View key={key}>
-            <RadioButton.Item mode='android' labelVariant='bodySmall' label={label} value={key} />
+            <TouchableRipple
+              onPress={() => onChange(key)}
+              accessibilityRole='radio'
+              accessibilityLabel={label}
+              accessibilityState={{ checked: value === key }}
+              importantForAccessibility='yes'>
+              <Wrapper>
+                <RadioButton value={key} onPress={() => onChange(key)} />
+                <Text variant='bodySmall'>{label}</Text>
+              </Wrapper>
+            </TouchableRipple>
             {inputName !== undefined && value === key && (
               <FormInput rules={{ required: true }} name={inputName} control={control} title={inputName} />
             )}

--- a/native/src/components/form/FormRadioButtons.tsx
+++ b/native/src/components/form/FormRadioButtons.tsx
@@ -39,7 +39,7 @@ const FormRadioButtons = <T extends FieldValues>({ name, control, values }: Form
               accessibilityState={{ checked: value === key }}
               importantForAccessibility='yes'>
               <Wrapper>
-                <RadioButton value={key} onPress={() => onChange(key)} />
+                <RadioButton.Android value={key} />
                 <Text variant='bodySmall'>{label}</Text>
               </Wrapper>
             </TouchableRipple>

--- a/native/src/components/form/FormRadioButtons.tsx
+++ b/native/src/components/form/FormRadioButtons.tsx
@@ -4,6 +4,7 @@ import { View } from 'react-native'
 import { RadioButton, TouchableRipple } from 'react-native-paper'
 import styled from 'styled-components/native'
 
+import { conditionalA11yProps } from '../../utils/helpers'
 import Text from '../base/Text'
 import FormInput from './FormInput'
 
@@ -39,11 +40,7 @@ const FormRadioButtons = <T extends FieldValues>({ name, control, values }: Form
               accessibilityState={{ checked: value === key }}
               importantForAccessibility='yes'>
               <Wrapper>
-                <RadioButton.Android
-                  value={key}
-                  accessibilityElementsHidden
-                  importantForAccessibility='no-hide-descendants'
-                />
+                <RadioButton.Android value={key} {...conditionalA11yProps({ hidden: true })} />
                 <Text variant='bodySmall'>{label}</Text>
               </Wrapper>
             </TouchableRipple>


### PR DESCRIPTION
### Short Description

This PR fixes accessibility of the radio buttons in malte help form. The radio buttons are not reacting to tap when the screen reader is activated, it reacts to keyboard but not to tap. See the comment from Ruby below https://github.com/digitalfabrik/integreat-app/pull/3849

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Wrap RadioButton and Text with TouchableRipple and set `accessibilityRole='radio'` and` importantForAccessibility='yes'`

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- should be none

### Testing

- Activate screen reader
- Go to malte -> Malte Rostock -> LSBTIQ* -> see the form below (test with android and iOS)

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: N/A

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
