### PR TITLE
3953: Show website for website link in contact cards

### DIFF
--- a/native/src/utils/renderHtml.ts
+++ b/native/src/utils/renderHtml.ts
@@ -225,7 +225,22 @@ const renderJS = (
         iframe.remove()
       }
     })
-  })()
+  })();
+
+  (function showWebsiteForLink() {
+    const contactCards = document.querySelectorAll('.contact-card')
+
+    contactCards.forEach(card => {
+      card.querySelectorAll('p').forEach(card => {
+        const img = card.querySelector('img')
+        const link = card.querySelector('a')
+
+        if (img && link && img.alt === 'Website: ') {
+          link.textContent = 'Website'
+        }
+      })
+    })
+  })();
 `
 
 // To use parameters or external constants in renderHTML, you need to use string interpolation, e.g.

--- a/web/src/components/RemoteContent.tsx
+++ b/web/src/components/RemoteContent.tsx
@@ -76,6 +76,12 @@ const RemoteContent = ({ html, centered = false, smallText = false }: RemoteCont
           element.style.removeProperty('filter')
         }
       }
+      if (element instanceof HTMLImageElement && element.alt === 'Website:') {
+        const link = element.closest('p')?.querySelector('a')
+        if (link) {
+          link.textContent = 'Website'
+        }
+      }
     })
 
     const anchors = currentSandBoxRef.getElementsByTagName('a')


### PR DESCRIPTION
### Short Description

This PR replaces `link` representation with text `website` which leads to the url to avoid clutterring of the contact card when the link is long

### Proposed Changes

<!-- Describe this PR in more detail. -->

- [x] - Add function to replace the link in renderHtml.tsx on native
- [x] - Add function to replace the link in on web

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- should be none

### Testing
Go to Testumgebung -> Page Preview Test -> See the contact card below

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3953 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
