### PR TITLE
fix: increase fuzzy search threshold to tolerate more typos

### DIFF
--- a/shared/hooks/useSearch.ts
+++ b/shared/hooks/useSearch.ts
@@ -53,7 +53,7 @@ const useSearch = (documents: ExtendedPageModel[], query: string): UseSearchRetu
       processTerm: normalizeString,
       searchOptions: {
         boost: { title: 2 },
-        fuzzy: true,
+        fuzzy: 0.3,
         combineWith: 'AND',
         prefix: true,
       },


### PR DESCRIPTION
### Short Description

Increases the fuzzy search threshold from `true` (default 0.2) to `0.3` so that searches with more typos still find results.

### Proposed Changes

- Changed `fuzzy: true` to `fuzzy: 0.3` in `shared/hooks/useSearch.ts` - per the [MiniSearch docs](https://lucaong.github.io/minisearch/classes/MiniSearch.MiniSearch.html#md:fuzzy-search), this sets the maximum edit distance as a fraction of term length, so a 7-letter word now tolerates up to 2 character errors instead of 1.

### Side Effects

- Search results may return more matches than before due to the increased fuzziness, potentially including less relevant results.

### Testing

- Search for "Farrad", "Farrhad", and "Farhrad" - all should return results.
- Verify that normal exact searches still work as expected.

### Resolved Issues

Fixes: #3933