### PR TITLE
3971: [iOS] Fix keyboard covering the landing page on iOS

### DIFF
--- a/native/src/components/LayoutedScrollView.tsx
+++ b/native/src/components/LayoutedScrollView.tsx
@@ -15,6 +15,7 @@ const LayoutedScrollView = ({ children, refreshControl, style }: LayoutedScrollV
       keyboardShouldPersistTaps='always'
       // Fixes VirtualizedLists nesting error
       // See https://github.com/facebook/react-native/issues/31697#issuecomment-1742437232
+      automaticallyAdjustKeyboardInsets
       nestedScrollEnabled
       refreshControl={refreshControl}
       contentContainerStyle={[


### PR DESCRIPTION
### Short Description

On iPhone devices, when scrolling to the end of the city selection list, the list jumps and the last item becomes hidden behind the on-screen keyboard. As a result, the user cannot select the last city.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Added `automaticallyAdjustKeyboardInsets` prop to `LayoutedScrollView` which is used in LoadingErrorHandler.
Note: For android it looks covered in the emulator but when I tested it on real device it behaved as expected.

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None.

### Testing

- Launch the app on iOS.
- Go to landing / change location page and scroll to the bottom.
- The "suggest integreat to your region" button should be visible and above the keyboard.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3971

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
