### PR TITLE
3911: Improve accessibility for the Header Menu

### DIFF
--- a/native/src/components/Header.tsx
+++ b/native/src/components/Header.tsx
@@ -145,6 +145,7 @@ const Header = ({
 
   const renderMenuItem = (title: string, onPress: () => void, icon?: string): ReactElement => (
     <Menu.Item
+      accessibilityLabel={t(title)}
       leadingIcon={icon ?? IconPlaceholder}
       key={title}
       title={t(title)}


### PR DESCRIPTION
### Short Description
Investigate accessibility for the Header Menu why the items says "comma" then the item name.
I tested the accessibility using "accessibility inspector" on mac but it could differ for VoiceOver(on real device).

And for more info about the issue: https://github.com/digitalfabrik/integreat-app/issues/3911#issuecomment-4171929691

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Added accessibilityLabel to force title without the comma.

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none.

### Testing

- Launch the app on an iOS simulator or device.
- run the accessibility inspector program and toggle speech and the inspection.
- Select the menuItems so hear what it says.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3911

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
