### PR TITLE
3989: Fix bottomNavigation's safe area

### DIFF
--- a/native/src/Navigator.tsx
+++ b/native/src/Navigator.tsx
@@ -1,5 +1,6 @@
 import { createStackNavigator, StackHeaderProps } from '@react-navigation/stack'
 import React, { ReactElement, useCallback, useEffect, useState } from 'react'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 import {
   BOTTOM_TAB_NAVIGATION_ROUTE,
@@ -78,6 +79,7 @@ type InitialRouteType =
 
 const Navigator = (): ReactElement | null => {
   const showSnackbar = useSnackbar()
+  const insets = useSafeAreaInsets()
   const appContext = useAppContext()
   const { settings, cityCode, changeCityCode, updateSettings } = appContext
   const [initialRoute, setInitialRoute] = useState<InitialRouteType>(null)
@@ -142,12 +144,16 @@ const Navigator = (): ReactElement | null => {
     <Stack.Navigator
       id={ROOT_NAVIGATOR_ID}
       initialRouteName={initialRoute.name}
-      screenOptions={{ headerMode: 'screen', animation: 'none' }}>
+      screenOptions={{ headerMode: 'screen', animation: 'none', cardStyle: { paddingBottom: insets.bottom } }}>
       <Stack.Group screenOptions={{ header: () => null }}>
         <Stack.Screen name={REDIRECT_ROUTE} initialParams={{ url: redirectUrl }} component={RedirectContainer} />
         <Stack.Screen name={INTRO_ROUTE} component={Intro} />
         <Stack.Screen name={SEARCH_ROUTE} component={SearchModalContainer} />
-        <Stack.Screen name={BOTTOM_TAB_NAVIGATION_ROUTE} component={BottomTabNavigation} />
+        <Stack.Screen
+          name={BOTTOM_TAB_NAVIGATION_ROUTE}
+          component={BottomTabNavigation}
+          options={{ cardStyle: { paddingBottom: 0 } }}
+        />
       </Stack.Group>
 
       <Stack.Group screenOptions={{ header: defaultHeader }}>

--- a/native/src/components/base/IconButton.tsx
+++ b/native/src/components/base/IconButton.tsx
@@ -25,6 +25,7 @@ const IconButton = ({ accessibilityLabel, icon, onPress, style, disabled }: Icon
   const theme = useTheme() as DefaultTheme
   return (
     <TouchableRipple
+      borderless
       onPress={onPress}
       style={[
         styles.TouchableRippleStyle,

--- a/native/src/navigation/BottomTabNavigation.tsx
+++ b/native/src/navigation/BottomTabNavigation.tsx
@@ -180,6 +180,7 @@ const BottomTabNavigation = ({ navigation }: BottomTabNavigationProps): ReactEle
           backgroundColor: theme.colors.surfaceVariant,
           display: bottomTabNavigationVisible ? 'flex' : 'none',
         },
+        sceneStyle: bottomTabNavigationVisible ? undefined : { paddingBottom: insets.bottom },
       }}>
       {Tabs}
     </Tab.Navigator>


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
<!-- Make sure to correctly set PR labels if necessary: `Native`/`Web` for native/web only PRs and `maintenance` for non-user-facing changes. -->

### Proposed Changes

<!-- Describe this PR in more detail. -->

- At `Navigator.tsx` added a paddingBottom for all screens other than bottomNav.
- At `BottomTabNavigation.tsx` I gave the TabNav `{ paddingBottom: insets.bottom }` only if its not visible (this is dedicated for bottomNav)
- I zeroed the `BOTTOM_TAB_NAVIGATION_ROUTE` screen's paddingBottom because we already handled it at `BottomTabNavigation.tsx`.
- unrelated fix: Fixed the touchable feedback for the icon button so now it's circular (you can test it on the tts player's play button)

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None.

### Testing

- Test on Android 35 and 36. (i didn't test it yet on iOS)
- Test Aschaffenburg and Integreat.
- Test all screens including change language, settings and the categories page.


### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3989

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
