### PR TITLE
3976: Default collapsed accordions and reorder sections

### DIFF
--- a/native/src/components/OpeningHours.tsx
+++ b/native/src/components/OpeningHours.tsx
@@ -110,7 +110,7 @@ const OpeningHours = ({
     <>
       <Accordion
         headerContent={<OpeningHoursTitle isCurrentlyOpen={isCurrentlyOpen} language={language} />}
-        initialCollapsed={!isCurrentlyOpen}>
+        initialCollapsed>
         <HoursList hours={openingHours} appointmentUrl={appointmentUrl} />
       </Accordion>
       {AppointmentLink}

--- a/native/src/components/PoiDetails.tsx
+++ b/native/src/components/PoiDetails.tsx
@@ -52,11 +52,19 @@ const PoiDetails = ({ poi, language, distance, onFocus }: PoiDetailsProps): Reac
       {!!poi.thumbnail && <CustomThumbnail src={poi.thumbnail} />}
       <PoiChips poi={poi} />
       <StyledDivider />
+      {content.length > 0 && (
+        <>
+          <Accordion headerContent={t('description')}>
+            <Page content={content} language={language} padding={false} />
+          </Accordion>
+          <StyledDivider />
+        </>
+      )}
       <AddressInfo location={poi.location} language={language} />
       <StyledDivider />
       {contacts.length > 0 && (
         <>
-          <Accordion headerContent={t('contacts')}>
+          <Accordion headerContent={t('contacts')} initialCollapsed>
             <StyledContactsContainer>
               {contacts.map((contact, index) => (
                 <Contact
@@ -80,14 +88,6 @@ const PoiDetails = ({ poi, language, distance, onFocus }: PoiDetailsProps): Reac
         isTemporarilyClosed={temporarilyClosed}
         appointmentUrl={appointmentUrl}
       />
-      {content.length > 0 && (
-        <>
-          <Accordion headerContent={t('description')}>
-            <Page content={content} language={language} padding={false} />
-          </Accordion>
-          <StyledDivider />
-        </>
-      )}
     </PoiDetailsContainer>
   )
 }

--- a/native/src/components/__tests__/OpeningHours.spec.tsx
+++ b/native/src/components/__tests__/OpeningHours.spec.tsx
@@ -1,3 +1,4 @@
+import { fireEvent } from '@testing-library/react-native'
 import React from 'react'
 
 import { OpeningHoursModel } from 'shared/api'
@@ -44,6 +45,7 @@ describe('OpeningHours', () => {
   it('should display that the location is opened', () => {
     const { getByText, queryByText, getAllByText } = renderOpeningHours(true, false, openingHours)
     expect(getByText('opened')).toBeTruthy()
+    fireEvent.press(getByText('openingHours'))
     expect(getAllByText(openingHours[0]!.timeSlots[0]!.start, { exact: false })).toHaveLength(7)
     expect(getAllByText(openingHours[0]!.timeSlots[0]!.end, { exact: false })).toHaveLength(7)
     expect(queryByText('pois:temporarilyClosed')).toBeFalsy()

--- a/native/src/components/__tests__/PoiDetails.spec.tsx
+++ b/native/src/components/__tests__/PoiDetails.spec.tsx
@@ -49,6 +49,7 @@ describe('PoiDetails', () => {
     expect(getByText('description')).toBeTruthy()
     expect(getByText(poi.content)).toBeTruthy()
 
+    fireEvent.press(getByText('contacts'))
     const contact = poi.contacts[0]!
     expect(getByText(contact.headline!)).toBeTruthy()
     expect(getByText('website')).toBeTruthy()

--- a/release-notes/unreleased/3976-Collapse-accordions-and-reorder-sections.yml
+++ b/release-notes/unreleased/3976-Collapse-accordions-and-reorder-sections.yml
@@ -4,5 +4,5 @@ platforms:
   - web
   - android
   - ios
-en: The description appears first, and contacts and opening hours are collapsed by default.
-de: Die Beschreibung steht zuerst. Kontakte und Öffnungszeiten sind standardmäßig eingeklappt.
+en: The description for places appears first, and contacts and opening hours are collapsed by default.
+de: Die Beschreibung kommt nun bei Orten zuerst. Kontakte und Öffnungszeiten sind standardmäßig eingeklappt.

--- a/release-notes/unreleased/3976-Collapse-accordions-and-reorder-sections.yml
+++ b/release-notes/unreleased/3976-Collapse-accordions-and-reorder-sections.yml
@@ -1,0 +1,8 @@
+issue_key: 3976
+show_in_stores: true
+platforms:
+  - web
+  - android
+  - ios
+en: The description appears first, and contacts and opening hours are collapsed by default.
+de: Die Beschreibung steht zuerst. Kontakte und Öffnungszeiten sind standardmäßig eingeklappt.

--- a/web/src/components/OpeningHours.tsx
+++ b/web/src/components/OpeningHours.tsx
@@ -56,10 +56,10 @@ const OpeningHours = ({
   if (isTemporarilyClosed || appointmentOnly) {
     const label = isTemporarilyClosed ? 'temporarilyClosed' : 'onlyWithAppointment'
     return (
-      <>
+      <Stack paddingBlock={1} gap={1}>
         <OpeningHoursTitle isCurrentlyOpen={isCurrentlyOpen} label={label} />
         {AppointmentLink}
-      </>
+      </Stack>
     )
   }
 
@@ -69,10 +69,7 @@ const OpeningHours = ({
 
   return (
     <>
-      <Accordion
-        id='hours'
-        title={<OpeningHoursTitle isCurrentlyOpen={isCurrentlyOpen} />}
-        defaultCollapsed={!isCurrentlyOpen}>
+      <Accordion id='hours' title={<OpeningHoursTitle isCurrentlyOpen={isCurrentlyOpen} />} defaultCollapsed>
         <HoursList hours={openingHours} appointmentUrl={appointmentUrl} />
       </Accordion>
       {AppointmentLink}

--- a/web/src/components/PoiDetails.tsx
+++ b/web/src/components/PoiDetails.tsx
@@ -61,7 +61,7 @@ const PoiDetails = ({ poi, distance }: PoiDetailsProps): ReactElement => {
   const contactsSection = contacts.length > 0 && (
     <>
       <Divider />
-      <Accordion id='contacts' title={t('contacts')}>
+      <Accordion id='contacts' title={t('contacts')} defaultCollapsed>
         <StyledContactsList
           items={contacts.map(contact => (
             <Contact key={contact.headline} contact={contact} />
@@ -97,17 +97,17 @@ const PoiDetails = ({ poi, distance }: PoiDetailsProps): ReactElement => {
         {!!poi.thumbnail && <CustomThumbnail src={poi.thumbnail} />}
       </Stack>
       <Divider />
-      {addressSection}
-      {contactsSection}
-      {openingHoursSection}
       {content.length > 0 && (
         <>
-          <Divider />
           <Accordion id='content' title={t('detailsInformation')}>
             <RemoteContent html={content} smallText />
           </Accordion>
+          <Divider />
         </>
       )}
+      {addressSection}
+      {contactsSection}
+      {openingHoursSection}
     </Stack>
   )
 }

--- a/web/src/components/RemoteContentSandBox.ts
+++ b/web/src/components/RemoteContentSandBox.ts
@@ -4,7 +4,7 @@ import { ExternalLinkIcon, PersonIcon, PersonLightIcon } from '../assets'
 
 const RemoteContentSandBox = styled('div')<{ centered: boolean; smallText: boolean }>`
   font-family: ${props => props.theme.typography.fontFamily};
-  font-size: ${props => props.theme.typography.body1.fontSize}px;
+  font-size: ${props => props.theme.typography[props.smallText ? 'body2' : 'body1'].fontSize}px;
   line-height: ${props => props.theme.typography.body1.lineHeight};
   display: flow-root; /* clearfix for the img floats */
 


### PR DESCRIPTION
### Short Description

The current content order on pois details makes orientation difficult, as important information is not immediately visible.

### Proposed Changes

- Moved the description to the top of the Poi details.
- Set the `defaultCollapsed` to true for contacts and opening hours.
- Added `paddingBlock={1} gap={1}` for OpeningHoursTitle because it was missing.
- There was unused smallText prop for `RemoteContent` I used it to switch between `body 2` and `body 1` font-sizes (the info is too big so I used SmallText for it).
- For native I moved the description to the top too.
<!-- Describe this PR in more detail. -->



### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None.

### Testing

- Go to the map at testumgebung and check any poi with an info/description.
- Expect the contacts and opening-hours to be collapsed.
- Test Native.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3976

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
