### PR TITLE
4002: Fix app not starting if other whitelabel is active

### DIFF
--- a/native/src/components/StaticServerProvider.tsx
+++ b/native/src/components/StaticServerProvider.tsx
@@ -8,13 +8,8 @@ type StaticServerProps = {
   children: ReactNode
 }
 
-const SERVER_PATH = RESOURCE_CACHE_DIR_PATH
-const SERVER_PORT = 8080
-
 const staticServer = new StaticServer({
-  fileDir: SERVER_PATH,
-  port: SERVER_PORT,
-  nonLocal: false,
+  fileDir: RESOURCE_CACHE_DIR_PATH,
 })
 
 export const StaticServerContext = createContext('')


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
<!-- Make sure to correctly set PR labels if necessary: `Native`/`Web` for native/web only PRs and `maintenance` for non-user-facing changes. -->
This PR fixes the problem that the app doesn't start and just shows a white screen if another whitelabel/dev version is already active.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Remove hard coded static server port
- Remove deprecated `nonLocal` property

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
See #4002.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4002

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
