### PR TITLE
3827: [Android] Only strip uhr from strings were it is actually added

### DIFF
--- a/native/src/utils/__tests__/tts.spec.ts
+++ b/native/src/utils/__tests__/tts.spec.ts
@@ -5,11 +5,10 @@ import { prepareText } from '../tts'
 describe('tts', () => {
   it('should correctly strip Uhr from tts sentences on android', () => {
     Platform.OS = 'android'
-    expect(prepareText('Dies ist mein Text, geschrieben um 12Uhr und später')).toEqual(
-      'Dies ist mein Text, geschrieben um 12 und später',
-    )
     expect(prepareText('12:30 Uhr')).toEqual('12:30')
-    expect(prepareText('3 Uhr')).toEqual('3')
+    expect(prepareText('8:22Uhr')).toEqual('8:22')
+    expect(prepareText('18:42 Uhr')).toEqual('18:42')
+    expect(prepareText('0:00Uhr')).toEqual('0:00')
   })
 
   it('should not strip Uhr from other sentences', () => {
@@ -17,6 +16,10 @@ describe('tts', () => {
     expect(prepareText('Die 12 Uhrzeiten')).toEqual('Die 12 Uhrzeiten')
     expect(prepareText('Die Uhr ist rund')).toEqual('Die Uhr ist rund')
     expect(prepareText('Es ist 12, das ist auf der Uhr oben.')).toEqual('Es ist 12, das ist auf der Uhr oben.')
+    expect(prepareText('3 Uhr')).toEqual('3 Uhr')
+    expect(prepareText('Dies ist mein Text, geschrieben um 12 Uhr und später')).toEqual(
+      'Dies ist mein Text, geschrieben um 12 Uhr und später',
+    )
   })
 
   it('should not strip Uhr from tts sentences on ios', () => {

--- a/native/src/utils/tts.ts
+++ b/native/src/utils/tts.ts
@@ -1,5 +1,7 @@
 import { Platform } from 'react-native'
 
-// Strips 'Uhr' from strings like '12 Uhr' or '11:30Uhr' since it is automatically added by tts on android
+// Strips 'Uhr' from strings like '8:22 Uhr' and '11:30Uhr' since it is automatically added by tts on android
 export const prepareText = (text: string): string =>
-  Platform.OS === 'android' ? text.replace(/(\d+)\s?Uhr(\W|$)/g, (_, time, suffix) => `${time}${suffix}`) : text
+  Platform.OS === 'android'
+    ? text.replace(/(\d{1,2}:\d{2})\s?Uhr(\W|$)/g, (_, time, suffix) => `${time}${suffix}`)
+    : text


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
<!-- Make sure to correctly set PR labels if necessary: `Native`/`Web` for native/web only PRs and `maintenance` for non-user-facing changes. -->
Follow up for #3924 since it led to cases where no `Uhr` is read at all. This PR only strips `Uhr` from cases where Android adds it automatically (see https://github.com/digitalfabrik/integreat-app/pull/3924#issuecomment-4205694789).

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Only strip `Uhr` if it uses `hh:mm` format
- Don't strip if there are no minutes or a dot instead of an colon

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
https://webnext.integreat.app/testumgebung/de/test-tts-uhr

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3827 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
