### PR TITLE
3911: Improve accessibility for bottom navigation

### DIFF
--- a/native/src/navigation/BottomTabNavigation.tsx
+++ b/native/src/navigation/BottomTabNavigation.tsx
@@ -135,20 +135,32 @@ const BottomTabNavigation = ({ navigation }: BottomTabNavigationProps): ReactEle
     <Tab.Screen
       name={CATEGORIES_TAB_ROUTE}
       component={CategoriesStackScreen}
-      options={{ tabBarLabel: createTabLabel(theme, t('localInformationLabel')), tabBarIcon: CategoriesIcon }}
+      options={{
+        tabBarLabel: createTabLabel(theme, t('localInformationLabel')),
+        tabBarIcon: CategoriesIcon,
+        tabBarAccessibilityLabel: t('localInformationLabel'),
+      }}
     />,
     poisEnabled && (
       <Tab.Screen
         name={POIS_TAB_ROUTE}
         component={PoisStackScreen}
-        options={{ tabBarLabel: createTabLabel(theme, t('locations')), tabBarIcon: createTabIcon('map-outline') }}
+        options={{
+          tabBarLabel: createTabLabel(theme, t('locations')),
+          tabBarIcon: createTabIcon('map-outline'),
+          tabBarAccessibilityLabel: t('locations'),
+        }}
       />
     ),
     (localNewsEnabled || tunewsEnabled) && (
       <Tab.Screen
         name={NEWS_TAB_ROUTE}
         component={NewsStackScreen}
-        options={{ tabBarLabel: createTabLabel(theme, t('news')), tabBarIcon: createTabIcon('newspaper') }}
+        options={{
+          tabBarLabel: createTabLabel(theme, t('news')),
+          tabBarIcon: createTabIcon('newspaper'),
+          tabBarAccessibilityLabel: t('news'),
+        }}
       />
     ),
     eventsEnabled && (
@@ -158,6 +170,7 @@ const BottomTabNavigation = ({ navigation }: BottomTabNavigationProps): ReactEle
         options={{
           tabBarLabel: createTabLabel(theme, t('events')),
           tabBarIcon: createTabIcon('calendar-blank-outline'),
+          tabBarAccessibilityLabel: t('events'),
         }}
       />
     ),


### PR DESCRIPTION
### Short Description

⚠️  This is a continuation on #3911.
voiceOver/inspector is pronouncing the bottom nav items with "comma" before its name.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Added `tabBarAccessibilityLabel` to force title without the comma.

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None.

### Testing

- Launch the app on an iOS simulator or device.
- run the accessibility inspector program and toggle speech and the inspection.
- Select the bottom-nav items and hear what it says.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3911

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
