### PR TITLE
3808: Add border to back button at PoisMobile

### DIFF
--- a/web/src/components/PoisMobile.tsx
+++ b/web/src/components/PoisMobile.tsx
@@ -20,7 +20,7 @@ import { DirectionDependentBackIcon } from './base/Dialog'
 
 const StyledIconButton = styled(IconButton)(({ theme }) => ({
   backgroundColor: theme.palette.background.accent,
-
+  border: `1px solid ${theme.palette.mode === 'light' ? theme.palette.grey[400] : theme.palette.grey[700]}`,
   ':hover': {
     backgroundColor: theme.palette.background.default,
   },


### PR DESCRIPTION
### Short Description

When the user selects a poi on the map page the back button is clearly visible, since it has no border.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Added a border and used Mui defined color `gray[400]` and `gray[700]` to match the Mui chips light and contrast colors.

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none.

### Testing

- Go to Map/poi and select any location.
- Check the border around the back button.
- Test the contrast mode.  

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3808

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
