### PR TITLE
4018: Fix maplibre crash on Android 12

### DIFF
--- a/.yarn/patches/@maplibre-maplibre-react-native-npm-10.4.2-a5da575b03.patch
+++ b/.yarn/patches/@maplibre-maplibre-react-native-npm-10.4.2-a5da575b03.patch
@@ -1,0 +1,26 @@
+diff --git a/android/src/main/java/org/maplibre/reactnative/events/EventEmitter.java b/android/src/main/java/org/maplibre/reactnative/events/EventEmitter.java
+index 379b72f6af5b685108b6bff76e506fe9613e5647..ea195f45268d26850078498e1ef95f4bb4916234 100644
+--- a/android/src/main/java/org/maplibre/reactnative/events/EventEmitter.java
++++ b/android/src/main/java/org/maplibre/reactnative/events/EventEmitter.java
+@@ -16,13 +16,14 @@ public class EventEmitter {
+ 
+     private static ReactContext getCurrentReactContext(ReactApplicationContext reactApplicationContext) {
+         if (reactApplicationContext.getApplicationContext() instanceof ReactApplication) {
+-            ReactApplication reactApplication = ((ReactApplication) reactApplicationContext
+-                    .getApplicationContext());
+-
+-            return reactApplication
+-                    .getReactNativeHost()
+-                    .getReactInstanceManager()
+-                    .getCurrentReactContext();
++//            ReactApplication reactApplication = ((ReactApplication) reactApplicationContext
++//                    .getApplicationContext());
++//
++//            return reactApplication
++//                    .getReactNativeHost()
++//                    .getReactInstanceManager()
++//                    .getCurrentReactContext();
++            return reactApplicationContext;
+         } else {
+             Log.d(LOG_TAG, "getApplicationContext() application doesn't implement ReactApplication");
+             return reactApplicationContext;

--- a/native/package.json
+++ b/native/package.json
@@ -47,7 +47,7 @@
     "@formatjs/intl-displaynames": "^6.8.13",
     "@formatjs/intl-locale": "^4.2.13",
     "@gorhom/bottom-sheet": "^5.2.8",
-    "@maplibre/maplibre-react-native": "^10.4.2",
+    "@maplibre/maplibre-react-native": "patch:@maplibre/maplibre-react-native@npm%3A10.4.2#~/.yarn/patches/@maplibre-maplibre-react-native-npm-10.4.2-a5da575b03.patch",
     "@mhpdev/react-native-speech": "^1.4.0",
     "@notifee/react-native": "^9.1.8",
     "@react-native-async-storage/async-storage": "^2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4445,7 +4445,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@maplibre/maplibre-react-native@npm:^10.4.2":
+"@maplibre/maplibre-react-native@npm:10.4.2":
   version: 10.4.2
   resolution: "@maplibre/maplibre-react-native@npm:10.4.2"
   dependencies:
@@ -4468,6 +4468,32 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/ac24884a218aaa5a6b08351913a313b373e1365e4ab50d0320ac7d2ce4b34c33617e1b98fa66011b3b5435358f74c64079c792b400e054ff26a196c0a91361c9
+  languageName: node
+  linkType: hard
+
+"@maplibre/maplibre-react-native@patch:@maplibre/maplibre-react-native@npm%3A10.4.2#~/.yarn/patches/@maplibre-maplibre-react-native-npm-10.4.2-a5da575b03.patch":
+  version: 10.4.2
+  resolution: "@maplibre/maplibre-react-native@patch:@maplibre/maplibre-react-native@npm%3A10.4.2#~/.yarn/patches/@maplibre-maplibre-react-native-npm-10.4.2-a5da575b03.patch::version=10.4.2&hash=2c991c"
+  dependencies:
+    "@turf/distance": "npm:^7.1.0"
+    "@turf/helpers": "npm:^7.1.0"
+    "@turf/length": "npm:^7.1.0"
+    "@turf/nearest-point-on-line": "npm:^7.1.0"
+    debounce: "npm:^2.2.0"
+  peerDependencies:
+    "@expo/config-plugins": ">=7"
+    "@types/geojson": ^7946.0.0
+    "@types/react": ">=16.6.1"
+    react: ">=16.6.1"
+    react-native: ">=0.59.9"
+  peerDependenciesMeta:
+    "@expo/config-plugins":
+      optional: true
+    "@types/geojson":
+      optional: true
+    "@types/react":
+      optional: true
+  checksum: 10c0/caa28c622de51ddbe0e770149dc2e4a5aaf483cf9185abd3c41c99d7ceb534271b1ac03ee4721f8ae17ece88b81db257b67a36e24e8fe80184935945e5bb3703
   languageName: node
   linkType: hard
 
@@ -17526,7 +17552,7 @@ __metadata:
     "@formatjs/intl-displaynames": "npm:^6.8.13"
     "@formatjs/intl-locale": "npm:^4.2.13"
     "@gorhom/bottom-sheet": "npm:^5.2.8"
-    "@maplibre/maplibre-react-native": "npm:^10.4.2"
+    "@maplibre/maplibre-react-native": "patch:@maplibre/maplibre-react-native@npm%3A10.4.2#~/.yarn/patches/@maplibre-maplibre-react-native-npm-10.4.2-a5da575b03.patch"
     "@mhpdev/react-native-speech": "npm:^1.4.0"
     "@notifee/react-native": "npm:^9.1.8"
     "@react-native-async-storage/async-storage": "npm:^2.2.0"


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
<!-- Make sure to correctly set PR labels if necessary: `Native`/`Web` for native/web only PRs and `maintenance` for non-user-facing changes. -->
Fix maplibre crash on Android 12 by reapplying the patch I accidentally removed in #3967.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Reapply patch for maplibre-react-native

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
See issue.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4018

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
