### PR TITLE
4035: Fix multiple push notifications

### DIFF
--- a/native/jest.setup.ts
+++ b/native/jest.setup.ts
@@ -16,6 +16,15 @@ jest.mock('@dr.pogodin/react-native-static-server', () =>
     stop: jest.fn(() => Promise.resolve(true)),
   })),
 )
+jest.mock('@react-native-firebase/messaging', () => ({
+  getMessaging: () => 'messaging',
+  setBackgroundMessageHandler: jest.fn(),
+  subscribeToTopic: jest.fn(),
+  unsubscribeFromTopic: jest.fn(),
+  onMessage: jest.fn(),
+  getInitialNotification: jest.fn(),
+  onNotificationOpenedApp: jest.fn(),
+}))
 
 jest.mock('shared/api', () => ({
   ...jest.requireActual('shared/api'),

--- a/native/src/utils/PushNotificationsManager.ts
+++ b/native/src/utils/PushNotificationsManager.ts
@@ -1,5 +1,14 @@
 import notifee, { AndroidImportance, Event, EventType } from '@notifee/react-native'
-import { FirebaseMessagingTypes } from '@react-native-firebase/messaging'
+import {
+  FirebaseMessagingTypes,
+  getInitialNotification,
+  getMessaging,
+  onMessage,
+  onNotificationOpenedApp,
+  setBackgroundMessageHandler,
+  subscribeToTopic,
+  unsubscribeFromTopic,
+} from '@react-native-firebase/messaging'
 import { useEffect } from 'react'
 import { checkNotifications, requestNotifications, RESULTS } from 'react-native-permissions'
 
@@ -41,7 +50,6 @@ export const unsubscribeNews = async (city: string, language: string): Promise<v
   const topic = newsTopic(city, language)
 
   try {
-    const { getMessaging, unsubscribeFromTopic } = await import('@react-native-firebase/messaging')
     await unsubscribeFromTopic(getMessaging(), topic)
     log(`Unsubscribed from ${topic} topic!`)
   } catch (e) {
@@ -70,7 +78,6 @@ export const subscribeNews = async ({
 
     const topic = newsTopic(cityCode, languageCode)
 
-    const { getMessaging, subscribeToTopic } = await import('@react-native-firebase/messaging')
     await subscribeToTopic(getMessaging(), topic)
     log(`Subscribed to ${topic} topic!`)
   } catch (e) {
@@ -98,8 +105,7 @@ const displayNotification = async (message: Message): Promise<void> => {
   })
 }
 
-const pushNotificationListener = async () => {
-  const { getMessaging, onMessage, setBackgroundMessageHandler } = await import('@react-native-firebase/messaging')
+const pushNotificationListener = (): void => {
   // Foreground notifications
   onMessage(getMessaging(), message => displayNotification(message as Message))
   // It is not necessary to set a background message handler as the notification is automatically displayed by the OS
@@ -132,8 +138,6 @@ const notifeeEventHandler = (
 const pushNotificationPressListener = async (
   navigate: (routeInformation: RouteInformationType) => void,
 ): Promise<() => void> => {
-  const { getMessaging, onNotificationOpenedApp, getInitialNotification } =
-    await import('@react-native-firebase/messaging')
   // FCM quit state notifications
   const initialMessage = await getInitialNotification(getMessaging())
   if (initialMessage) {
@@ -175,7 +179,7 @@ export const usePushNotificationListener = (navigate: (routeInformation: RouteIn
   }, [appContext])
 
   useEffect(() => {
-    pushNotificationListener().catch(reportError)
+    pushNotificationListener()
   }, [])
 
   useEffect(() => {

--- a/native/src/utils/PushNotificationsManager.ts
+++ b/native/src/utils/PushNotificationsManager.ts
@@ -105,14 +105,6 @@ const displayNotification = async (message: Message): Promise<void> => {
   })
 }
 
-const pushNotificationListener = (): void => {
-  // Foreground notifications
-  onMessage(getMessaging(), message => displayNotification(message as Message))
-  // It is not necessary to set a background message handler as the notification is automatically displayed by the OS
-  // Set one anyway to avoid the warning that no background message handler is set
-  setBackgroundMessageHandler(getMessaging(), async () => undefined)
-}
-
 const routeInformationFromMessage = (message: Message): NonNullableRouteInformationType => ({
   cityCode: message.data.city_code,
   languageCode: message.data.language_code,
@@ -179,7 +171,12 @@ export const usePushNotificationListener = (navigate: (routeInformation: RouteIn
   }, [appContext])
 
   useEffect(() => {
-    pushNotificationListener()
+    // It is not necessary to set a background message handler as the notification is automatically displayed by the OS
+    // Set one anyway to avoid the warning that no background message handler is set
+    setBackgroundMessageHandler(getMessaging(), async () => undefined)
+
+    // Foreground notifications
+    return onMessage(getMessaging(), message => displayNotification(message as Message))
   }, [])
 
   useEffect(() => {

--- a/native/src/utils/__tests__/PushNotificationsManager.spec.tsx
+++ b/native/src/utils/__tests__/PushNotificationsManager.spec.tsx
@@ -16,15 +16,6 @@ import render from '../../testing/render'
 import * as PushNotificationsManager from '../PushNotificationsManager'
 import { usePushNotificationListener } from '../PushNotificationsManager'
 
-jest.mock('@react-native-firebase/messaging', () => ({
-  getMessaging: () => 'messaging',
-  subscribeToTopic: jest.fn(),
-  unsubscribeFromTopic: jest.fn(),
-  onMessage: jest.fn(),
-  getInitialNotification: jest.fn(),
-  onNotificationOpenedApp: jest.fn(),
-}))
-
 jest.mock('@notifee/react-native', () => ({
   AndroidImportance: { HIGH: 4 },
   getInitialNotification: jest.fn(),

--- a/native/src/utils/__tests__/PushNotificationsManager.spec.tsx
+++ b/native/src/utils/__tests__/PushNotificationsManager.spec.tsx
@@ -124,7 +124,10 @@ describe('PushNotificationsManager', () => {
     }
 
     it('should display a notification if the app is in the foreground', async () => {
-      mocked(onMessage).mockImplementation((_, listener) => listener(message))
+      mocked(onMessage).mockImplementation((_, listener) => {
+        listener(message)
+        return jest.fn()
+      })
       renderMockComponent()
       await waitFor(() =>
         expect(notifee.displayNotification).toHaveBeenCalledWith({
@@ -171,6 +174,18 @@ describe('PushNotificationsManager', () => {
         newsType: 'local',
         route: 'news',
       })
+    })
+
+    it('should unsubscribe from onMessage when unmounted to prevent duplicate notifications on remount', async () => {
+      const mockUnsubscribe = jest.fn()
+      mocked(onMessage).mockReturnValue(mockUnsubscribe)
+
+      const { unmount } = renderMockComponent()
+      await waitFor(() => expect(onMessage).toHaveBeenCalledTimes(1))
+
+      unmount()
+
+      expect(mockUnsubscribe).toHaveBeenCalledTimes(1)
     })
   })
 })


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
<!-- Make sure to correctly set PR labels if necessary: `Native`/`Web` for native/web only PRs and `maintenance` for non-user-facing changes. -->
Fix receiving multiple push notifications in the app foreground by properly cleaning up by unsubscribing the `onMessage` handler.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Properly call the unsubscribe of `onMessage` on remount
- Use normal synchronous imports of firebase messaging

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
See issue.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4035

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
