### PR TITLE
3995: Fix ToggleButtons text overflow

### DIFF
--- a/web/src/components/base/ToggleButton.tsx
+++ b/web/src/components/base/ToggleButton.tsx
@@ -6,13 +6,13 @@ import React, { ElementType, ReactElement } from 'react'
 
 import Svg from './Svg'
 
-export const toggleButtonWidth = 100
+export const toggleButtonWidth = 120
 
 const StyledButton = styled(MuiToggleButton)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   width: toggleButtonWidth,
-  height: 100,
+  minHeight: 120,
   textAlign: 'center',
   gap: 8,
   wordBreak: 'break-word',


### PR DESCRIPTION
### Short Description

The Poi filter at Obdach (web app) some buttons has an overflow and some doesn't have the name padding as others.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Adjusted width and height to 120.
- Changed `height` to `minHeight` just keep it flexible in case of an item that has a longer text.

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

- Launch obdach web-app (Augsburg).
- Go to map/poi.
- Open filters.
- Test also integreat.
- Test mobile screens.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3995

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
