### PR TITLE
4058: [iOS] Fix chat input label being shown incorrectly

### DIFF
--- a/web/src/components/ThemeContainer.tsx
+++ b/web/src/components/ThemeContainer.tsx
@@ -127,6 +127,20 @@ const createTheme = (
             },
           },
         },
+        // Multiline TextField labels are not displayed correctly on iOS devices
+        // https://github.com/digitalfabrik/integreat-app/issues/4058
+        // https://github.com/mui/material-ui/issues/46945#issuecomment-3299699965
+        MuiOutlinedInput: {
+          styleOverrides: {
+            notchedOutline: {
+              '@supports (-webkit-appearance: none)': {
+                '& legend': {
+                  visibility: 'visible !important',
+                },
+              },
+            },
+          },
+        },
       },
     }),
     { disableAlign: true },


### PR DESCRIPTION
### Short Description

This PR fixes label being shown incorrectly on a textfield when the input is an outlined variant. There is a quick fix for that https://github.com/mui/material-ui/issues/46945#issuecomment-3299699965

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Override mui theme style with a provided suggestion https://github.com/mui/material-ui/issues/46945#issuecomment-3299699965

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

Check all input fields: Feedback, Search results not found feedback, FragIntegreat chat

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4058 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
