### PR TITLE
3478: Improve accessibility by Zoom-in Zoom-out buttons

### DIFF
--- a/native/src/components/BottomSheetHandle.tsx
+++ b/native/src/components/BottomSheetHandle.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react'
 import styled from 'styled-components/native'
 
-const Handle = styled.View`
+const Handle = styled.TouchableOpacity`
   width: 34px;
   border: 1px solid ${props => props.theme.colors.onSurfaceVariant};
   background-color: ${props => props.theme.colors.onSurfaceVariant};
@@ -10,6 +10,12 @@ const Handle = styled.View`
   margin: 20px 0;
 `
 
-const BottomSheetHandle = (): ReactElement => <Handle />
+type BottomSheetHandleProps = {
+  nextFocusForward?: number
+}
+
+const BottomSheetHandle = ({ nextFocusForward }: BottomSheetHandleProps): ReactElement => (
+  <Handle focusable nextFocusForward={nextFocusForward} />
+)
 
 export default BottomSheetHandle

--- a/native/src/components/BottomSheetHandle.tsx
+++ b/native/src/components/BottomSheetHandle.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react'
 import styled from 'styled-components/native'
 
-const Handle = styled.TouchableOpacity`
+const Handle = styled.Pressable`
   width: 34px;
   border: 1px solid ${props => props.theme.colors.onSurfaceVariant};
   background-color: ${props => props.theme.colors.onSurfaceVariant};
@@ -15,6 +15,7 @@ type BottomSheetHandleProps = {
 }
 
 const BottomSheetHandle = ({ nextFocusForward }: BottomSheetHandleProps): ReactElement => (
+  // @ts-expect-error Pressable doesn't have a type for nextFocusForward but it is a valid prop
   <Handle focusable nextFocusForward={nextFocusForward} />
 )
 

--- a/native/src/components/MapView.tsx
+++ b/native/src/components/MapView.tsx
@@ -14,9 +14,9 @@ import {
   useCurrentPosition,
 } from '@maplibre/maplibre-react-native'
 import type { BBox, Feature, GeoJsonProperties, Geometry, Position } from 'geojson'
-import React, { ReactElement, useCallback, useEffect, useRef, useState } from 'react'
+import React, { ReactElement, type Ref, useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import type { NativeSyntheticEvent } from 'react-native'
+import type { NativeSyntheticEvent, View } from 'react-native'
 import styled, { useTheme } from 'styled-components/native'
 
 import {
@@ -39,6 +39,7 @@ import { clusterCountLayer, clusterLayer, markerLayer } from '../constants/layer
 import useUserLocation from '../hooks/useUserLocation'
 import { conditionalA11yProps } from '../utils/helpers'
 import { reportError } from '../utils/sentry'
+import MapZoomControls from './MapZoomControls'
 import MapAttribution from './MapsAttribution'
 import Icon from './base/Icon'
 import IconButton from './base/IconButton'
@@ -91,6 +92,7 @@ type MapViewProps = {
   bottomSheetFullscreen: boolean
   zoom: number | undefined
   Overlay?: ReactElement
+  zoomInRef?: Ref<View>
 }
 
 const MapView = ({
@@ -104,6 +106,7 @@ const MapView = ({
   bottomSheetHeight,
   bottomSheetFullscreen,
   zoom,
+  zoomInRef,
 }: MapViewProps): ReactElement => {
   const toLngLat = (position: Position): LngLat => {
     const [longitude, latitude] = position
@@ -213,6 +216,20 @@ const MapView = ({
     zoomOnClusterPress(pressedCoordinates)
   }
 
+  const zoomBy = useCallback(async (delta: number) => {
+    if (mapRef.current === null) {
+      return
+    }
+
+    const currentZoom = await mapRef.current.getZoom()
+
+    setCameraSettings({
+      zoom: currentZoom + delta,
+      duration: animationDuration,
+      easing: 'ease',
+    })
+  }, [])
+
   const locationPermissionGrantedIcon = followUserLocation ? 'crosshairs-gps' : 'crosshairs'
   const locationPermissionIcon = userLocation ? locationPermissionGrantedIcon : 'crosshairs-off'
 
@@ -259,6 +276,12 @@ const MapView = ({
         onPress={onRequestLocation}
         position={bottomSheetHeight}
         accessibilityLabel={t('showOwnLocation')}
+      />
+      <MapZoomControls
+        onZoomIn={() => zoomBy(1)}
+        onZoomOut={() => zoomBy(-1)}
+        bottomSheetHeight={bottomSheetHeight}
+        zoomInRef={zoomInRef}
       />
     </OuterWrapper>
   )

--- a/native/src/components/MapView.tsx
+++ b/native/src/components/MapView.tsx
@@ -91,7 +91,7 @@ type MapViewProps = {
   bottomSheetFullscreen: boolean
   zoom: number | undefined
   Overlay?: ReactElement
-  zoomInRef?: Ref<View>
+  zoomRef?: Ref<View>
 }
 
 const MapView = ({
@@ -106,7 +106,7 @@ const MapView = ({
   bottomSheetMidHeight,
   bottomSheetFullscreen,
   zoom,
-  zoomInRef,
+  zoomRef,
 }: MapViewProps): ReactElement => {
   const mapRef = useRef<MapRef>(null)
   const cameraRef = useRef<CameraRef>(null)
@@ -183,20 +183,6 @@ const MapView = ({
     }
   }
 
-  const zoomBy = useCallback(async (delta: number) => {
-    if (mapRef.current === null) {
-      return
-    }
-
-    const currentZoom = await mapRef.current.getZoom()
-
-    setCameraSettings({
-      zoom: currentZoom + delta,
-      duration: animationDuration,
-      easing: 'ease',
-    })
-  }, [])
-
   const locationPermissionGrantedIcon = trackUserLocation ? 'crosshairs-gps' : 'crosshairs'
   const locationPermissionIcon = userLocation ? locationPermissionGrantedIcon : 'crosshairs-off'
 
@@ -244,12 +230,7 @@ const MapView = ({
         position={bottomSheetHeight}
         accessibilityLabel={t('showOwnLocation')}
       />
-      <MapZoomControls
-        onZoomIn={() => zoomBy(1)}
-        onZoomOut={() => zoomBy(-1)}
-        bottomSheetHeight={bottomSheetHeight}
-        zoomInRef={zoomInRef}
-      />
+      <MapZoomControls mapRef={mapRef} cameraRef={cameraRef} bottomSheetHeight={bottomSheetHeight} ref={zoomRef} />
     </OuterWrapper>
   )
 }

--- a/native/src/components/MapView.tsx
+++ b/native/src/components/MapView.tsx
@@ -57,17 +57,20 @@ const StyledMap = styled(MapLibreMapView)`
   width: 100%;
 `
 
-const StyledIcon = styled(IconButton)<{
-  position: number | string
-}>`
+const ControlsContainer = styled.View<{ bottomSheetHeight: number }>`
   position: absolute;
   right: 0;
-  bottom: ${props => props.position}${props => (typeof props.position === 'number' ? 'px' : '')};
+  bottom: ${props => props.bottomSheetHeight}px;
+  gap: 8px;
+  padding: 16px;
+  align-items: center;
+`
+
+const LocationButton = styled(IconButton)`
   background-color: ${props => props.theme.colors.secondary};
-  margin: 16px;
-  width: 50px;
-  height: 50px;
-  border-radius: 25px;
+  width: 48px;
+  height: 48px;
+  border-radius: 24px;
 `
 
 const OverlayContainer = styled.View`
@@ -221,16 +224,20 @@ const MapView = ({
       </MapContainer>
       <OverlayContainer {...conditionalA11yProps({ hidden: bottomSheetFullscreen })}>{Overlay}</OverlayContainer>
       <MapAttribution accessible={bottomSheetFullscreen} />
-      <StyledIcon
-        {...conditionalA11yProps({ hidden: bottomSheetFullscreen })}
-        icon={
-          <Icon color={theme.dark ? theme.colors.background : theme.colors.onSurface} source={locationPermissionIcon} />
-        }
-        onPress={onRequestLocation}
-        position={bottomSheetHeight}
-        accessibilityLabel={t('showOwnLocation')}
-      />
-      <MapZoomControls mapRef={mapRef} cameraRef={cameraRef} bottomSheetHeight={bottomSheetHeight} ref={zoomRef} />
+      <ControlsContainer bottomSheetHeight={bottomSheetHeight}>
+        <MapZoomControls mapRef={mapRef} cameraRef={cameraRef} ref={zoomRef} />
+        <LocationButton
+          {...conditionalA11yProps({ hidden: bottomSheetFullscreen })}
+          icon={
+            <Icon
+              color={theme.dark ? theme.colors.background : theme.colors.onSurface}
+              source={locationPermissionIcon}
+            />
+          }
+          onPress={onRequestLocation}
+          accessibilityLabel={t('showOwnLocation')}
+        />
+      </ControlsContainer>
     </OuterWrapper>
   )
 }

--- a/native/src/components/MapView.tsx
+++ b/native/src/components/MapView.tsx
@@ -13,9 +13,9 @@ import {
   TrackUserLocation,
 } from '@maplibre/maplibre-react-native'
 import type { BBox } from 'geojson'
-import React, { ReactElement, useCallback, useRef, useState } from 'react'
+import React, { ReactElement, type Ref, useCallback, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import type { NativeSyntheticEvent } from 'react-native'
+import type { NativeSyntheticEvent, View } from 'react-native'
 import styled, { useTheme } from 'styled-components/native'
 
 import {
@@ -37,6 +37,7 @@ import {
 import { clusterCountLayer, clusterLayer, markerLayer } from '../constants/layers'
 import usePreviousProp from '../hooks/usePreviousProp'
 import { conditionalA11yProps } from '../utils/helpers'
+import MapZoomControls from './MapZoomControls'
 import MapAttribution from './MapsAttribution'
 import Icon from './base/Icon'
 import IconButton from './base/IconButton'
@@ -90,6 +91,7 @@ type MapViewProps = {
   bottomSheetFullscreen: boolean
   zoom: number | undefined
   Overlay?: ReactElement
+  zoomInRef?: Ref<View>
 }
 
 const MapView = ({
@@ -104,6 +106,7 @@ const MapView = ({
   bottomSheetMidHeight,
   bottomSheetFullscreen,
   zoom,
+  zoomInRef,
 }: MapViewProps): ReactElement => {
   const mapRef = useRef<MapRef>(null)
   const cameraRef = useRef<CameraRef>(null)
@@ -180,6 +183,20 @@ const MapView = ({
     }
   }
 
+  const zoomBy = useCallback(async (delta: number) => {
+    if (mapRef.current === null) {
+      return
+    }
+
+    const currentZoom = await mapRef.current.getZoom()
+
+    setCameraSettings({
+      zoom: currentZoom + delta,
+      duration: animationDuration,
+      easing: 'ease',
+    })
+  }, [])
+
   const locationPermissionGrantedIcon = trackUserLocation ? 'crosshairs-gps' : 'crosshairs'
   const locationPermissionIcon = userLocation ? locationPermissionGrantedIcon : 'crosshairs-off'
 
@@ -226,6 +243,12 @@ const MapView = ({
         onPress={onRequestLocation}
         position={bottomSheetHeight}
         accessibilityLabel={t('showOwnLocation')}
+      />
+      <MapZoomControls
+        onZoomIn={() => zoomBy(1)}
+        onZoomOut={() => zoomBy(-1)}
+        bottomSheetHeight={bottomSheetHeight}
+        zoomInRef={zoomInRef}
       />
     </OuterWrapper>
   )

--- a/native/src/components/MapZoomControls.tsx
+++ b/native/src/components/MapZoomControls.tsx
@@ -1,0 +1,79 @@
+import React, { ReactElement, Ref, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Pressable, StyleSheet, type StyleProp, type View, type ViewStyle } from 'react-native'
+import { useTheme } from 'styled-components/native'
+
+import Icon from './base/Icon'
+
+// 50px button height + 16px margin
+const buttonSpacing = 66
+
+const styles = StyleSheet.create({
+  button: {
+    position: 'absolute',
+    right: 0,
+    margin: 16,
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+})
+
+type FocusedButtonProps = {
+  children: ReactElement
+  accessibilityLabel: string
+  ref?: Ref<View>
+  style?: StyleProp<ViewStyle>
+  onPress: () => void
+}
+
+const FocusedButton = ({ children, accessibilityLabel, ref, style, onPress }: FocusedButtonProps) => {
+  const [isFocused, setIsFocused] = useState(false)
+  const theme = useTheme()
+
+  return (
+    <Pressable
+      ref={ref}
+      onFocus={() => setIsFocused(true)}
+      onBlur={() => setIsFocused(false)}
+      onPress={isFocused ? onPress : undefined}
+      accessibilityLabel={accessibilityLabel}
+      style={[styles.button, style, { backgroundColor: theme.colors.surface, opacity: isFocused ? 1 : 0 }]}>
+      {children}
+    </Pressable>
+  )
+}
+
+type MapZoomControlsProps = {
+  onZoomIn: () => void
+  onZoomOut: () => void
+  bottomSheetHeight: number
+  zoomInRef?: Ref<View>
+}
+
+const MapZoomControls = ({ onZoomIn, onZoomOut, bottomSheetHeight, zoomInRef }: MapZoomControlsProps): ReactElement => {
+  const { t } = useTranslation('pois')
+  const theme = useTheme()
+
+  return (
+    <>
+      <FocusedButton
+        style={{ bottom: bottomSheetHeight + buttonSpacing }}
+        onPress={onZoomOut}
+        accessibilityLabel={t('zoomOut')}>
+        <Icon source='minus' color={theme.colors.onSurface} />
+      </FocusedButton>
+      <FocusedButton
+        style={{ bottom: bottomSheetHeight + buttonSpacing * 2 }}
+        onPress={onZoomIn}
+        accessibilityLabel={t('zoomIn')}
+        ref={zoomInRef}>
+        <Icon source='plus' color={theme.colors.onSurface} />
+      </FocusedButton>
+    </>
+  )
+}
+
+export default MapZoomControls

--- a/native/src/components/MapZoomControls.tsx
+++ b/native/src/components/MapZoomControls.tsx
@@ -24,6 +24,7 @@ const styles = StyleSheet.create({
     borderRadius: 24,
     justifyContent: 'center',
     alignItems: 'center',
+    overflow: 'hidden',
   },
 })
 

--- a/native/src/components/MapZoomControls.tsx
+++ b/native/src/components/MapZoomControls.tsx
@@ -1,18 +1,24 @@
-import React, { ReactElement, Ref, useState } from 'react'
+import type { CameraRef, MapRef } from '@maplibre/maplibre-react-native'
+import React, { ReactElement, Ref, RefObject, useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Pressable, StyleSheet, type StyleProp, type View, type ViewStyle } from 'react-native'
+import { findNodeHandle, Pressable, StyleSheet, type StyleProp, View, type ViewStyle } from 'react-native'
 import { useTheme } from 'styled-components/native'
+
+import { animationDuration } from 'shared'
 
 import Icon from './base/Icon'
 
-// 48px button height + 16px margin
-const buttonSpacing = 64
+// 50px location button height + 16px margin + 8px gap
+const locationButtonOffset = 74
 
 const styles = StyleSheet.create({
-  button: {
+  container: {
     position: 'absolute',
     right: 0,
-    margin: 16,
+    gap: 8,
+  },
+  button: {
+    marginRight: 16,
     width: 48,
     height: 48,
     borderRadius: 24,
@@ -27,9 +33,10 @@ type FocusedButtonProps = {
   ref?: Ref<View>
   style?: StyleProp<ViewStyle>
   onPress: () => void
+  nextFocusForward?: number
 }
 
-const FocusedButton = ({ children, accessibilityLabel, ref, style, onPress }: FocusedButtonProps) => {
+const FocusedButton = ({ children, accessibilityLabel, ref, style, onPress, nextFocusForward }: FocusedButtonProps) => {
   const [isFocused, setIsFocused] = useState(false)
   const theme = useTheme()
 
@@ -40,6 +47,8 @@ const FocusedButton = ({ children, accessibilityLabel, ref, style, onPress }: Fo
       onBlur={() => setIsFocused(false)}
       onPress={isFocused ? onPress : undefined}
       accessibilityLabel={accessibilityLabel}
+      // @ts-expect-error Pressable doesn't have a type for nextFocusForward but it is a valid prop
+      nextFocusForward={nextFocusForward}
       style={[styles.button, style, { backgroundColor: theme.colors.surface, opacity: isFocused ? 1 : 0 }]}>
       {children}
     </Pressable>
@@ -47,32 +56,42 @@ const FocusedButton = ({ children, accessibilityLabel, ref, style, onPress }: Fo
 }
 
 type MapZoomControlsProps = {
-  onZoomIn: () => void
-  onZoomOut: () => void
+  mapRef: RefObject<MapRef | null>
+  cameraRef: RefObject<CameraRef | null>
   bottomSheetHeight: number
-  zoomInRef?: Ref<View>
+  ref?: Ref<View>
 }
 
-const MapZoomControls = ({ onZoomIn, onZoomOut, bottomSheetHeight, zoomInRef }: MapZoomControlsProps): ReactElement => {
+const MapZoomControls = ({ mapRef, cameraRef, bottomSheetHeight, ref }: MapZoomControlsProps): ReactElement => {
   const { t } = useTranslation('pois')
   const theme = useTheme()
+  const [zoomOutFocusTarget, setZoomOutFocusTarget] = useState<number | undefined>(undefined)
+
+  const handleZoomOutRef = useCallback((view: View | null) => {
+    setZoomOutFocusTarget(findNodeHandle(view) ?? undefined)
+  }, [])
+
+  const zoom = async (delta: number) => {
+    if (mapRef.current === null || cameraRef.current === null) {
+      return
+    }
+    const currentZoom = await mapRef.current.getZoom()
+    cameraRef.current.zoomTo(currentZoom + delta, { duration: animationDuration, easing: 'ease' })
+  }
 
   return (
-    <>
+    <View style={[styles.container, { bottom: bottomSheetHeight + locationButtonOffset }]}>
       <FocusedButton
-        style={{ bottom: bottomSheetHeight + buttonSpacing }}
-        onPress={onZoomOut}
-        accessibilityLabel={t('zoomOut')}>
-        <Icon source='minus' color={theme.colors.onSurface} />
-      </FocusedButton>
-      <FocusedButton
-        style={{ bottom: bottomSheetHeight + buttonSpacing * 2 }}
-        onPress={onZoomIn}
+        onPress={() => zoom(1)}
         accessibilityLabel={t('zoomIn')}
-        ref={zoomInRef}>
+        ref={ref}
+        nextFocusForward={zoomOutFocusTarget}>
         <Icon source='plus' color={theme.colors.onSurface} />
       </FocusedButton>
-    </>
+      <FocusedButton onPress={() => zoom(-1)} accessibilityLabel={t('zoomOut')} ref={handleZoomOutRef}>
+        <Icon source='minus' color={theme.colors.onSurface} />
+      </FocusedButton>
+    </View>
   )
 }
 

--- a/native/src/components/MapZoomControls.tsx
+++ b/native/src/components/MapZoomControls.tsx
@@ -8,17 +8,11 @@ import { animationDuration } from 'shared'
 
 import Icon from './base/Icon'
 
-// 50px location button height + 16px margin + 8px gap
-const locationButtonOffset = 74
-
 const styles = StyleSheet.create({
   container: {
-    position: 'absolute',
-    right: 0,
     gap: 8,
   },
   button: {
-    marginRight: 16,
     width: 48,
     height: 48,
     borderRadius: 24,
@@ -28,7 +22,7 @@ const styles = StyleSheet.create({
   },
 })
 
-type FocusedButtonProps = {
+type FocusedOnlyButtonProps = {
   children: ReactElement
   accessibilityLabel: string
   ref?: Ref<View>
@@ -37,7 +31,14 @@ type FocusedButtonProps = {
   nextFocusForward?: number
 }
 
-const FocusedButton = ({ children, accessibilityLabel, ref, style, onPress, nextFocusForward }: FocusedButtonProps) => {
+const FocusedOnlyButton = ({
+  children,
+  accessibilityLabel,
+  ref,
+  style,
+  onPress,
+  nextFocusForward,
+}: FocusedOnlyButtonProps) => {
   const [isFocused, setIsFocused] = useState(false)
   const theme = useTheme()
 
@@ -59,11 +60,10 @@ const FocusedButton = ({ children, accessibilityLabel, ref, style, onPress, next
 type MapZoomControlsProps = {
   mapRef: RefObject<MapRef | null>
   cameraRef: RefObject<CameraRef | null>
-  bottomSheetHeight: number
   ref?: Ref<View>
 }
 
-const MapZoomControls = ({ mapRef, cameraRef, bottomSheetHeight, ref }: MapZoomControlsProps): ReactElement => {
+const MapZoomControls = ({ mapRef, cameraRef, ref }: MapZoomControlsProps): ReactElement => {
   const { t } = useTranslation('pois')
   const theme = useTheme()
   const [zoomOutFocusTarget, setZoomOutFocusTarget] = useState<number | undefined>(undefined)
@@ -81,17 +81,17 @@ const MapZoomControls = ({ mapRef, cameraRef, bottomSheetHeight, ref }: MapZoomC
   }
 
   return (
-    <View style={[styles.container, { bottom: bottomSheetHeight + locationButtonOffset }]}>
-      <FocusedButton
+    <View style={styles.container}>
+      <FocusedOnlyButton
         onPress={() => zoom(1)}
         accessibilityLabel={t('zoomIn')}
         ref={ref}
         nextFocusForward={zoomOutFocusTarget}>
         <Icon source='plus' color={theme.colors.onSurface} />
-      </FocusedButton>
-      <FocusedButton onPress={() => zoom(-1)} accessibilityLabel={t('zoomOut')} ref={handleZoomOutRef}>
+      </FocusedOnlyButton>
+      <FocusedOnlyButton onPress={() => zoom(-1)} accessibilityLabel={t('zoomOut')} ref={handleZoomOutRef}>
         <Icon source='minus' color={theme.colors.onSurface} />
-      </FocusedButton>
+      </FocusedOnlyButton>
     </View>
   )
 }

--- a/native/src/components/MapZoomControls.tsx
+++ b/native/src/components/MapZoomControls.tsx
@@ -5,8 +5,8 @@ import { useTheme } from 'styled-components/native'
 
 import Icon from './base/Icon'
 
-// 50px button height + 16px margin
-const buttonSpacing = 66
+// 48px button height + 16px margin
+const buttonSpacing = 64
 
 const styles = StyleSheet.create({
   button: {

--- a/native/src/components/PoisBottomSheet.tsx
+++ b/native/src/components/PoisBottomSheet.tsx
@@ -54,6 +54,7 @@ type PoiBottomSheetProps = {
   setSnapPointIndex: (index: number) => void
   setScrollPosition: (position: number) => void
   isFullscreen: boolean
+  zoomInFocusTarget?: number
 }
 
 const PoisBottomSheet = ({
@@ -69,6 +70,7 @@ const PoisBottomSheet = ({
   setSnapPointIndex,
   setScrollPosition,
   isFullscreen,
+  zoomInFocusTarget,
 }: PoiBottomSheetProps): ReactElement | null => {
   const { languageCode } = useCityAppContext()
   const { t } = useTranslation('pois')
@@ -88,6 +90,11 @@ const PoisBottomSheet = ({
     selectPoi(poi)
     bottomSheetRef.current?.snapToIndex(1)
   }
+
+  const HandleComponent = useCallback(
+    () => <BottomSheetHandle nextFocusForward={zoomInFocusTarget} />,
+    [zoomInFocusTarget],
+  )
 
   const PoiDetail = poi ? (
     <PoiDetails
@@ -122,7 +129,7 @@ const PoisBottomSheet = ({
       enableDynamicSizing={false}
       animateOnMount
       backgroundStyle={{ backgroundColor: theme.colors.background }}
-      handleComponent={BottomSheetHandle}
+      handleComponent={HandleComponent}
       onChange={setSnapPointIndex}>
       <BottomSheetContent>
         {slug ? (

--- a/native/src/components/PoisBottomSheet.tsx
+++ b/native/src/components/PoisBottomSheet.tsx
@@ -49,6 +49,7 @@ type PoiBottomSheetProps = {
   snapPointIndex: number
   setSnapPointIndex: (index: number) => void
   isFullscreen: boolean
+  zoomInFocusTarget?: number
 }
 
 const PoisBottomSheet = ({
@@ -62,6 +63,7 @@ const PoisBottomSheet = ({
   snapPointIndex,
   setSnapPointIndex,
   isFullscreen,
+  zoomInFocusTarget,
 }: PoiBottomSheetProps): ReactElement | null => {
   const [remountKey, setRemountKey] = useState(0)
   const { languageCode } = useRegionAppContext()
@@ -84,6 +86,11 @@ const PoisBottomSheet = ({
     selectPoi(poi)
     bottomSheetRef.current?.snapToIndex(1)
   }
+
+  const HandleComponent = useCallback(
+    () => <BottomSheetHandle nextFocusForward={zoomInFocusTarget} />,
+    [zoomInFocusTarget],
+  )
 
   const PoiDetail = poi ? (
     <PoiDetails
@@ -119,7 +126,7 @@ const PoisBottomSheet = ({
       enableDynamicSizing={false}
       animateOnMount
       backgroundStyle={{ backgroundColor: theme.colors.background }}
-      handleComponent={BottomSheetHandle}
+      handleComponent={HandleComponent}
       onChange={setSnapPointIndex}>
       <BottomSheetContent>
         {slug ? (

--- a/native/src/components/PoisBottomSheet.tsx
+++ b/native/src/components/PoisBottomSheet.tsx
@@ -1,5 +1,5 @@
 import BottomSheet, { BottomSheetFlatList, BottomSheetScrollView } from '@gorhom/bottom-sheet'
-import React, { memo, ReactElement, useRef, useState } from 'react'
+import React, { memo, ReactElement, useCallback, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { View } from 'react-native'
 import styled, { useTheme } from 'styled-components/native'

--- a/native/src/routes/Pois.tsx
+++ b/native/src/routes/Pois.tsx
@@ -1,7 +1,7 @@
 import { BottomSheetFlatListMethods } from '@gorhom/bottom-sheet'
-import React, { ReactElement, useRef, useState } from 'react'
+import React, { ReactElement, useRef, useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { StyleSheet, useWindowDimensions } from 'react-native'
+import { findNodeHandle, StyleSheet, useWindowDimensions, type View } from 'react-native'
 import { Chip } from 'react-native-paper'
 import { SvgUri } from 'react-native-svg'
 import styled from 'styled-components/native'
@@ -45,6 +45,7 @@ const Pois = ({ pois: allPois, cityModel, route, navigation }: PoisProps): React
   const [userLocation, setUserLocation] = useState<LocationType | null>(null)
   const [bottomSheetSnapPointIndex, setBottomSheetSnapPointIndex] = useState(1)
   const [listScrollPosition, setListScrollPosition] = useState(0)
+  const [zoomInFocusTarget, setZoomInFocusTarget] = useState<number | undefined>(undefined)
   const poiListRef = useRef<BottomSheetFlatListMethods>(null)
   const { t } = useTranslation('pois')
   const { height } = useWindowDimensions()
@@ -58,6 +59,10 @@ const Pois = ({ pois: allPois, cityModel, route, navigation }: PoisProps): React
   })
 
   const scrollToOffset = (offset: number) => poiListRef.current?.scrollToOffset({ offset, animated: false })
+
+  const handleZoomInRef = useCallback((view: View | null) => {
+    setZoomInFocusTarget(findNodeHandle(view) ?? undefined)
+  }, [])
 
   const deselectAll = () => {
     navigation.setParams({ slug: undefined, multipoi: undefined })
@@ -177,6 +182,7 @@ const Pois = ({ pois: allPois, cityModel, route, navigation }: PoisProps): React
         userLocation={userLocation}
         zoom={zoom}
         Overlay={FiltersOverlayButtons}
+        zoomInRef={handleZoomInRef}
       />
       <PoisBottomSheet
         poiListRef={poiListRef}
@@ -191,6 +197,7 @@ const Pois = ({ pois: allPois, cityModel, route, navigation }: PoisProps): React
         setSnapPointIndex={setBottomSheetSnapPointIndex}
         setScrollPosition={setListScrollPosition}
         isFullscreen={bottomSheetFullscreen}
+        zoomInFocusTarget={zoomInFocusTarget}
       />
     </Container>
   )

--- a/native/src/routes/Pois.tsx
+++ b/native/src/routes/Pois.tsx
@@ -154,6 +154,7 @@ const Pois = ({ localHistory, initialZoom, pois: allPois, regionModel }: PoisPro
         userLocation={userLocation}
         zoom={initialZoom}
         Overlay={FiltersOverlayButtons}
+        zoomRef={handleZoomInRef}
       />
       <PoisBottomSheet
         pois={sortPois(pois, userLocation)}

--- a/native/src/routes/Pois.tsx
+++ b/native/src/routes/Pois.tsx
@@ -1,6 +1,6 @@
-import React, { ReactElement, useState } from 'react'
+import React, { ReactElement, useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useWindowDimensions } from 'react-native'
+import { findNodeHandle, useWindowDimensions, type View } from 'react-native'
 import { Chip } from 'react-native-paper'
 import { SvgUri } from 'react-native-svg'
 import styled from 'styled-components/native'
@@ -58,6 +58,7 @@ type PoisProps = {
 const Pois = ({ localHistory, initialZoom, pois: allPois, regionModel }: PoisProps): ReactElement => {
   const { slug, multipoi, poiCategoryId, currentlyOpen, showFilterSelection } = localHistory.current
   const [bottomSheetSnapPointIndex, setBottomSheetSnapPointIndex] = useState(1)
+  const [zoomInFocusTarget, setZoomInFocusTarget] = useState<number | undefined>(undefined)
   const { userLocation, refreshPermissionAndLocation } = useUserLocation({ requestPermissionInitially: false })
   const { t } = useTranslation('pois')
   const { height } = useWindowDimensions()
@@ -70,6 +71,10 @@ const Pois = ({ localHistory, initialZoom, pois: allPois, regionModel }: PoisPro
     pois: allPois,
     params: { slug, multipoi, poiCategoryId, currentlyOpen },
   })
+
+  const handleZoomInRef = useCallback((view: View | null) => {
+    setZoomInFocusTarget(findNodeHandle(view) ?? undefined)
+  }, [])
 
   const deselect = () => localHistory.push(multipoi !== undefined && slug ? { multipoi } : {})
 
@@ -167,6 +172,7 @@ const Pois = ({ localHistory, initialZoom, pois: allPois, regionModel }: PoisPro
         snapPointIndex={bottomSheetSnapPointIndex}
         setSnapPointIndex={setBottomSheetSnapPointIndex}
         isFullscreen={bottomSheetFullscreen}
+        zoomInFocusTarget={zoomInFocusTarget}
       />
     </Container>
   )

--- a/translations/translations.json
+++ b/translations/translations.json
@@ -11561,7 +11561,9 @@
       "poisCount_few": "{{count}} Orte",
       "poisCount_many": "{{count}} Orte",
       "poisCount_other": "{{count}} Orte",
-      "contacts": "Kontakte"
+      "contacts": "Kontakte",
+      "zoomIn": "Zoom in",
+      "zoomOut": "Zoom out"
     },
     "am": {
       "pageTitle": "ካርታ",
@@ -12121,7 +12123,9 @@
       "poisCount_few": "{{count}} locations",
       "poisCount_many": "{{count}} locations",
       "poisCount_other": "{{count}} locations",
-      "contacts": "Contacts"
+      "contacts": "Contacts",
+      "zoomIn": "Zoom in",
+      "zoomOut": "Zoom out"
     },
     "es": {
       "pageTitle": "Mapa",

--- a/translations/translations.json
+++ b/translations/translations.json
@@ -11566,8 +11566,8 @@
       "poisCount_many": "{{count}} Orte",
       "poisCount_other": "{{count}} Orte",
       "contacts": "Kontakte",
-      "zoomIn": "Zoom in",
-      "zoomOut": "Zoom out"
+      "zoomIn": "Vergrößern",
+      "zoomOut": "Verkleinern"
     },
     "am": {
       "pageTitle": "ካርታ",

--- a/translations/translations.json
+++ b/translations/translations.json
@@ -11565,7 +11565,9 @@
       "poisCount_few": "{{count}} Orte",
       "poisCount_many": "{{count}} Orte",
       "poisCount_other": "{{count}} Orte",
-      "contacts": "Kontakte"
+      "contacts": "Kontakte",
+      "zoomIn": "Zoom in",
+      "zoomOut": "Zoom out"
     },
     "am": {
       "pageTitle": "ካርታ",
@@ -12125,7 +12127,9 @@
       "poisCount_few": "{{count}} locations",
       "poisCount_many": "{{count}} locations",
       "poisCount_other": "{{count}} locations",
-      "contacts": "Contacts"
+      "contacts": "Contacts",
+      "zoomIn": "Zoom in",
+      "zoomOut": "Zoom out"
     },
     "es": {
       "pageTitle": "Mapa",

--- a/web/src/components/MapView.tsx
+++ b/web/src/components/MapView.tsx
@@ -62,6 +62,8 @@ type MapCursorType = 'grab' | 'auto' | 'pointer'
 
 export type MapViewRef = {
   setGeocontrol: (control: maplibregl.IControl) => void
+  zoomIn: () => void
+  zoomOut: () => void
 }
 
 const MapView = ({
@@ -91,6 +93,8 @@ const MapView = ({
     ref,
     () => ({
       setGeocontrol: (control: maplibregl.IControl) => mapRef?.addControl(control),
+      zoomIn: () => mapRef?.zoomIn(),
+      zoomOut: () => mapRef?.zoomOut(),
     }),
     [mapRef],
   )

--- a/web/src/components/MapZoomControls.tsx
+++ b/web/src/components/MapZoomControls.tsx
@@ -1,0 +1,47 @@
+import AddIcon from '@mui/icons-material/Add'
+import RemoveIcon from '@mui/icons-material/Remove'
+import IconButton from '@mui/material/IconButton'
+import Stack from '@mui/material/Stack'
+import { styled } from '@mui/material/styles'
+import React, { ReactElement } from 'react'
+import { useTranslation } from 'react-i18next'
+
+const StyledIconButton = styled(IconButton)`
+  background-color: ${props => props.theme.palette.background.accent};
+  border: 1px solid
+    ${props => (props.theme.isContrastTheme ? props.theme.palette.grey[700] : props.theme.palette.grey[400])};
+
+  :hover {
+    background-color: ${props => props.theme.palette.background.default};
+  }
+
+  ${props => props.theme.breakpoints.down('md')} {
+    inset-inline-end: -100px;
+
+    :focus {
+      inset-inline-end: 0;
+    }
+  }
+`
+
+type MapZoomControlsProps = {
+  onZoomIn: () => void
+  onZoomOut: () => void
+}
+
+const MapZoomControls = ({ onZoomIn, onZoomOut }: MapZoomControlsProps): ReactElement => {
+  const { t } = useTranslation('pois')
+
+  return (
+    <Stack gap={1}>
+      <StyledIconButton onClick={onZoomIn} aria-label={t('zoomIn')}>
+        <AddIcon />
+      </StyledIconButton>
+      <StyledIconButton onClick={onZoomOut} aria-label={t('zoomOut')}>
+        <RemoveIcon />
+      </StyledIconButton>
+    </Stack>
+  )
+}
+
+export default MapZoomControls

--- a/web/src/components/MapZoomControls.tsx
+++ b/web/src/components/MapZoomControls.tsx
@@ -6,6 +6,8 @@ import { styled } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { MapViewRef } from './MapView'
+
 const StyledIconButton = styled(IconButton)`
   background-color: ${props => props.theme.palette.background.accent};
   border: 1px solid
@@ -25,19 +27,18 @@ const StyledIconButton = styled(IconButton)`
 `
 
 type MapZoomControlsProps = {
-  onZoomIn: () => void
-  onZoomOut: () => void
+  mapViewRef: MapViewRef
 }
 
-const MapZoomControls = ({ onZoomIn, onZoomOut }: MapZoomControlsProps): ReactElement => {
+const MapZoomControls = ({ mapViewRef }: MapZoomControlsProps): ReactElement => {
   const { t } = useTranslation('pois')
 
   return (
     <Stack gap={1}>
-      <StyledIconButton onClick={onZoomIn} aria-label={t('zoomIn')}>
+      <StyledIconButton onClick={mapViewRef.zoomIn} aria-label={t('zoomIn')}>
         <AddIcon />
       </StyledIconButton>
-      <StyledIconButton onClick={onZoomOut} aria-label={t('zoomOut')}>
+      <StyledIconButton onClick={mapViewRef.zoomOut} aria-label={t('zoomOut')}>
         <RemoveIcon />
       </StyledIconButton>
     </Stack>

--- a/web/src/components/PoisMobile.tsx
+++ b/web/src/components/PoisMobile.tsx
@@ -13,6 +13,7 @@ import useDimensions from '../hooks/useDimensions'
 import BottomActionSheet, { ScrollableBottomSheetRef } from './BottomActionSheet'
 import MapAttribution from './MapAttribution'
 import MapView, { MapViewRef } from './MapView'
+import MapZoomControls from './MapZoomControls'
 import PoiSharedChildren from './PoiSharedChildren'
 import SkeletonHeader from './SkeletonHeader'
 import SkeletonList from './SkeletonList'
@@ -35,6 +36,11 @@ const AttributionContainer = styled('div')`
 const GeocontrolContainer = styled(AttributionContainer)`
   right: 16px;
   margin-bottom: 24px;
+`
+
+const ZoomControlsContainer = styled(AttributionContainer)`
+  right: 8px;
+  margin-bottom: 66px;
 `
 
 const SkeletonPoiContent = () => (
@@ -151,6 +157,9 @@ const PoisMobile = ({
         ref={sheetRef}
         sibling={
           <>
+            <ZoomControlsContainer>
+              {mapViewRef && <MapZoomControls onZoomIn={mapViewRef.zoomIn} onZoomOut={mapViewRef.zoomOut} />}
+            </ZoomControlsContainer>
             <GeocontrolContainer ref={geocontrolPosition} />
             <AttributionContainer>
               <MapAttribution />

--- a/web/src/components/PoisMobile.tsx
+++ b/web/src/components/PoisMobile.tsx
@@ -38,9 +38,12 @@ const GeocontrolContainer = styled(AttributionContainer)`
   margin-bottom: 24px;
 `
 
+// margin-bottom for ZoomControlsContainer is calculated as follows:
+// The Geocontrol height with its margin-bottom = 29px + 24px
+// = 53px + 8px gap rounded up to 64px
 const ZoomControlsContainer = styled(AttributionContainer)`
   right: 8px;
-  margin-bottom: 66px;
+  margin-bottom: 64px;
 `
 
 const SkeletonPoiContent = () => (

--- a/web/src/components/PoisMobile.tsx
+++ b/web/src/components/PoisMobile.tsx
@@ -33,17 +33,13 @@ const AttributionContainer = styled('div')`
   bottom: calc(min(var(--rsbs-overlay-h, 0), ${props => props.theme.dimensions.bottomSheet.snapPoints.medium}px));
 `
 
-const GeocontrolContainer = styled(AttributionContainer)`
+const MapControlsContainer = styled(AttributionContainer)`
   right: 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
   margin-bottom: 24px;
-`
-
-// margin-bottom for ZoomControlsContainer is calculated as follows:
-// The Geocontrol height with its margin-bottom = 29px + 24px
-// = 53px + 8px gap rounded up to 64px
-const ZoomControlsContainer = styled(AttributionContainer)`
-  right: 8px;
-  margin-bottom: 64px;
 `
 
 const SkeletonPoiContent = () => (
@@ -160,10 +156,10 @@ const PoisMobile = ({
         ref={sheetRef}
         sibling={
           <>
-            <ZoomControlsContainer>
-              {mapViewRef && <MapZoomControls onZoomIn={mapViewRef.zoomIn} onZoomOut={mapViewRef.zoomOut} />}
-            </ZoomControlsContainer>
-            <GeocontrolContainer ref={geocontrolPosition} />
+            <MapControlsContainer>
+              {mapViewRef && <MapZoomControls mapViewRef={mapViewRef} />}
+              <div ref={geocontrolPosition} />
+            </MapControlsContainer>
             <AttributionContainer>
               <MapAttribution />
             </AttributionContainer>


### PR DESCRIPTION
### Short Description
This zoom in and zoom out buttons will allow keyboard users to be able to zoom just by focusing on the these buttons.

⚠️  This is a sub-branch of `#4056 Upgrade maplibre to v11`

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Created a state `mapViewRef` at web to control the zoom.
- New component called `MapZoomControls.tsx`:
   - For web I used `:focus` and right to show the button like skip to content. (for desktop it already has `NavigationControl` and it's not hidden).
   - For native used `Pressable` that has `onFocus` and `onBlur` and  its hidden by opacity (I cant use right to move it offscreen because the keyboard tab will not focus on it).
   - I had an issue at native that I can't reach the Zoom button while using keyboard tab so I adjusted the `BottomSheetHandle` to forward the focus (nextFocusForward) to the zoom button next using TouchableOpacity.

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- At native the area where the buttons are located while not focused on (opacity 0) are rendered and could affect pressing on the map on that area.
- This focus forwarding workaround on native doesn't work on iOS. (Settings -> Accessibility -> Keyboards -> Full Keyboard Access -> On).

### Testing

- Launch Integreat and go to poi/map.
- Press tab on keyboard to reach the zoom buttons (on native press down arrow to reach the minus  after you reach the plus)
- Test web on desktop and mobile screens (on web it should be visible all the time).
- Test contrast mode.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3478 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
