### PR TITLE
4023: Main imprint route

### DIFF
--- a/build-configs/BuildConfigType.ts
+++ b/build-configs/BuildConfigType.ts
@@ -79,13 +79,13 @@ export type CommonBuildConfigType = {
     default: string
     [language: string]: string
   }
+  // Main imprint of the app.
+  mainImprint: string
 }
 // Available only on web
 export type WebBuildConfigType = CommonBuildConfigType & {
   // Used for generating manifest.json
   appDescription: string
-  // Main imprint of the app.
-  mainImprint: string
   // Url to the manifest.json generated with webpack.
   manifestUrl?: string
   icons: {

--- a/build-configs/aschaffenburg/index.ts
+++ b/build-configs/aschaffenburg/index.ts
@@ -49,6 +49,7 @@ const commonAschaffenburgBuildConfig: CommonBuildConfigType = {
   accessibilityUrls: {
     default: 'https://integreat-app.de/barrierefreiheit/',
   },
+  mainImprint,
 }
 
 export const androidAschaffenburgBuildConfig: AndroidBuildConfigType = {
@@ -91,7 +92,6 @@ export const iosAschaffenburgBuildConfig: IosBuildConfigType = {
 export const webAschaffenburgBuildConfig: WebBuildConfigType = {
   ...commonAschaffenburgBuildConfig,
   appDescription: 'Ihr digitaler Begleiter für die Stadt Aschaffenburg',
-  mainImprint,
   icons: {
     appLogo: '/app-icon-round.svg',
     appLogoMobile: '/app-icon-round.svg',

--- a/build-configs/integreat/index.ts
+++ b/build-configs/integreat/index.ts
@@ -52,6 +52,7 @@ const commonIntegreatBuildConfig: CommonBuildConfigType = {
   accessibilityUrls: {
     default: 'https://integreat-app.de/barrierefreiheit/',
   },
+  mainImprint,
 }
 export const androidIntegreatBuildConfig: AndroidBuildConfigType = {
   ...commonIntegreatBuildConfig,
@@ -91,7 +92,6 @@ export const iosIntegreatBuildConfig: IosBuildConfigType = {
 export const webIntegreatBuildConfig: WebBuildConfigType = {
   ...commonIntegreatBuildConfig,
   appDescription: 'Integreat – die lokale und mehrsprachige Integrations-Plattform für Zugewanderte',
-  mainImprint,
   manifestUrl: '/manifest.json',
   icons: {
     appLogo: '/app-logo.svg',

--- a/build-configs/malte/index.ts
+++ b/build-configs/malte/index.ts
@@ -49,6 +49,7 @@ const commonMalteBuildConfig: CommonBuildConfigType = {
   accessibilityUrls: {
     default: 'https://integreat-app.de/barrierefreiheit/',
   },
+  mainImprint,
 }
 
 const androidMalteBuildConfig: AndroidBuildConfigType = {
@@ -91,7 +92,6 @@ const iosMalteBuildConfig: IosBuildConfigType = {
 const webMalteBuildConfig: WebBuildConfigType = {
   ...commonMalteBuildConfig,
   appDescription: 'Guide of the Malteser Werke for Refugees. Digital. Multilingual. Free.',
-  mainImprint,
   icons: {
     appLogo: '/app-logo.svg',
     appLogoMobile: '/app-icon-round.svg',

--- a/build-configs/obdach/index.ts
+++ b/build-configs/obdach/index.ts
@@ -39,13 +39,13 @@ const commonObdachBuildConfig: CommonBuildConfigType = {
   accessibilityUrls: {
     default: 'https://integreat-app.de/barrierefreiheit/',
   },
+  mainImprint,
 }
 
 export const webObdachBuildConfig: WebBuildConfigType = {
   ...commonObdachBuildConfig,
   appDescription:
     'Netzwerk Obdach & Wohnen – die lokale und mehrsprachige Plattform für Obdachlose und Menschen die von Obdachlosigkeit bedroht sind',
-  mainImprint,
   manifestUrl: '/manifest.json',
   icons: {
     appLogo: '/app-logo.svg',

--- a/native/src/Navigator.tsx
+++ b/native/src/Navigator.tsx
@@ -10,6 +10,7 @@ import {
   SUGGEST_TO_REGION_ROUTE,
   CONSENT_ROUTE,
   IMPRINT_ROUTE,
+  MAIN_IMPRINT_ROUTE,
   FEEDBACK_MODAL_ROUTE,
   IMAGE_VIEW_MODAL_ROUTE,
   INTRO_ROUTE,
@@ -43,6 +44,7 @@ import Intro from './routes/Intro'
 import Landing from './routes/Landing'
 import Licenses from './routes/Licenses'
 import LoadingErrorHandler from './routes/LoadingErrorHandler'
+import MainImprint from './routes/MainImprint'
 import PDFViewModal from './routes/PDFViewModal'
 import SearchContainer from './routes/SearchContainer'
 import Settings from './routes/Settings'
@@ -168,6 +170,7 @@ const Navigator = (): ReactElement | null => {
         <Stack.Screen name={SETTINGS_ROUTE} component={Settings} />
         <Stack.Screen name={LICENSES_ROUTE} component={Licenses} />
         <Stack.Screen name={CONSENT_ROUTE} component={Consent} />
+        <Stack.Screen name={MAIN_IMPRINT_ROUTE} component={MainImprint} />
       </Stack.Group>
     </Stack.Navigator>
   )

--- a/native/src/constants/NavigationTypes.ts
+++ b/native/src/constants/NavigationTypes.ts
@@ -5,6 +5,7 @@ import {
   CategoriesRouteType,
   ChangeLanguageModalRouteType,
   ImprintRouteType,
+  MainImprintRouteType,
   EventsRouteType,
   FeedbackModalRouteType,
   ImageViewModalRouteType,
@@ -25,6 +26,7 @@ import {
   EVENTS_ROUTE,
   NEWS_ROUTE,
   IMPRINT_ROUTE,
+  MAIN_IMPRINT_ROUTE,
   SETTINGS_ROUTE,
   SEARCH_ROUTE,
   CHANGE_LANGUAGE_MODAL_ROUTE,
@@ -62,6 +64,7 @@ export type RootRoutesType =
   | LandingRouteType
   | SuggestToRegionRouteType
   | ImprintRouteType
+  | MainImprintRouteType
   | SettingsRouteType
   | SearchRouteType
   | ChangeLanguageModalRouteType
@@ -112,6 +115,7 @@ export type RootRoutesParamsType = {
   [LANDING_ROUTE]: undefined
   [SUGGEST_TO_REGION_ROUTE]: undefined
   [IMPRINT_ROUTE]: undefined
+  [MAIN_IMPRINT_ROUTE]: undefined
   [CONSENT_ROUTE]: undefined
   [SETTINGS_ROUTE]: undefined
   [SEARCH_ROUTE]: {

--- a/native/src/constants/__mocks__/buildConfig.ts
+++ b/native/src/constants/__mocks__/buildConfig.ts
@@ -50,6 +50,7 @@ const buildConfig = jest.fn<CommonBuildConfigType, []>(
     accessibilityUrls: {
       default: 'https://integreat-app.de/barrierefreiheit/',
     },
+    mainImprint: 'Test imprint',
   }),
 )
 export default buildConfig

--- a/native/src/routes/MainImprint.tsx
+++ b/native/src/routes/MainImprint.tsx
@@ -1,0 +1,21 @@
+import React, { ReactElement } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import LayoutedScrollView from '../components/LayoutedScrollView'
+import Page from '../components/Page'
+import Text from '../components/base/Text'
+import buildConfig from '../constants/buildConfig'
+
+const MainImprint = (): ReactElement => {
+  const { i18n } = useTranslation()
+  return (
+    <LayoutedScrollView>
+      <Text variant='h1' style={{ margin: 16 }}>
+        Impressum und Datenschutz
+      </Text>
+      <Page content={buildConfig().mainImprint} language={i18n.language} />
+    </LayoutedScrollView>
+  )
+}
+
+export default MainImprint

--- a/native/src/utils/createSettingsSections.ts
+++ b/native/src/utils/createSettingsSections.ts
@@ -11,7 +11,6 @@ import NativeConstants from '../constants/NativeConstants'
 import { NavigationProps } from '../constants/NavigationTypes'
 import buildConfig from '../constants/buildConfig'
 import { AppContextType } from '../contexts/AppContextProvider'
-import urlFromRouteInformation from '../utils/url'
 import { SettingsType } from './AppSettings'
 import { requestPushNotificationPermission, subscribeNews, unsubscribeNews } from './PushNotificationsManager'
 import openExternalUrl from './openExternalUrl'
@@ -116,10 +115,7 @@ const createSettingsSections = ({
   {
     role: 'link',
     title: t('layout:imprint'),
-    onPress: async () =>
-      settings.selectedCity
-        ? navigation.navigate(IMPRINT_ROUTE)
-        : openExternalUrl(urlFromRouteInformation({ route: MAIN_IMPRINT_ROUTE }), showSnackbar),
+    onPress: () => navigation.navigate(settings.selectedCity ? IMPRINT_ROUTE : MAIN_IMPRINT_ROUTE),
   },
   {
     role: 'link',


### PR DESCRIPTION
### Short Description

Add a main imprint route internally instead of opening an external url

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Move mainImprint to common build config                                                                                                                                         
- Add Main imprint route                                                                                                                                                          
- Create MainImprint.tsx page component                                                                                                                                           
- Navigate to main imprint route instead of external url  

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

1. Make a fresh install of the app to ensure no region is selected
2. Click on the "..." menu and select settings
3. Click on imprint

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4023

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
