### PR TITLE
4037: [Android] Fix bottomSheet's disappearance

### DIFF
--- a/native/src/components/PoisBottomSheet.tsx
+++ b/native/src/components/PoisBottomSheet.tsx
@@ -91,6 +91,7 @@ const PoisBottomSheet = ({
 
   // Workaround for bottomSheet gets hidden after permissions dialog on Android so we force remounting after app comes back to foreground.
   // reanimated's shared values gets affected by the permissions dialog (UI thread is stopped when the permission dialog is displayed).
+  // For more details https://github.com/digitalfabrik/integreat-app/issues/4037 and https://github.com/gorhom/react-native-bottom-sheet/issues/1791#issuecomment-2060957019
   useAppStateListener(nextAppState => {
     if (nextAppState === 'active') {
       setRemountKey(previous => previous + 1)

--- a/native/src/components/PoisBottomSheet.tsx
+++ b/native/src/components/PoisBottomSheet.tsx
@@ -3,9 +3,9 @@ import BottomSheet, {
   BottomSheetFlatListMethods,
   BottomSheetScrollView,
 } from '@gorhom/bottom-sheet'
-import React, { memo, ReactElement, Ref, useCallback, useRef } from 'react'
+import React, { memo, ReactElement, Ref, useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { NativeScrollEvent, NativeSyntheticEvent, View } from 'react-native'
+import { AppState, AppStateStatus, NativeScrollEvent, NativeSyntheticEvent, View } from 'react-native'
 import styled, { useTheme } from 'styled-components/native'
 
 import { LocationType } from 'shared'
@@ -74,6 +74,7 @@ const PoisBottomSheet = ({
   const { t } = useTranslation('pois')
   const theme = useTheme()
   const bottomSheetRef = useRef<BottomSheet>(null)
+  const [remountKey, setRemountKey] = useState(0)
 
   const handlePoiFocus = useCallback(() => {
     if (!isFullscreen && bottomSheetRef.current) {
@@ -86,6 +87,18 @@ const PoisBottomSheet = ({
     selectPoi(poi)
     bottomSheetRef.current?.snapToIndex(1)
   }
+
+  // Workaround for bottomSheet gets hidden after permissions dialog on Android so we force remounting after app comes back to foreground.
+  // reanimated's shared values gets affected by the permissions dialog (UI thread is stopped when the permission dialog is displayed).
+  useEffect(() => {
+    const handleAppStateChange = (nextAppState: AppStateStatus) => {
+      if (nextAppState === 'active') {
+        setRemountKey(prev => prev + 1)
+      }
+    }
+    const subscription = AppState.addEventListener('change', handleAppStateChange)
+    return () => subscription.remove()
+  }, [])
 
   const PoiDetail = poi ? (
     <PoiDetails
@@ -111,6 +124,7 @@ const PoisBottomSheet = ({
 
   return (
     <StyledBottomSheet
+      key={remountKey}
       ref={bottomSheetRef}
       accessibilityLabel=''
       index={snapPointIndex}

--- a/native/src/components/PoisBottomSheet.tsx
+++ b/native/src/components/PoisBottomSheet.tsx
@@ -3,14 +3,15 @@ import BottomSheet, {
   BottomSheetFlatListMethods,
   BottomSheetScrollView,
 } from '@gorhom/bottom-sheet'
-import React, { memo, ReactElement, Ref, useCallback, useEffect, useRef, useState } from 'react'
+import React, { memo, ReactElement, Ref, useCallback, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { AppState, AppStateStatus, NativeScrollEvent, NativeSyntheticEvent, View } from 'react-native'
+import { NativeScrollEvent, NativeSyntheticEvent, View } from 'react-native'
 import styled, { useTheme } from 'styled-components/native'
 
 import { LocationType } from 'shared'
 import { ErrorCode, PoiModel } from 'shared/api'
 
+import useAppStateListener from '../hooks/useAppStateListener'
 import useRegionAppContext from '../hooks/useRegionAppContext'
 import BottomSheetHandle from './BottomSheetHandle'
 import Failure from './Failure'
@@ -90,15 +91,11 @@ const PoisBottomSheet = ({
 
   // Workaround for bottomSheet gets hidden after permissions dialog on Android so we force remounting after app comes back to foreground.
   // reanimated's shared values gets affected by the permissions dialog (UI thread is stopped when the permission dialog is displayed).
-  useEffect(() => {
-    const handleAppStateChange = (nextAppState: AppStateStatus) => {
-      if (nextAppState === 'active') {
-        setRemountKey(prev => prev + 1)
-      }
+  useAppStateListener(nextAppState => {
+    if (nextAppState === 'active') {
+      setRemountKey(previous => previous + 1)
     }
-    const subscription = AppState.addEventListener('change', handleAppStateChange)
-    return () => subscription.remove()
-  }, [])
+  })
 
   const PoiDetail = poi ? (
     <PoiDetails


### PR DESCRIPTION
### Short Description

Bottom Sheet sometimes disappears from the view all of a sudden and it is not that consistent.
(To reproduce this issue you should wait for the location permission 3 seconds before selecting an action.)

### Proposed Changes

<!-- Describe this PR in more detail. -->

- This is a workaround to remount the bottomSheet when the UI thread stops when it gets interrupted by the permission dialog.
- Added a `useEffect` that runs once and subscribes to `AppState` changes. When the app returns to `'active'` (e.g. after the permission dialog closes), it increments `remountKey`.
- Assigned `key={remountKey}` to `<StyledBottomSheet>` so it remounts the bottomSheet again when its incremented.

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- The AppState could re-render the sheet when the app is in the background.

### Testing

- Make sure that the app is deleted from the emulator.
- Launch integreat on android and go to Poi/map.
- Wait for the location permission dialog around 3 second before selecting deny or "only while using the app".
- just to make sure repeat the test multiple time with different waiting time.
- Test iOS.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4037

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
