### PR TITLE
4092: Fix poiDetails keyboard accessibility

### DIFF
--- a/native/src/components/Accordion.tsx
+++ b/native/src/components/Accordion.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement, ReactNode, useState } from 'react'
+import { View } from 'react-native'
 import { List, useTheme } from 'react-native-paper'
 
 type AccordionProps = {
@@ -6,6 +7,7 @@ type AccordionProps = {
   children: ReactNode
   description?: string
   initialCollapsed?: boolean
+  nativeID?: string
 }
 
 const Accordion = ({
@@ -13,21 +15,24 @@ const Accordion = ({
   headerContent,
   description,
   initialCollapsed = false,
+  nativeID,
 }: AccordionProps): ReactElement => {
   const [collapsed, setCollapsed] = useState<boolean>(initialCollapsed)
   const theme = useTheme()
 
   return (
-    <List.Accordion
-      title={headerContent}
-      style={{ paddingVertical: 0, paddingRight: 0, paddingLeft: 0 }}
-      contentStyle={{ paddingLeft: 0, paddingRight: 0 }}
-      titleStyle={{ fontWeight: 'bold', color: theme.colors.onBackground }}
-      expanded={!collapsed}
-      onPress={() => setCollapsed(!collapsed)}
-      description={description}>
-      {children}
-    </List.Accordion>
+    <View nativeID={nativeID}>
+      <List.Accordion
+        title={headerContent}
+        style={{ paddingVertical: 0, paddingRight: 0, paddingLeft: 0 }}
+        contentStyle={{ paddingLeft: 0, paddingRight: 0 }}
+        titleStyle={{ fontWeight: 'bold', color: theme.colors.onBackground }}
+        expanded={!collapsed}
+        onPress={() => setCollapsed(!collapsed)}
+        description={description}>
+        {children}
+      </List.Accordion>
+    </View>
   )
 }
 

--- a/native/src/components/Accordion.tsx
+++ b/native/src/components/Accordion.tsx
@@ -1,5 +1,4 @@
 import React, { ReactElement, ReactNode, useState } from 'react'
-import { View } from 'react-native'
 import { List, useTheme } from 'react-native-paper'
 
 type AccordionProps = {
@@ -7,7 +6,6 @@ type AccordionProps = {
   children: ReactNode
   description?: string
   initialCollapsed?: boolean
-  nativeID?: string
 }
 
 const Accordion = ({
@@ -15,24 +13,21 @@ const Accordion = ({
   headerContent,
   description,
   initialCollapsed = false,
-  nativeID,
 }: AccordionProps): ReactElement => {
   const [collapsed, setCollapsed] = useState<boolean>(initialCollapsed)
   const theme = useTheme()
 
   return (
-    <View nativeID={nativeID}>
-      <List.Accordion
-        title={headerContent}
-        style={{ paddingVertical: 0, paddingRight: 0, paddingLeft: 0 }}
-        contentStyle={{ paddingLeft: 0, paddingRight: 0 }}
-        titleStyle={{ fontWeight: 'bold', color: theme.colors.onBackground }}
-        expanded={!collapsed}
-        onPress={() => setCollapsed(!collapsed)}
-        description={description}>
-        {children}
-      </List.Accordion>
-    </View>
+    <List.Accordion
+      title={headerContent}
+      style={{ paddingVertical: 0, paddingRight: 0, paddingLeft: 0 }}
+      contentStyle={{ paddingLeft: 0, paddingRight: 0 }}
+      titleStyle={{ fontWeight: 'bold', color: theme.colors.onBackground }}
+      expanded={!collapsed}
+      onPress={() => setCollapsed(!collapsed)}
+      description={description}>
+      {children}
+    </List.Accordion>
   )
 }
 

--- a/native/src/components/Accordion.tsx
+++ b/native/src/components/Accordion.tsx
@@ -25,7 +25,6 @@ const Accordion = ({
       titleStyle={{ fontWeight: 'bold', color: theme.colors.onBackground }}
       expanded={!collapsed}
       onPress={() => setCollapsed(!collapsed)}
-      rippleColor='transparent'
       description={description}>
       {children}
     </List.Accordion>

--- a/native/src/components/AddressInfo.tsx
+++ b/native/src/components/AddressInfo.tsx
@@ -42,7 +42,7 @@ const AddressInfo = ({ location, language }: AddressInfoProps): ReactElement => 
   }
 
   return (
-    <Container language={language}>
+    <Container nativeID='accessibility-order-address' language={language}>
       <TouchableRipple borderless accessibilityLabel={t('copyAddress')} role='button' onPress={copyLocationToClipboard}>
         <>
           <Text>{address}</Text>

--- a/native/src/components/OpeningHours.tsx
+++ b/native/src/components/OpeningHours.tsx
@@ -109,6 +109,7 @@ const OpeningHours = ({
   return (
     <>
       <Accordion
+        nativeID='accessibility-order-opening-hours'
         headerContent={<OpeningHoursTitle isCurrentlyOpen={isCurrentlyOpen} language={language} />}
         initialCollapsed>
         <HoursList hours={openingHours} appointmentUrl={appointmentUrl} />

--- a/native/src/components/OpeningHours.tsx
+++ b/native/src/components/OpeningHours.tsx
@@ -109,7 +109,6 @@ const OpeningHours = ({
   return (
     <>
       <Accordion
-        nativeID='accessibility-order-opening-hours'
         headerContent={<OpeningHoursTitle isCurrentlyOpen={isCurrentlyOpen} language={language} />}
         initialCollapsed>
         <HoursList hours={openingHours} appointmentUrl={appointmentUrl} />

--- a/native/src/components/PoiDetails.tsx
+++ b/native/src/components/PoiDetails.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
+import { Platform } from 'react-native'
 import { Divider } from 'react-native-paper'
 import styled from 'styled-components/native'
 
@@ -39,22 +40,12 @@ const PoiDetails = ({ poi, language, distance, onFocus }: PoiDetailsProps): Reac
   const { t } = useTranslation('pois')
   const { title, content, contacts, openingHours, temporarilyClosed, isCurrentlyOpen, category, appointmentUrl } = poi
 
-  // [4092] accessibilityOrder feature is experimental and could change in the future
-  // Used here to fix the the loop that happens between the description accordion and the address copy button.
-  // https://reactnative.dev/docs/accessibility#experimental_accessibilityorder
-  const accessibilityOrder = [
-    ...(content.length > 0 ? ['accessibility-order-description'] : []),
-    'accessibility-order-address',
-    ...(contacts.length > 0 ? ['accessibility-order-contacts'] : []),
-    'accessibility-order-opening-hours',
-  ]
-
   return (
     <PoiDetailsContainer
       accessibilityLabel={`${title} - ${category.name}`}
       onFocus={onFocus}
       screenReaderFocusable
-      experimental_accessibilityOrder={accessibilityOrder}>
+      focusable={Platform.OS === 'ios' ? true : undefined}>
       <Text variant='h5' style={{ paddingBottom: 4 }}>
         {title}
       </Text>
@@ -68,7 +59,7 @@ const PoiDetails = ({ poi, language, distance, onFocus }: PoiDetailsProps): Reac
       <StyledDivider />
       {content.length > 0 && (
         <>
-          <Accordion nativeID='accessibility-order-description' headerContent={t('description')}>
+          <Accordion headerContent={t('description')}>
             <Page content={content} language={language} padding={false} />
           </Accordion>
           <StyledDivider />
@@ -78,7 +69,7 @@ const PoiDetails = ({ poi, language, distance, onFocus }: PoiDetailsProps): Reac
       <StyledDivider />
       {contacts.length > 0 && (
         <>
-          <Accordion nativeID='accessibility-order-contacts' headerContent={t('contacts')} initialCollapsed>
+          <Accordion headerContent={t('contacts')} initialCollapsed>
             <StyledContactsContainer>
               {contacts.map((contact, index) => (
                 <Contact

--- a/native/src/components/PoiDetails.tsx
+++ b/native/src/components/PoiDetails.tsx
@@ -14,7 +14,7 @@ import Page from './Page'
 import PoiChips from './PoiChips'
 import Text from './base/Text'
 
-const PoiDetailsContainer = styled.View`
+const PoiDetailsContainer = styled.View<{ experimental_accessibilityOrder?: string[] }>`
   flex: 1;
   background-color: ${props => props.theme.colors.background};
   gap: 16px;
@@ -39,8 +39,22 @@ const PoiDetails = ({ poi, language, distance, onFocus }: PoiDetailsProps): Reac
   const { t } = useTranslation('pois')
   const { title, content, contacts, openingHours, temporarilyClosed, isCurrentlyOpen, category, appointmentUrl } = poi
 
+  // [4092] accessibilityOrder feature is experimental and could change in the future
+  // Used here to fix the the loop that happens between the description accordion and the address copy button.
+  // https://reactnative.dev/docs/accessibility#experimental_accessibilityorder
+  const accessibilityOrder = [
+    ...(content.length > 0 ? ['accessibility-order-description'] : []),
+    'accessibility-order-address',
+    ...(contacts.length > 0 ? ['accessibility-order-contacts'] : []),
+    'accessibility-order-opening-hours',
+  ]
+
   return (
-    <PoiDetailsContainer accessibilityLabel={`${title} - ${category.name}`} onFocus={onFocus} focusable>
+    <PoiDetailsContainer
+      accessibilityLabel={`${title} - ${category.name}`}
+      onFocus={onFocus}
+      screenReaderFocusable
+      experimental_accessibilityOrder={accessibilityOrder}>
       <Text variant='h5' style={{ paddingBottom: 4 }}>
         {title}
       </Text>
@@ -54,7 +68,7 @@ const PoiDetails = ({ poi, language, distance, onFocus }: PoiDetailsProps): Reac
       <StyledDivider />
       {content.length > 0 && (
         <>
-          <Accordion headerContent={t('description')}>
+          <Accordion nativeID='accessibility-order-description' headerContent={t('description')}>
             <Page content={content} language={language} padding={false} />
           </Accordion>
           <StyledDivider />
@@ -64,7 +78,7 @@ const PoiDetails = ({ poi, language, distance, onFocus }: PoiDetailsProps): Reac
       <StyledDivider />
       {contacts.length > 0 && (
         <>
-          <Accordion headerContent={t('contacts')} initialCollapsed>
+          <Accordion nativeID='accessibility-order-contacts' headerContent={t('contacts')} initialCollapsed>
             <StyledContactsContainer>
               {contacts.map((contact, index) => (
                 <Contact

--- a/native/src/components/PoiDetails.tsx
+++ b/native/src/components/PoiDetails.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Platform } from 'react-native'
 import { Divider } from 'react-native-paper'
 import styled from 'styled-components/native'
 
@@ -41,11 +40,7 @@ const PoiDetails = ({ poi, language, distance, onFocus }: PoiDetailsProps): Reac
   const { title, content, contacts, openingHours, temporarilyClosed, isCurrentlyOpen, category, appointmentUrl } = poi
 
   return (
-    <PoiDetailsContainer
-      accessibilityLabel={`${title} - ${category.name}`}
-      onFocus={onFocus}
-      screenReaderFocusable
-      focusable={Platform.OS === 'ios' ? true : undefined}>
+    <PoiDetailsContainer accessibilityLabel={`${title} - ${category.name}`} onFocus={onFocus} screenReaderFocusable>
       <Text variant='h5' style={{ paddingBottom: 4 }}>
         {title}
       </Text>

--- a/native/src/components/PoiDetails.tsx
+++ b/native/src/components/PoiDetails.tsx
@@ -15,7 +15,7 @@ import Page from './Page'
 import PoiChips from './PoiChips'
 import Text from './base/Text'
 
-const PoiDetailsContainer = styled.View<{ experimental_accessibilityOrder?: string[] }>`
+const PoiDetailsContainer = styled.View`
   flex: 1;
   background-color: ${props => props.theme.colors.background};
   gap: 16px;

--- a/native/src/components/PoiListItem.tsx
+++ b/native/src/components/PoiListItem.tsx
@@ -15,9 +15,10 @@ type PoiListItemProps = {
   navigateToPoi: () => void
   distance: number | null
   onFocus: () => void
+  isKeyboardFocusable: boolean
 }
 
-const PoiListItem = ({ poi, language, navigateToPoi, distance, onFocus }: PoiListItemProps) => {
+const PoiListItem = ({ poi, language, navigateToPoi, distance, onFocus, isKeyboardFocusable }: PoiListItemProps) => {
   const { t } = useTranslation('pois')
   const theme = useTheme()
 
@@ -37,7 +38,7 @@ const PoiListItem = ({ poi, language, navigateToPoi, distance, onFocus }: PoiLis
       onPress={navigateToPoi}
       role='link'
       onFocus={onFocus}
-      focusable
+      accessible={isKeyboardFocusable}
       style={styles.ListItemStyle}
       description={
         <View>

--- a/native/src/components/PoiListItem.tsx
+++ b/native/src/components/PoiListItem.tsx
@@ -15,10 +15,10 @@ type PoiListItemProps = {
   navigateToPoi: () => void
   distance: number | null
   onFocus: () => void
-  isKeyboardFocusable: boolean
+  visible: boolean
 }
 
-const PoiListItem = ({ poi, language, navigateToPoi, distance, onFocus, isKeyboardFocusable }: PoiListItemProps) => {
+const PoiListItem = ({ poi, language, navigateToPoi, distance, onFocus, visible }: PoiListItemProps) => {
   const { t } = useTranslation('pois')
   const theme = useTheme()
 
@@ -38,7 +38,7 @@ const PoiListItem = ({ poi, language, navigateToPoi, distance, onFocus, isKeyboa
       onPress={navigateToPoi}
       role='link'
       onFocus={onFocus}
-      accessible={isKeyboardFocusable}
+      accessible={visible}
       style={styles.ListItemStyle}
       description={
         <View>

--- a/native/src/components/PoisBottomSheet.tsx
+++ b/native/src/components/PoisBottomSheet.tsx
@@ -111,7 +111,7 @@ const PoisBottomSheet = ({
       navigateToPoi={() => handlePoiSelection(poi)}
       distance={userLocation && poi.distance(userLocation)}
       onFocus={expandFullscreen}
-      isKeyboardFocusable={!slug}
+      visible={!slug}
     />
   )
 

--- a/native/src/components/PoisBottomSheet.tsx
+++ b/native/src/components/PoisBottomSheet.tsx
@@ -119,7 +119,7 @@ const PoisBottomSheet = ({
     <StyledBottomSheet
       key={remountKey}
       ref={bottomSheetRef}
-      accessibilityLabel=''
+      accessible={false}
       index={snapPointIndex}
       isFullscreen={isFullscreen}
       snapPoints={snapPoints}

--- a/native/src/components/PoisBottomSheet.tsx
+++ b/native/src/components/PoisBottomSheet.tsx
@@ -111,6 +111,7 @@ const PoisBottomSheet = ({
       navigateToPoi={() => handlePoiSelection(poi)}
       distance={userLocation && poi.distance(userLocation)}
       onFocus={expandFullscreen}
+      isKeyboardFocusable={!slug}
     />
   )
 


### PR DESCRIPTION
### Short Description
A user with an external keyboard can't access the poi details at bottomSheet.

⚠️  This is a sub-branch of 4113

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Because the poiDetails is above the list I had to disable the focus when I press tab on the poiDetails so I added a prop to  `PoiListItem` called `isKeyboardFocusable` to disable accessible if there is there is no slug.

- Removed `rippleColor='transparent'` from Accordion because it affects the keyboard focus highlight.

- At PoiDetailsContainer I changed `focusable` to `screenReaderFocusable` to prevent it from focusing on non pressable content and keep it just for the readers.
- There was an issue with Accordion and the location copy button that the focus gets stuck in a loop between them so I tried many solution to solve that but non worked other than an experimental accessibility prop called `experimental_accessibilityOrder` and gave it an array of strings that represents the current order.
https://reactnative.dev/docs/accessibility#experimental_accessibilityorder
- Added a prop `nativeID` to the Accordion and wrapped it with a view just for nativeID.
### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None (other than that experimental prop I used).

### Testing

- Test PoiDetails on Android and keep pressing tab to navigate.
- Test the talkback functionality.
- Test iOS.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4092

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
