### PR TITLE
2691: Add caching for web requests

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -43,6 +43,7 @@
     "@mui/x-date-pickers": "^8.27.2",
     "@sentry/react": "^10.46.0",
     "@sentry/types": "^10.46.0",
+    "@tanstack/react-query": "^5.100.10",
     "build-configs": "0.0.1",
     "core-js": "^3.49.0",
     "dompurify": "^3.4.0",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,5 @@
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import 'core-js/actual/array/at'
 import { Settings as LuxonSettings } from 'luxon'
 import React, { ReactElement, useEffect, useState } from 'react'
@@ -16,6 +17,8 @@ import { initSentry } from './utils/sentry'
 LuxonSettings.throwOnInvalid = true
 LuxonSettings.defaultLocale = config.defaultFallback
 
+const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } } })
+
 const App = (): ReactElement => {
   const [contentLanguage, setContentLanguage] = useState<string>(config.defaultFallback)
   const contentDirection = contentLanguage
@@ -27,17 +30,19 @@ const App = (): ReactElement => {
   }, [])
 
   return (
-    <ThemeContainer contentDirection={contentDirection}>
-      <I18nProvider contentLanguage={contentLanguage}>
-        <LocalizationProvider dateAdapter={CustomAdapterLuxon} adapterLocale={contentLanguage}>
-          <Router>
-            <TtsContainer languageCode={contentLanguage}>
-              <RootNavigator setContentLanguage={setContentLanguage} />
-            </TtsContainer>
-          </Router>
-        </LocalizationProvider>
-      </I18nProvider>
-    </ThemeContainer>
+    <QueryClientProvider client={queryClient}>
+      <ThemeContainer contentDirection={contentDirection}>
+        <I18nProvider contentLanguage={contentLanguage}>
+          <LocalizationProvider dateAdapter={CustomAdapterLuxon} adapterLocale={contentLanguage}>
+            <Router>
+              <TtsContainer languageCode={contentLanguage}>
+                <RootNavigator setContentLanguage={setContentLanguage} />
+              </TtsContainer>
+            </Router>
+          </LocalizationProvider>
+        </I18nProvider>
+      </ThemeContainer>
+    </QueryClientProvider>
   )
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -17,7 +17,9 @@ import { initSentry } from './utils/sentry'
 LuxonSettings.throwOnInvalid = true
 LuxonSettings.defaultLocale = config.defaultFallback
 
-const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } } })
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false, networkMode: 'always' } },
+})
 
 const App = (): ReactElement => {
   const [contentLanguage, setContentLanguage] = useState<string>(config.defaultFallback)

--- a/web/src/RegionContentNavigator.tsx
+++ b/web/src/RegionContentNavigator.tsx
@@ -11,7 +11,7 @@ import {
   POIS_ROUTE,
   SEARCH_ROUTE,
 } from 'shared'
-import { NotFoundError, useLoadFromEndpoint, createRegionEndpoint } from 'shared/api'
+import { NotFoundError, createRegionEndpoint } from 'shared/api'
 
 import FailureSwitcherWithHelmet from './components/FailureSwitcherWithHelmet'
 import Footer from './components/Footer'
@@ -20,6 +20,7 @@ import LanguageFailure from './components/LanguageFailure'
 import Layout from './components/Layout'
 import RegionContentLayout from './components/RegionContentLayout'
 import { cmsApiBaseUrl } from './constants/urls'
+import useQueryFromEndpoint from './hooks/useQueryFromEndpoint'
 import {
   LOCAL_NEWS_ROUTE,
   RoutePatterns,
@@ -47,24 +48,25 @@ const RegionContentNavigator = ({ languageCode }: RegionContentNavigatorProps): 
   // This component is only opened when there is a regionCode in the route
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const regionCode = useParams().regionCode!
-  const {
-    data: region,
-    error,
-    loading,
-  } = useLoadFromEndpoint(createRegionEndpoint, cmsApiBaseUrl, { region: regionCode })
+  const { data: region, error: regionError } = useQueryFromEndpoint(createRegionEndpoint, cmsApiBaseUrl, {
+    region: regionCode,
+  })
   const pathname = normalizePath(useLocation().pathname)
 
-  if (!region && !loading) {
-    const notFoundError = new NotFoundError({
-      type: 'region',
-      id: regionCode,
-      region: regionCode,
-      language: languageCode,
-    })
+  if (regionError) {
+    const error =
+      regionError instanceof NotFoundError
+        ? new NotFoundError({
+            type: 'region',
+            id: regionCode,
+            region: regionCode,
+            language: languageCode,
+          })
+        : regionError
 
     return (
       <Layout header={<GeneralHeader languageCode={languageCode} />} footer={<Footer />}>
-        <FailureSwitcherWithHelmet error={error ?? notFoundError} />
+        <FailureSwitcherWithHelmet error={error} />
       </Layout>
     )
   }
@@ -89,7 +91,7 @@ const RegionContentNavigator = ({ languageCode }: RegionContentNavigatorProps): 
   }
 
   const regionRouteProps: RegionRouteProps = {
-    region,
+    region: region ?? null,
     pathname,
     regionCode,
     languageCode,

--- a/web/src/__tests__/FixedRegionContentNavigator.spec.tsx
+++ b/web/src/__tests__/FixedRegionContentNavigator.spec.tsx
@@ -8,10 +8,6 @@ const renderSuccessful = 'route'
 
 jest.mock('react-i18next')
 jest.mock('../RegionContentNavigator', () => () => <div>{renderSuccessful}</div>)
-jest.mock('shared/api', () => ({
-  ...jest.requireActual('shared/api'),
-  useLoadFromEndpoint: jest.fn(() => ({ data: null, error: null, loading: false, refresh: jest.fn() })),
-}))
 
 describe('FixedRegionContentNavigator', () => {
   const languageCode = 'de'

--- a/web/src/__tests__/RegionContentNavigator.spec.tsx
+++ b/web/src/__tests__/RegionContentNavigator.spec.tsx
@@ -3,19 +3,16 @@ import { useLocation } from 'react-router'
 
 import { IMPRINT_ROUTE, NEWS_ROUTE, normalizePath, POIS_ROUTE, SEARCH_ROUTE } from 'shared'
 import { RegionModel, RegionModelBuilder } from 'shared/api'
-import {
-  mockUseLoadFromEndpointWithData,
-  mockUseLoadFromEndpointWithError,
-} from 'shared/api/endpoints/testing/mockUseLoadFromEndpoint'
 
 import RegionContentNavigator from '../RegionContentNavigator'
 import { regionContentPattern } from '../routes'
+import {
+  mockUseQueryFromEndpointWithData,
+  mockUseQueryFromEndpointWithError,
+} from '../testing/mockUseQueryFromEndpoint'
 import { renderRoute } from '../testing/render'
 
-jest.mock('shared/api', () => ({
-  ...jest.requireActual('shared/api'),
-  useLoadFromEndpoint: jest.fn(),
-}))
+jest.mock('../hooks/useQueryFromEndpoint')
 jest.mock('../components/RegionContentHeader')
 jest.mock('../components/RegionContentLayout')
 jest.mock('react-i18next')
@@ -48,7 +45,7 @@ describe('RegionContentNavigator', () => {
   it.each([{ routeName: SEARCH_ROUTE }, { routeName: IMPRINT_ROUTE }, { routeName: POIS_ROUTE }])(
     'should navigate to $routeName route',
     async ({ routeName }) => {
-      mockUseLoadFromEndpointWithData(region)
+      mockUseQueryFromEndpointWithData(region)
       const { findByText } = renderRegionContentNavigator(routeName)
       // findByText is needed as routes are lazy loaded
       expect(await findByText(routeName)).toBeTruthy()
@@ -56,19 +53,13 @@ describe('RegionContentNavigator', () => {
   )
 
   it('should show an error if endpoint throws an error', () => {
-    mockUseLoadFromEndpointWithError('Region cannot be loaded')
+    mockUseQueryFromEndpointWithError('Region cannot be loaded')
     const { getByText } = renderRegionContentNavigator(SEARCH_ROUTE)
     expect(getByText('error:unknownError')).toBeTruthy()
   })
 
-  it('should show an error if region cannot be loaded', () => {
-    mockUseLoadFromEndpointWithData(null)
-    const { getByText } = renderRegionContentNavigator(SEARCH_ROUTE)
-    expect(getByText('error:notFound.region')).toBeTruthy()
-  })
-
   it('should not navigate to pois route if pois are not enabled', async () => {
-    mockUseLoadFromEndpointWithData(regionWithDisabledFeatures)
+    mockUseQueryFromEndpointWithData(regionWithDisabledFeatures)
     const { queryByText } = renderRegionContentNavigator(POIS_ROUTE)
     expect(queryByText(POIS_ROUTE)).not.toBeTruthy()
   })
@@ -78,7 +69,7 @@ describe('RegionContentNavigator', () => {
       from          | to
       ${NEWS_ROUTE} | ${'/augsburg/de/news/local'}
     `('should redirect from $from to $to', ({ from, to }) => {
-      mockUseLoadFromEndpointWithData(region)
+      mockUseQueryFromEndpointWithData(region)
       const { getByText } = renderRegionContentNavigator(from)
       expect(getByText(to)).toBeTruthy()
     })

--- a/web/src/__tests__/RootNavigator.spec.tsx
+++ b/web/src/__tests__/RootNavigator.spec.tsx
@@ -4,15 +4,16 @@ import { useLocation } from 'react-router'
 
 import { normalizePath } from 'shared'
 import { RegionModelBuilder } from 'shared/api'
-import {
-  mockUseLoadFromEndpointOnceWithData,
-  mockUseLoadFromEndpointWithData,
-} from 'shared/api/endpoints/testing/mockUseLoadFromEndpoint'
 
 import RootNavigator from '../RootNavigator'
 import buildConfig from '../constants/buildConfig'
+import {
+  mockUseQueryFromEndpointOnceWithData,
+  mockUseQueryFromEndpointWithData,
+} from '../testing/mockUseQueryFromEndpoint'
 import { renderWithRouterAndTheme } from '../testing/render'
 
+jest.mock('../hooks/useQueryFromEndpoint')
 jest.mock('i18next', () => ({
   ...jest.requireActual('i18next'),
   createInstance: () => ({ language: 'de' }),
@@ -22,7 +23,6 @@ jest.mock('stylis')
 
 jest.mock('shared/api', () => ({
   ...jest.requireActual('shared/api'),
-  useLoadFromEndpoint: jest.fn(),
   useLoadAsync: jest.fn(() => ({ data: null, error: null })),
 }))
 
@@ -51,7 +51,7 @@ describe('RootNavigator', () => {
   })
 
   it('should render the regions page', async () => {
-    mockUseLoadFromEndpointOnceWithData(regions)
+    mockUseQueryFromEndpointOnceWithData(regions)
 
     const { getByText } = renderRootNavigator('/regions/de')
 
@@ -73,7 +73,7 @@ describe('RootNavigator', () => {
       ${'/augsburg/news/local'}     | ${'/augsburg/de/news/local'}
       ${'/augsburg/news/tu-news'}   | ${'/augsburg/de/news/tu-news'}
     `('should redirect from $from to $to', ({ from, to }) => {
-      mockUseLoadFromEndpointWithData(regions)
+      mockUseQueryFromEndpointWithData(regions)
 
       const { getByText } = renderRootNavigator(from)
 
@@ -105,7 +105,7 @@ describe('RootNavigator', () => {
         ${'/oldtown/news'}       | ${'/oldtown/de/news'}
         ${'/oldtown/news/local'} | ${'/oldtown/de/news/local'}
       `('should redirect from $from to $to for fixedRegion', async ({ from, to }) => {
-        mockUseLoadFromEndpointWithData(regions)
+        mockUseQueryFromEndpointWithData(regions)
 
         const { getByText } = renderRootNavigator(from)
 

--- a/web/src/components/ChatContainer.tsx
+++ b/web/src/components/ChatContainer.tsx
@@ -14,7 +14,7 @@ import { TtsContext } from '../contexts/TtsContext'
 import useDimensions from '../hooks/useDimensions'
 import useLocalStorage from '../hooks/useLocalStorage'
 import useLockedBody from '../hooks/useLockedBody'
-import { chatIdKey } from '../utils/chat'
+import { chatIdKey, generateChatId } from '../utils/chat'
 import ChatController from './ChatController'
 import ChatMenu from './ChatMenu'
 import HeaderLanguageSelectorItem from './HeaderLanguageSelectorItem'
@@ -51,9 +51,9 @@ const ChatContainer = ({ region, languageCode, languageChangePaths }: ChatContai
   const { desktop, xsmall, visibleFooterHeight, bottomNavigationHeight } = useDimensions()
   const { visible: ttsPlayerVisible } = useContext(TtsContext)
 
-  const { value: chatId, updateLocalStorageItem: updateChatId } = useLocalStorage<string | null>({
+  const { value: chatId, updateLocalStorageItem: updateChatId } = useLocalStorage<string>({
     key: chatIdKey(region.code),
-    initialValue: null,
+    initialValue: generateChatId(),
   })
 
   const chatName = getChatName(buildConfig().appName)
@@ -100,7 +100,7 @@ const ChatContainer = ({ region, languageCode, languageChangePaths }: ChatContai
             : []),
           <ChatMenu key='chatMenu' chatId={chatId} updateChatId={updateChatId} />,
         ]}>
-        <ChatController chatId={chatId} updateChatId={updateChatId} region={region} languageCode={languageCode} />
+        <ChatController chatId={chatId} region={region} languageCode={languageCode} />
       </StyledDialog>
     )
   }

--- a/web/src/components/ChatController.tsx
+++ b/web/src/components/ChatController.tsx
@@ -6,29 +6,21 @@ import { cmsApiBaseUrl } from '../constants/urls'
 import useIsTabActive from '../hooks/useIsTabActive'
 import useLocalStorage from '../hooks/useLocalStorage'
 import useQueryFromEndpoint from '../hooks/useQueryFromEndpoint'
-import { generateChatId } from '../utils/chat'
 import Chat from './Chat'
 
 type ChatControllerProps = {
   region: RegionModel
   languageCode: string
-  chatId: string | null
-  updateChatId: (newChatId: string | null) => void
+  chatId: string
 }
 
 const LOCAL_STORAGE_ITEM_CHAT_PRIVACY_POLICIES = 'Chat-Privacy-Policies'
 const DEFAULT_POLLING_INTERVAL = 15000
 const TYPING_POLLING_INTERVAL = 3000
 
-const ChatController = ({ region, languageCode, chatId, updateChatId }: ChatControllerProps): ReactElement => {
+const ChatController = ({ region, languageCode, chatId }: ChatControllerProps): ReactElement => {
   const [sendingError, setSendingError] = useState<Error | null>(null)
   const isBrowserTabActive = useIsTabActive()
-
-  const initializeChat = (): string => {
-    const newId = generateChatId()
-    updateChatId(newId)
-    return newId
-  }
 
   const {
     data,
@@ -42,7 +34,7 @@ const ChatController = ({ region, languageCode, chatId, updateChatId }: ChatCont
     {
       regionCode: region.code,
       language: languageCode,
-      deviceId: chatId ?? '',
+      deviceId: chatId,
     },
     { cached: false },
   )
@@ -69,7 +61,7 @@ const ChatController = ({ region, languageCode, chatId, updateChatId }: ChatCont
       regionCode: region.code,
       language: languageCode,
       message,
-      deviceId: chatId ?? initializeChat(),
+      deviceId: chatId,
     })
 
     if (data !== null) {

--- a/web/src/components/ChatController.tsx
+++ b/web/src/components/ChatController.tsx
@@ -1,17 +1,11 @@
 import React, { ReactElement, useEffect, useState } from 'react'
 
-import { SendingStatusType } from 'shared'
-import {
-  RegionModel,
-  createChatMessagesEndpoint,
-  createSendChatMessageEndpoint,
-  NotFoundError,
-  useLoadFromEndpoint,
-} from 'shared/api'
+import { RegionModel, createChatMessagesEndpoint, createSendChatMessageEndpoint, NotFoundError } from 'shared/api'
 
 import { cmsApiBaseUrl } from '../constants/urls'
 import useIsTabActive from '../hooks/useIsTabActive'
 import useLocalStorage from '../hooks/useLocalStorage'
+import useQueryFromEndpoint from '../hooks/useQueryFromEndpoint'
 import { generateChatId } from '../utils/chat'
 import Chat from './Chat'
 
@@ -27,8 +21,7 @@ const DEFAULT_POLLING_INTERVAL = 15000
 const TYPING_POLLING_INTERVAL = 3000
 
 const ChatController = ({ region, languageCode, chatId, updateChatId }: ChatControllerProps): ReactElement => {
-  const regionCode = region.code
-  const [sendingStatus, setSendingStatus] = useState<SendingStatusType>('idle')
+  const [sendingError, setSendingError] = useState<Error | null>(null)
   const isBrowserTabActive = useIsTabActive()
 
   const initializeChat = (): string => {
@@ -38,18 +31,23 @@ const ChatController = ({ region, languageCode, chatId, updateChatId }: ChatCont
   }
 
   const {
-    data: chatMessagesReturn,
-    refresh: refreshMessages,
+    data,
+    refetch: refreshMessages,
     error,
-    loading,
+    isPending,
     setData,
-  } = useLoadFromEndpoint(createChatMessagesEndpoint, cmsApiBaseUrl, {
-    regionCode,
-    language: languageCode,
-    deviceId: chatId ?? '',
-  })
-  const botTyping = chatMessagesReturn?.botTyping
-  const messageCount = chatMessagesReturn?.messages.length ?? 0
+  } = useQueryFromEndpoint(
+    createChatMessagesEndpoint,
+    cmsApiBaseUrl,
+    {
+      regionCode: region.code,
+      language: languageCode,
+      deviceId: chatId ?? '',
+    },
+    { cached: false },
+  )
+  const botTyping = data?.botTyping
+  const messageCount = data?.messages.length ?? 0
 
   const { value, updateLocalStorageItem } = useLocalStorage<Record<string, boolean>>({
     key: LOCAL_STORAGE_ITEM_CHAT_PRIVACY_POLICIES,
@@ -67,9 +65,8 @@ const ChatController = ({ region, languageCode, chatId, updateChatId }: ChatCont
   }, [refreshMessages, isBrowserTabActive, messageCount, botTyping])
 
   const submitMessage = async (message: string) => {
-    setSendingStatus('sending')
     const { data, error } = await createSendChatMessageEndpoint(cmsApiBaseUrl).request({
-      regionCode,
+      regionCode: region.code,
       language: languageCode,
       message,
       deviceId: chatId ?? initializeChat(),
@@ -77,22 +74,21 @@ const ChatController = ({ region, languageCode, chatId, updateChatId }: ChatCont
 
     if (data !== null) {
       setData(data)
-      setSendingStatus('successful')
     }
 
     if (error !== null) {
-      setSendingStatus('failed')
+      setSendingError(error)
     }
   }
 
   return (
     <Chat
       region={region}
-      messages={chatMessagesReturn?.messages ?? []}
+      messages={data?.messages ?? []}
       submitMessage={submitMessage}
       // If no message has been sent yet, fetching the messages yields a 404 not found error
-      hasError={error !== null && !(error instanceof NotFoundError)}
-      isLoading={chatMessagesReturn === null && (loading || sendingStatus === 'sending')}
+      hasError={!!sendingError || (error !== null && !(error instanceof NotFoundError))}
+      isLoading={isPending}
       isTyping={botTyping ?? false}
       privacyPolicyAccepted={privacyPolicyAccepted}
       acceptPrivacyPolicy={acceptCustomPrivacyPolicy}

--- a/web/src/components/ChatMenu.tsx
+++ b/web/src/components/ChatMenu.tsx
@@ -9,12 +9,13 @@ import Typography from '@mui/material/Typography'
 import React, { ReactElement, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { generateChatId } from '../utils/chat'
 import MenuItem from './MenuItem'
 import AlertDialog from './base/AlertDialog'
 
 type ChatMenuProps = {
   chatId: string | null
-  updateChatId: (newValue: string | null) => void
+  updateChatId: (newValue: string) => void
 }
 
 const ChatMenu = ({ chatId, updateChatId }: ChatMenuProps): ReactElement => {
@@ -28,7 +29,7 @@ const ChatMenu = ({ chatId, updateChatId }: ChatMenuProps): ReactElement => {
   }
   const createNewChat = () => {
     setMenuAnchorElement(null)
-    updateChatId(null)
+    updateChatId(generateChatId())
     setNewChatConfirmationDialogOpen(false)
   }
 

--- a/web/src/components/SprungbrettOffer.tsx
+++ b/web/src/components/SprungbrettOffer.tsx
@@ -1,9 +1,10 @@
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { OfferModel, useLoadFromEndpoint, createSprungbrettJobsEndpoint } from 'shared/api'
+import { OfferModel, createSprungbrettJobsEndpoint } from 'shared/api'
 
 import List from '../components/base/List'
+import useQueryFromEndpoint from '../hooks/useQueryFromEndpoint'
 import FailureSwitcher from './FailureSwitcher'
 import SkeletonList from './SkeletonList'
 import SprungbrettListItem from './SprungbrettListItem'
@@ -15,14 +16,18 @@ type SprungbrettOfferPageProps = {
 const SprungbrettOffer = ({ sprungbrettOffer }: SprungbrettOfferPageProps): ReactElement | null => {
   const { t } = useTranslation('sprungbrett')
 
-  const { data, error, loading } = useLoadFromEndpoint(createSprungbrettJobsEndpoint, sprungbrettOffer.path, undefined)
+  const { data, error, isPending } = useQueryFromEndpoint(
+    createSprungbrettJobsEndpoint,
+    sprungbrettOffer.path,
+    undefined,
+  )
 
-  if (loading) {
+  if (isPending) {
     return <SkeletonList />
   }
 
-  if (!data) {
-    return <FailureSwitcher error={error ?? new Error('Data missing')} />
+  if (error) {
+    return <FailureSwitcher error={error} />
   }
 
   const items = data.map(job => <SprungbrettListItem key={job.url} job={job} />)

--- a/web/src/components/__tests__/ChatContainer.spec.tsx
+++ b/web/src/components/__tests__/ChatContainer.spec.tsx
@@ -3,8 +3,8 @@ import React from 'react'
 
 import { getChatName } from 'shared'
 import { RegionModelBuilder } from 'shared/api'
-import { mockUseLoadFromEndpointWithData } from 'shared/api/endpoints/testing/mockUseLoadFromEndpoint'
 
+import { mockUseQueryFromEndpointWithData } from '../../testing/mockUseQueryFromEndpoint'
 import { renderRoute } from '../../testing/render'
 import ChatContainer from '../ChatContainer'
 
@@ -15,18 +15,14 @@ jest.mock('react-i18next', () => ({
   }),
   Trans: ({ i18nKey }: { i18nKey: string }) => i18nKey,
 }))
-
-jest.mock('shared/api', () => ({
-  ...jest.requireActual('shared/api'),
-  useLoadFromEndpoint: jest.fn(),
-}))
 jest.mock('../../hooks/useLocalStorage', () => () => ({
   value: { augsburg: true },
   updateLocalStorageItem: jest.fn(),
 }))
+jest.mock('../../hooks/useQueryFromEndpoint')
 
 describe('ChatContainer', () => {
-  mockUseLoadFromEndpointWithData({ messages: [] })
+  mockUseQueryFromEndpointWithData({ messages: [] })
   const routePattern = '/:regionCode/:languageCode'
   const region = new RegionModelBuilder(1).build()[0]!
   const pathname = `/${region.code}/de`

--- a/web/src/components/__tests__/ChatController.spec.tsx
+++ b/web/src/components/__tests__/ChatController.spec.tsx
@@ -29,7 +29,7 @@ describe('ChatContainer', () => {
     const value = { testumgebung: true }
     mocked(useLocalStorage<Record<string, boolean>>).mockImplementation(() => ({ value, updateLocalStorageItem }))
     const { getByText, queryByText } = renderWithTheme(
-      <ChatController chatId={null} updateChatId={jest.fn()} region={region} languageCode='de' />,
+      <ChatController chatId='test-id' region={region} languageCode='de' />,
     )
     expect(queryByText('conversationText')).toBeFalsy()
     expect(queryByText('conversationHelperText')).toBeFalsy()
@@ -42,7 +42,7 @@ describe('ChatContainer', () => {
   it('should fetch chat messages without caching', () => {
     const value = { testumgebung: true, augsburg: true }
     mocked(useLocalStorage<Record<string, boolean>>).mockImplementation(() => ({ value, updateLocalStorageItem }))
-    renderWithTheme(<ChatController chatId='test-id' updateChatId={jest.fn()} region={region} languageCode='de' />)
+    renderWithTheme(<ChatController chatId='test-id' region={region} languageCode='de' />)
     expect(mocked(useQueryFromEndpoint)).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.anything(), {
       cached: false,
     })
@@ -52,7 +52,7 @@ describe('ChatContainer', () => {
     const value = { testumgebung: true, augsburg: true }
     mocked(useLocalStorage<Record<string, boolean>>).mockImplementation(() => ({ value, updateLocalStorageItem }))
     const { getByText, queryByText } = renderWithTheme(
-      <ChatController chatId={null} updateChatId={jest.fn()} region={region} languageCode='de' />,
+      <ChatController chatId='test-id' region={region} languageCode='de' />,
     )
     expect(queryByText('privacyPolicyInformation')).toBeFalsy()
     expect(getByText('conversationText')).toBeTruthy()

--- a/web/src/components/__tests__/ChatController.spec.tsx
+++ b/web/src/components/__tests__/ChatController.spec.tsx
@@ -2,9 +2,10 @@ import { fireEvent } from '@testing-library/react'
 import React from 'react'
 
 import { RegionModelBuilder } from 'shared/api'
-import { mockUseLoadFromEndpointWithData } from 'shared/api/endpoints/testing/mockUseLoadFromEndpoint'
 
 import useLocalStorage from '../../hooks/useLocalStorage'
+import useQueryFromEndpoint from '../../hooks/useQueryFromEndpoint'
+import { mockUseQueryFromEndpointWithData } from '../../testing/mockUseQueryFromEndpoint'
 import { renderWithTheme } from '../../testing/render'
 import ChatController from '../ChatController'
 
@@ -13,14 +14,11 @@ jest.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
   Trans: ({ i18nKey }: { i18nKey: string }) => i18nKey,
 }))
-jest.mock('shared/api', () => ({
-  ...jest.requireActual('shared/api'),
-  useLoadFromEndpoint: jest.fn(),
-}))
 jest.mock('../../hooks/useLocalStorage')
+jest.mock('../../hooks/useQueryFromEndpoint')
 
 describe('ChatContainer', () => {
-  mockUseLoadFromEndpointWithData({ messages: [] })
+  mockUseQueryFromEndpointWithData({ messages: [] })
   const { mocked } = jest
   const updateLocalStorageItem = jest.fn()
   const region = new RegionModelBuilder(1).build()[0]!
@@ -39,6 +37,15 @@ describe('ChatContainer', () => {
     fireEvent.click(getByText('common:privacyPolicy'))
     expect(updateLocalStorageItem).toHaveBeenCalledTimes(1)
     expect(updateLocalStorageItem).toHaveBeenCalledWith({ testumgebung: true, augsburg: true })
+  })
+
+  it('should fetch chat messages without caching', () => {
+    const value = { testumgebung: true, augsburg: true }
+    mocked(useLocalStorage<Record<string, boolean>>).mockImplementation(() => ({ value, updateLocalStorageItem }))
+    renderWithTheme(<ChatController chatId='test-id' updateChatId={jest.fn()} region={region} languageCode='de' />)
+    expect(mocked(useQueryFromEndpoint)).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.anything(), {
+      cached: false,
+    })
   })
 
   it('should directly show chat if privacy policy already accepted', () => {

--- a/web/src/components/__tests__/PdfMenuItem.spec.tsx
+++ b/web/src/components/__tests__/PdfMenuItem.spec.tsx
@@ -8,10 +8,6 @@ import { renderWithRouterAndTheme } from '../../testing/render'
 import PdfMenuItem from '../PdfMenuItem'
 
 jest.mock('react-i18next')
-jest.mock('shared/api', () => ({
-  ...jest.requireActual('shared/api'),
-  useLoadFromEndpoint: jest.fn(),
-}))
 
 const rootCategory = new CategoryModel({
   root: true,

--- a/web/src/components/__tests__/SprungbrettOffer.spec.tsx
+++ b/web/src/components/__tests__/SprungbrettOffer.spec.tsx
@@ -1,17 +1,15 @@
 import { RenderResult } from '@testing-library/react'
 import React from 'react'
 
-import { OfferModel, SprungbrettJobModel, useLoadFromEndpoint } from 'shared/api'
-import { mockUseLoadFromEndpointWithError } from 'shared/api/endpoints/testing/mockUseLoadFromEndpoint'
+import { OfferModel, SprungbrettJobModel } from 'shared/api'
 
+import useQueryFromEndpoint from '../../hooks/useQueryFromEndpoint'
+import { mockUseQueryFromEndpointWithError } from '../../testing/mockUseQueryFromEndpoint'
 import { renderWithRouterAndTheme } from '../../testing/render'
 import SprungbrettOffer from '../SprungbrettOffer'
 
-jest.mock('shared/api', () => ({
-  ...jest.requireActual('shared/api'),
-  useLoadFromEndpoint: jest.fn(),
-}))
 jest.mock('react-i18next')
+jest.mock('../../hooks/useQueryFromEndpoint')
 
 describe('SprungbrettOffer', () => {
   beforeEach(() => {
@@ -62,7 +60,7 @@ describe('SprungbrettOffer', () => {
     renderWithRouterAndTheme(<SprungbrettOffer sprungbrettOffer={sprungbrettOffer} />)
 
   it('should render list sprungbrett jobs', () => {
-    mocked(useLoadFromEndpoint).mockImplementation(() => returnValue as never)
+    mocked(useQueryFromEndpoint).mockImplementation(() => returnValue as never)
 
     const { getByText } = renderSprungbrett()
 
@@ -73,7 +71,7 @@ describe('SprungbrettOffer', () => {
 
   it('should render error when loading fails', () => {
     const errorMessage = 'Offers are not available!'
-    mockUseLoadFromEndpointWithError(errorMessage)
+    mockUseQueryFromEndpointWithError(errorMessage)
 
     const { getByText } = renderSprungbrett()
 

--- a/web/src/hooks/__tests__/useLoadSearchDocuments.spec.ts
+++ b/web/src/hooks/__tests__/useLoadSearchDocuments.spec.ts
@@ -7,18 +7,15 @@ import {
   LanguageModelBuilder,
   PoiModelBuilder,
 } from 'shared/api'
-import {
-  mockUseLoadFromEndpointLoading,
-  mockUseLoadFromEndpointOnceWithData,
-  mockUseLoadFromEndpointWithError,
-} from 'shared/api/endpoints/testing/mockUseLoadFromEndpoint'
 
+import {
+  mockUseQueryFromEndpointLoading,
+  mockUseQueryFromEndpointOnceWithData,
+  mockUseQueryFromEndpointWithError,
+} from '../../testing/mockUseQueryFromEndpoint'
 import useLoadSearchDocuments from '../useLoadSearchDocuments'
 
-jest.mock('shared/api', () => ({
-  ...jest.requireActual('shared/api'),
-  useLoadFromEndpoint: jest.fn(),
-}))
+jest.mock('../useQueryFromEndpoint')
 
 describe('useLoadSearchDocuments', () => {
   beforeEach(() => {
@@ -32,9 +29,9 @@ describe('useLoadSearchDocuments', () => {
   const locations = new PoiModelBuilder(3).build()
 
   it('should return the correct results', () => {
-    mockUseLoadFromEndpointOnceWithData(categories)
-    mockUseLoadFromEndpointOnceWithData(events)
-    mockUseLoadFromEndpointOnceWithData(locations)
+    mockUseQueryFromEndpointOnceWithData(categories)
+    mockUseQueryFromEndpointOnceWithData(events)
+    mockUseQueryFromEndpointOnceWithData(locations)
     const { result } = renderHook(() => useLoadSearchDocuments({ regionCode, languageCode, cmsApiBaseUrl: '' }))
     const { data } = result.current
     expect(data).toHaveLength(17)
@@ -45,19 +42,19 @@ describe('useLoadSearchDocuments', () => {
   })
 
   it('should handle loading', () => {
-    mockUseLoadFromEndpointOnceWithData(categories)
-    mockUseLoadFromEndpointLoading({ data: events })
-    mockUseLoadFromEndpointOnceWithData(locations)
+    mockUseQueryFromEndpointOnceWithData(categories)
+    mockUseQueryFromEndpointLoading({ data: events })
+    mockUseQueryFromEndpointOnceWithData(locations)
     const { result } = renderHook(() => useLoadSearchDocuments({ regionCode, languageCode, cmsApiBaseUrl: '' }))
     const { loading } = result.current
     expect(loading).toBe(true)
   })
 
   it('should handle an error', () => {
-    mockUseLoadFromEndpointOnceWithData(categories)
-    mockUseLoadFromEndpointOnceWithData(events)
+    mockUseQueryFromEndpointOnceWithData(categories)
+    mockUseQueryFromEndpointOnceWithData(events)
     const errorMessage = 'no pois found'
-    mockUseLoadFromEndpointWithError(errorMessage)
+    mockUseQueryFromEndpointWithError(errorMessage)
     const { result } = renderHook(() => useLoadSearchDocuments({ regionCode, languageCode, cmsApiBaseUrl: '' }))
     const { error } = result.current
     expect(error).toStrictEqual(new Error(errorMessage))

--- a/web/src/hooks/__tests__/useQueryFromEndpoint.spec.tsx
+++ b/web/src/hooks/__tests__/useQueryFromEndpoint.spec.tsx
@@ -1,0 +1,117 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import React from 'react'
+
+import { loadFromEndpoint } from 'shared/api'
+
+import useQueryFromEndpoint from '../useQueryFromEndpoint'
+
+jest.mock('shared/api', () => ({
+  ...jest.requireActual('shared/api'),
+  loadFromEndpoint: jest.fn(),
+}))
+
+const { mocked } = jest
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+const createEndpoint = jest.fn().mockReturnValue({ stateName: 'test-endpoint' })
+const baseUrl = 'https://example.com'
+const params = { region: 'augsburg', language: 'de' }
+
+describe('useQueryFromEndpoint', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should return data when the endpoint resolves', async () => {
+    const data = { id: 1, title: 'Test' }
+    mocked(loadFromEndpoint).mockResolvedValue(data)
+
+    const { result } = renderHook(() => useQueryFromEndpoint(createEndpoint, baseUrl, params), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.data).toEqual(data))
+    expect(result.current.error).toBeNull()
+    expect(result.current.isPending).toBe(false)
+  })
+
+  it('should return an error when the endpoint rejects', async () => {
+    const error = new Error('fetch failed')
+    mocked(loadFromEndpoint).mockRejectedValue(error)
+
+    const { result } = renderHook(() => useQueryFromEndpoint(createEndpoint, baseUrl, params), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.error).toEqual(error))
+    expect(result.current.data).toBeUndefined()
+  })
+
+  it('should be pending initially', () => {
+    mocked(loadFromEndpoint).mockResolvedValue({})
+
+    const { result } = renderHook(() => useQueryFromEndpoint(createEndpoint, baseUrl, params), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.isPending).toBe(true)
+    expect(result.current.data).toBeUndefined()
+  })
+
+  it('should be immediately stale when cached is false', async () => {
+    const data = { id: 1, title: 'Test' }
+    mocked(loadFromEndpoint).mockResolvedValue(data)
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+
+    const { result } = renderHook(() => useQueryFromEndpoint(createEndpoint, baseUrl, params, { cached: false }), {
+      wrapper,
+    })
+
+    await waitFor(() => expect(result.current.data).toEqual(data))
+    expect(result.current.isStale).toBe(true)
+  })
+
+  it('should use QueryClient staleTime when cached is true', async () => {
+    const data = { id: 1, title: 'Test' }
+    mocked(loadFromEndpoint).mockResolvedValue(data)
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+
+    const { result } = renderHook(() => useQueryFromEndpoint(createEndpoint, baseUrl, params, { cached: true }), {
+      wrapper,
+    })
+
+    await waitFor(() => expect(result.current.data).toEqual(data))
+    expect(result.current.isStale).toBe(false)
+  })
+
+  it('should update cached data when setData is called', async () => {
+    const initialData = { id: 1, title: 'Initial' }
+    const updatedData = { id: 1, title: 'Updated' }
+    mocked(loadFromEndpoint).mockResolvedValue(initialData)
+
+    const { result } = renderHook(() => useQueryFromEndpoint(createEndpoint, baseUrl, params), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.data).toEqual(initialData))
+
+    result.current.setData(updatedData)
+
+    await waitFor(() => expect(result.current.data).toEqual(updatedData))
+  })
+})

--- a/web/src/hooks/__tests__/useUserLocation.spec.tsx
+++ b/web/src/hooks/__tests__/useUserLocation.spec.tsx
@@ -11,7 +11,6 @@ jest.mock('../useUserLocation', () => ({
 
 jest.mock('shared/api', () => ({
   ...jest.requireActual('shared/api'),
-  useLoadFromEndpoint: jest.fn(),
   useLoadAsync: jest.fn(() => ({ data: null, error: null, loading: false, refresh: jest.fn() })),
 }))
 

--- a/web/src/hooks/useLoadSearchDocuments.ts
+++ b/web/src/hooks/useLoadSearchDocuments.ts
@@ -1,13 +1,9 @@
 import { useMemo } from 'react'
 
 import { prepareSearchDocuments } from 'shared'
-import {
-  createCategoriesEndpoint,
-  createEventsEndpoint,
-  createPOIsEndpoint,
-  ExtendedDocumentModel,
-  useLoadFromEndpoint,
-} from 'shared/api'
+import { createCategoriesEndpoint, createEventsEndpoint, createPOIsEndpoint, ExtendedDocumentModel } from 'shared/api'
+
+import useQueryFromEndpoint from './useQueryFromEndpoint'
 
 type UseLoadSearchDocumentsProps = {
   regionCode: string
@@ -28,9 +24,9 @@ const useLoadSearchDocuments = ({
 }: UseLoadSearchDocumentsProps): UseLoadSearchDocumentsReturn => {
   const params = { region: regionCode, language: languageCode }
 
-  const categories = useLoadFromEndpoint(createCategoriesEndpoint, cmsApiBaseUrl, params)
-  const events = useLoadFromEndpoint(createEventsEndpoint, cmsApiBaseUrl, params)
-  const pois = useLoadFromEndpoint(createPOIsEndpoint, cmsApiBaseUrl, params)
+  const categories = useQueryFromEndpoint(createCategoriesEndpoint, cmsApiBaseUrl, params)
+  const events = useQueryFromEndpoint(createEventsEndpoint, cmsApiBaseUrl, params)
+  const pois = useQueryFromEndpoint(createPOIsEndpoint, cmsApiBaseUrl, params)
 
   const documents = useMemo(
     () => prepareSearchDocuments(categories.data, events.data, pois.data),
@@ -39,7 +35,7 @@ const useLoadSearchDocuments = ({
 
   return {
     data: documents,
-    loading: categories.loading || events.loading || pois.loading,
+    loading: categories.isPending || events.isPending || pois.isPending,
     error: categories.error || events.error || pois.error,
   }
 }

--- a/web/src/hooks/useQueryFromEndpoint.ts
+++ b/web/src/hooks/useQueryFromEndpoint.ts
@@ -1,0 +1,34 @@
+import { useQuery, useQueryClient, UseQueryResult } from '@tanstack/react-query'
+
+import { Endpoint, loadFromEndpoint } from 'shared/api'
+
+// staleTime is 5 minutes
+// eslint-disable-next-line no-magic-numbers
+const defaultStaleTime = 5 * 60 * 1000
+
+type UseQueryFromEndpointReturn<T extends object> = UseQueryResult<T> & {
+  setData: (data: T) => void
+}
+
+const useQueryFromEndpoint = <T extends object, P>(
+  createEndpoint: (baseUrl: string) => Endpoint<P, T>,
+  baseUrl: string,
+  params: P,
+  { cached = true }: { cached?: boolean } = {},
+): UseQueryFromEndpointReturn<T> => {
+  const queryClient = useQueryClient()
+
+  const endpoint = createEndpoint(baseUrl)
+  const queryKey = [endpoint.stateName, params]
+
+  return {
+    ...useQuery({
+      queryKey,
+      queryFn: async () => loadFromEndpoint(createEndpoint, baseUrl, params),
+      staleTime: cached ? defaultStaleTime : 0,
+    }),
+    setData: data => queryClient.setQueryData(queryKey, data),
+  }
+}
+
+export default useQueryFromEndpoint

--- a/web/src/routes/CategoriesPage.tsx
+++ b/web/src/routes/CategoriesPage.tsx
@@ -1,5 +1,6 @@
+import { useQuery } from '@tanstack/react-query'
 import { DateTime } from 'luxon'
-import React, { ReactElement, useCallback, useMemo } from 'react'
+import React, { ReactElement, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Navigate, useParams } from 'react-router'
 
@@ -11,8 +12,6 @@ import {
   createCategoryParentsEndpoint,
   NotFoundError,
   ResponseError,
-  useLoadAsync,
-  useLoadFromEndpoint,
 } from 'shared/api'
 
 import { BreadcrumbProps } from '../components/Breadcrumb'
@@ -29,6 +28,7 @@ import SkeletonTiles from '../components/SkeletonTiles'
 import buildConfig from '../constants/buildConfig'
 import { cmsApiBaseUrl } from '../constants/urls'
 import usePreviousProp from '../hooks/usePreviousProp'
+import useQueryFromEndpoint from '../hooks/useQueryFromEndpoint'
 import useTtsPlayer from '../hooks/useTtsPlayer'
 import { RegionRouteProps } from './index'
 
@@ -42,9 +42,9 @@ const useCategoryData = (
 ) => {
   const {
     data: rawCategories,
-    loading: categoriesLoading,
+    isPending: categoriesLoading,
     error: categoriesError,
-  } = useLoadFromEndpoint(createCategoryChildrenEndpoint, cmsApiBaseUrl, {
+  } = useQueryFromEndpoint(createCategoryChildrenEndpoint, cmsApiBaseUrl, {
     region: regionCode,
     language: languageCode,
     // We show tiles for the root category so only first level children are needed
@@ -52,7 +52,7 @@ const useCategoryData = (
     regionContentPath: pathname,
   })
 
-  const requestParents = useCallback(async () => {
+  const loadCategoryParents = async () => {
     if (!categoryId) {
       // The endpoint does not work for the root category, just return an empty array
       return []
@@ -68,9 +68,16 @@ const useCategoryData = (
     }
 
     return data
-  }, [regionCode, languageCode, pathname, categoryId])
+  }
 
-  const { data: parents, loading: parentsLoading, error: parentsError } = useLoadAsync(requestParents)
+  const {
+    data: parents,
+    isPending: parentsLoading,
+    error: parentsError,
+  } = useQuery({
+    queryKey: ['categoryParents', [regionCode, languageCode, pathname, categoryId]],
+    queryFn: loadCategoryParents,
+  })
 
   // The root category is not delivered via our endpoints
   const categories = useMemo(

--- a/web/src/routes/EventsPage.tsx
+++ b/web/src/routes/EventsPage.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from 'react-i18next'
 import { useParams } from 'react-router'
 
 import { EVENTS_ROUTE, pathnameFromRouteInformation, useDateFilter } from 'shared'
-import { createEventsEndpoint, NotFoundError, useLoadFromEndpoint } from 'shared/api'
+import { createEventsEndpoint, NotFoundError } from 'shared/api'
 
 import DatesPageDetail from '../components/DatesPageDetail'
 import EventListItem, { Icon } from '../components/EventListItem'
@@ -25,6 +25,7 @@ import H1 from '../components/base/H1'
 import List from '../components/base/List'
 import { cmsApiBaseUrl } from '../constants/urls'
 import useJsonLd from '../hooks/useJsonLd'
+import useQueryFromEndpoint from '../hooks/useQueryFromEndpoint'
 import useTtsPlayer from '../hooks/useTtsPlayer'
 import createJsonLdEvent from '../utils/createJsonLdEvent'
 import featuredImageToSrcSet from '../utils/featuredImageToSrcSet'
@@ -42,11 +43,11 @@ const EventsPage = ({ region, pathname, languageCode, regionCode }: RegionRouteP
   const { eventId } = useParams()
   const { t } = useTranslation('events')
 
-  const { data: events, error } = useLoadFromEndpoint(createEventsEndpoint, cmsApiBaseUrl, {
+  const { data: events, error } = useQueryFromEndpoint(createEventsEndpoint, cmsApiBaseUrl, {
     region: regionCode,
     language: languageCode,
   })
-  const { startDate, setStartDate, endDate, setEndDate, filteredEvents, startDateError } = useDateFilter(events)
+  const { startDate, setStartDate, endDate, setEndDate, filteredEvents, startDateError } = useDateFilter(events ?? null)
 
   // Support legacy slugs of old recurring events with one event per recurrence
   const pathnameWithoutDate = pathname.split('$')[0]

--- a/web/src/routes/ImprintPage.tsx
+++ b/web/src/routes/ImprintPage.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { IMPRINT_ROUTE, pathnameFromRouteInformation } from 'shared'
-import { createImprintEndpoint, useLoadFromEndpoint } from 'shared/api'
+import { createImprintEndpoint } from 'shared/api'
 
 import FailureSwitcherWithHelmet from '../components/FailureSwitcherWithHelmet'
 import Helmet from '../components/Helmet'
@@ -11,6 +11,7 @@ import RegionContentLayout, { RegionContentLayoutProps } from '../components/Reg
 import RegionContentToolbar from '../components/RegionContentToolbar'
 import SkeletonPage from '../components/SkeletonPage'
 import { cmsApiBaseUrl } from '../constants/urls'
+import useQueryFromEndpoint from '../hooks/useQueryFromEndpoint'
 import { RegionRouteProps } from './index'
 
 const ImprintPage = ({ regionCode, languageCode, region }: RegionRouteProps): ReactElement | null => {
@@ -18,9 +19,9 @@ const ImprintPage = ({ regionCode, languageCode, region }: RegionRouteProps): Re
 
   const {
     data: imprint,
-    loading,
-    error: imprintError,
-  } = useLoadFromEndpoint(createImprintEndpoint, cmsApiBaseUrl, {
+    isPending,
+    error,
+  } = useQueryFromEndpoint(createImprintEndpoint, cmsApiBaseUrl, {
     region: regionCode,
     language: languageCode,
   })
@@ -43,16 +44,7 @@ const ImprintPage = ({ regionCode, languageCode, region }: RegionRouteProps): Re
     Toolbar: <RegionContentToolbar slug={imprint?.slug} />,
   }
 
-  if (loading) {
-    return (
-      <RegionContentLayout isLoading {...locationLayoutParams}>
-        <SkeletonPage />
-      </RegionContentLayout>
-    )
-  }
-
-  if (!imprint) {
-    const error = imprintError || new Error('Imprint should not be null!')
+  if (error) {
     return (
       <RegionContentLayout isLoading {...locationLayoutParams}>
         <FailureSwitcherWithHelmet error={error} />
@@ -61,9 +53,13 @@ const ImprintPage = ({ regionCode, languageCode, region }: RegionRouteProps): Re
   }
 
   return (
-    <RegionContentLayout isLoading={false} {...locationLayoutParams}>
+    <RegionContentLayout isLoading={isPending} {...locationLayoutParams}>
       <Helmet pageTitle={pageTitle} languageChangePaths={languageChangePaths} regionModel={region} />
-      <Page lastUpdate={imprint.lastUpdate} title={imprint.title} content={imprint.content} />
+      {imprint ? (
+        <Page lastUpdate={imprint.lastUpdate} title={imprint.title} content={imprint.content} />
+      ) : (
+        <SkeletonPage />
+      )}
     </RegionContentLayout>
   )
 }

--- a/web/src/routes/LocalNewsPage.tsx
+++ b/web/src/routes/LocalNewsPage.tsx
@@ -9,7 +9,7 @@ import {
   pathnameFromRouteInformation,
   replaceLinks,
 } from 'shared'
-import { createLocalNewsEndpoint, LocalNewsModel, NotFoundError, useLoadFromEndpoint } from 'shared/api'
+import { createLocalNewsEndpoint, LocalNewsModel, NotFoundError } from 'shared/api'
 
 import FailureSwitcherWithHelmet from '../components/FailureSwitcherWithHelmet'
 import Helmet from '../components/Helmet'
@@ -22,6 +22,7 @@ import SkeletonList from '../components/SkeletonList'
 import SkeletonPage from '../components/SkeletonPage'
 import List from '../components/base/List'
 import { cmsApiBaseUrl } from '../constants/urls'
+import useQueryFromEndpoint from '../hooks/useQueryFromEndpoint'
 import useTtsPlayer from '../hooks/useTtsPlayer'
 import { RegionRouteProps } from './index'
 
@@ -31,9 +32,9 @@ const LocalNewsPage = ({ region, pathname, languageCode, regionCode }: RegionRou
 
   const {
     data: localNews,
-    loading,
+    isPending,
     error: newsError,
-  } = useLoadFromEndpoint(createLocalNewsEndpoint, cmsApiBaseUrl, { region: regionCode, language: languageCode })
+  } = useQueryFromEndpoint(createLocalNewsEndpoint, cmsApiBaseUrl, { region: regionCode, language: languageCode })
 
   const newsModel = newsId ? localNews?.find((it: LocalNewsModel) => it.id.toString() === newsId) : undefined
   useTtsPlayer(newsModel, languageCode)
@@ -129,7 +130,7 @@ const LocalNewsPage = ({ region, pathname, languageCode, regionCode }: RegionRou
         localNewsEnabled={region.localNewsEnabled}
         language={languageCode}
       />
-      {loading ? <SkeletonList /> : <List items={NewsListItems ?? []} NoItemsMessage='news:currentlyNoNews' />}
+      {isPending ? <SkeletonList /> : <List items={NewsListItems ?? []} NoItemsMessage='news:currentlyNoNews' />}
     </RegionContentLayout>
   )
 }

--- a/web/src/routes/PoisPage.tsx
+++ b/web/src/routes/PoisPage.tsx
@@ -3,13 +3,14 @@ import { useTranslation } from 'react-i18next'
 import { useParams } from 'react-router'
 
 import { normalizePath, pathnameFromRouteInformation, POIS_ROUTE } from 'shared'
-import { useLoadFromEndpoint, createPOIsEndpoint } from 'shared/api'
+import { createPOIsEndpoint } from 'shared/api'
 
 import FailureSwitcherWithHelmet from '../components/FailureSwitcherWithHelmet'
 import Helmet from '../components/Helmet'
 import Pois from '../components/Pois'
 import RegionContentLayout, { RegionContentLayoutProps } from '../components/RegionContentLayout'
 import { cmsApiBaseUrl } from '../constants/urls'
+import useQueryFromEndpoint from '../hooks/useQueryFromEndpoint'
 import useTtsPlayer from '../hooks/useTtsPlayer'
 import useUserLocation from '../hooks/useUserLocation'
 import { RegionRouteProps } from './index'
@@ -20,7 +21,7 @@ const PoisPage = ({ regionCode, languageCode, region, pathname }: RegionRoutePro
   const { t } = useTranslation('pois')
   const { data: userLocation } = useUserLocation()
 
-  const { data, loading, error } = useLoadFromEndpoint(createPOIsEndpoint, cmsApiBaseUrl, {
+  const { data, isPending, error } = useQueryFromEndpoint(createPOIsEndpoint, cmsApiBaseUrl, {
     region: regionCode,
     language: languageCode,
   })
@@ -73,7 +74,7 @@ const PoisPage = ({ regionCode, languageCode, region, pathname }: RegionRoutePro
         languageChangePaths={languageChangePaths}
         regionModel={region}
       />
-      <Pois loading={loading} pois={data ?? []} userLocation={userLocation} region={region} />
+      <Pois loading={isPending} pois={data ?? []} userLocation={userLocation} region={region} />
     </RegionContentLayout>
   )
 }

--- a/web/src/routes/RegionsPage.tsx
+++ b/web/src/routes/RegionsPage.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { createRegionsEndpoint, useLoadFromEndpoint } from 'shared/api'
+import { createRegionsEndpoint } from 'shared/api'
 
 import FailureSwitcherWithHelmet from '../components/FailureSwitcherWithHelmet'
 import Footer from '../components/Footer'
@@ -12,13 +12,14 @@ import RegionSelector from '../components/RegionSelector'
 import SuggestToRegionFooter from '../components/SuggestToRegionFooter'
 import buildConfig from '../constants/buildConfig'
 import { cmsApiBaseUrl } from '../constants/urls'
+import useQueryFromEndpoint from '../hooks/useQueryFromEndpoint'
 
 type RegionsPageProps = {
   languageCode: string
 }
 
 const RegionsPage = ({ languageCode }: RegionsPageProps): ReactElement => {
-  const { data: regions, loading, error } = useLoadFromEndpoint(createRegionsEndpoint, cmsApiBaseUrl, undefined)
+  const { data: regions, isPending, error } = useQueryFromEndpoint(createRegionsEndpoint, cmsApiBaseUrl, undefined)
   const [stickyTop, setStickyTop] = useState<number>(0)
   const { t } = useTranslation('regions')
 
@@ -43,7 +44,7 @@ const RegionsPage = ({ languageCode }: RegionsPageProps): ReactElement => {
         </>
       }>
       <Helmet pageTitle={pageTitle} metaDescription={metaDescription} rootPage />
-      <RegionSelector regions={regions ?? []} language={languageCode} stickyTop={stickyTop} loading={loading} />
+      <RegionSelector regions={regions ?? []} language={languageCode} stickyTop={stickyTop} loading={isPending} />
     </Layout>
   )
 }

--- a/web/src/routes/TuNewsDetailPage.tsx
+++ b/web/src/routes/TuNewsDetailPage.tsx
@@ -4,7 +4,7 @@ import React, { ReactElement } from 'react'
 import { useParams } from 'react-router'
 
 import { TU_NEWS_TYPE, tunewsLabel } from 'shared'
-import { createTunewsElementEndpoint, NotFoundError, useLoadFromEndpoint } from 'shared/api'
+import { createTunewsElementEndpoint, NotFoundError } from 'shared/api'
 
 import { TuNewsActiveIcon } from '../assets'
 import FailureSwitcherWithHelmet from '../components/FailureSwitcherWithHelmet'
@@ -15,6 +15,7 @@ import RegionContentToolbar from '../components/RegionContentToolbar'
 import SkeletonPage from '../components/SkeletonPage'
 import Svg from '../components/base/Svg'
 import { tunewsApiBaseUrl } from '../constants/urls'
+import useQueryFromEndpoint from '../hooks/useQueryFromEndpoint'
 import useTtsPlayer from '../hooks/useTtsPlayer'
 import { RegionRouteProps } from './index'
 
@@ -37,7 +38,7 @@ const TuNewsDetailPage = ({ region, pathname, regionCode, languageCode }: Region
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const newsId = useParams().newsId!
 
-  const { data: newsModel, error: newsError } = useLoadFromEndpoint(createTunewsElementEndpoint, tunewsApiBaseUrl, {
+  const { data: newsModel, error: newsError } = useQueryFromEndpoint(createTunewsElementEndpoint, tunewsApiBaseUrl, {
     id: parseInt(newsId, 10),
   })
 

--- a/web/src/routes/TuNewsPage.tsx
+++ b/web/src/routes/TuNewsPage.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, useCallback } from 'react'
 
 import { NEWS_ROUTE, pathnameFromRouteInformation, TU_NEWS_TYPE, tunewsLabel } from 'shared'
-import { createTunewsEndpoint, createTunewsLanguagesEndpoint, TunewsModel, useLoadFromEndpoint } from 'shared/api'
+import { createTunewsEndpoint, createTunewsLanguagesEndpoint, TunewsModel } from 'shared/api'
 
 import FailureSwitcherWithHelmet from '../components/FailureSwitcherWithHelmet'
 import Helmet from '../components/Helmet'
@@ -13,13 +13,14 @@ import RegionContentLayout, { RegionContentLayoutProps } from '../components/Reg
 import RegionContentToolbar from '../components/RegionContentToolbar'
 import SkeletonList from '../components/SkeletonList'
 import { tunewsApiBaseUrl } from '../constants/urls'
+import useQueryFromEndpoint from '../hooks/useQueryFromEndpoint'
 import { RegionRouteProps } from './index'
 
 const DEFAULT_PAGE = 1
 const DEFAULT_COUNT = 10
 
 const TuNewsPage = ({ regionCode, languageCode, region }: RegionRouteProps): ReactElement | null => {
-  const { data: tuNewsLanguages, error } = useLoadFromEndpoint(
+  const { data: tuNewsLanguages, error } = useQueryFromEndpoint(
     createTunewsLanguagesEndpoint,
     tunewsApiBaseUrl,
     undefined,

--- a/web/src/routes/__tests__/ImprintPage.spec.tsx
+++ b/web/src/routes/__tests__/ImprintPage.spec.tsx
@@ -3,17 +3,13 @@ import React from 'react'
 
 import { IMPRINT_ROUTE, pathnameFromRouteInformation } from 'shared'
 import { RegionModelBuilder, DocumentModel } from 'shared/api'
-import { mockUseLoadFromEndpointOnceWithData } from 'shared/api/endpoints/testing/mockUseLoadFromEndpoint'
 
+import { mockUseQueryFromEndpointOnceWithData } from '../../testing/mockUseQueryFromEndpoint'
 import { renderRoute } from '../../testing/render'
 import ImprintPage from '../ImprintPage'
 import { RoutePatterns } from '../index'
 
-jest.mock('shared/api', () => ({
-  ...jest.requireActual('shared/api'),
-  useLoadFromEndpoint: jest.fn(),
-}))
-
+jest.mock('../../hooks/useQueryFromEndpoint')
 jest.mock('react-i18next')
 
 describe('ImprintPage', () => {
@@ -40,7 +36,7 @@ describe('ImprintPage', () => {
   const routePattern = `/:regionCode/:languageCode/${RoutePatterns[IMPRINT_ROUTE]}`
 
   const renderImprintPage = () => {
-    mockUseLoadFromEndpointOnceWithData(imprint)
+    mockUseQueryFromEndpointOnceWithData(imprint)
     return renderRoute(
       <ImprintPage region={region} languageCode={languageCode} regionCode={region.code} pathname={pathname} />,
       { pathname, routePattern },

--- a/web/src/routes/__tests__/MainImprintPage.spec.tsx
+++ b/web/src/routes/__tests__/MainImprintPage.spec.tsx
@@ -4,10 +4,6 @@ import { renderWithRouterAndTheme } from '../../testing/render'
 import MainImprintPage from '../MainImprintPage'
 
 jest.mock('react-i18next')
-jest.mock('shared/api', () => ({
-  ...jest.requireActual('shared/api'),
-  useLoadFromEndpoint: jest.fn(() => ({ data: null, error: null, loading: false, refresh: jest.fn() })),
-}))
 
 describe('MainImprintPage', () => {
   const languageCode = 'de'

--- a/web/src/routes/__tests__/PoisPage.spec.tsx
+++ b/web/src/routes/__tests__/PoisPage.spec.tsx
@@ -4,21 +4,21 @@ import { Route, Routes } from 'react-router'
 
 import { regionContentPath, POIS_ROUTE } from 'shared'
 import { RegionModelBuilder, PoiModelBuilder } from 'shared/api'
-import {
-  mockUseLoadFromEndpointWithData,
-  mockUseLoadFromEndpointWithError,
-} from 'shared/api/endpoints/testing/mockUseLoadFromEndpoint'
 
+import {
+  mockUseQueryFromEndpointWithData,
+  mockUseQueryFromEndpointWithError,
+} from '../../testing/mockUseQueryFromEndpoint'
 import { renderWithRouterAndTheme } from '../../testing/render'
 import PoisPage from '../PoisPage'
 import { RoutePatterns } from '../index'
 
 jest.mock('maplibre-gl')
 jest.mock('react-i18next')
+jest.mock('../../hooks/useQueryFromEndpoint')
 
 jest.mock('shared/api', () => ({
   ...jest.requireActual('shared/api'),
-  useLoadFromEndpoint: jest.fn(),
   useLoadAsync: jest.fn(() => ({ data: [10.8, 48.3] })),
 }))
 
@@ -55,20 +55,20 @@ describe('PoisPage', () => {
     )
 
   it('should render a list with all pois', () => {
-    mockUseLoadFromEndpointWithData(pois)
+    mockUseQueryFromEndpointWithData(pois)
     const { getByText } = renderPois()
     expect(getByText(poi0.title)).toBeTruthy()
     expect(getByText(poi1.title)).toBeTruthy()
   })
 
   it('should render an error', () => {
-    mockUseLoadFromEndpointWithError('something went wrong')
+    mockUseQueryFromEndpointWithError('something went wrong')
     const { getByText } = renderPois()
     expect(getByText('error:unknownError')).toBeTruthy()
   })
 
   it('should render poi details page when list item was clicked', () => {
-    mockUseLoadFromEndpointWithData(pois)
+    mockUseQueryFromEndpointWithData(pois)
     const { getByText, getByRole } = renderPois()
     fireEvent.click(getByRole('link', { name: poi0.title }))
     expect(getByText(poi0.title)).toBeTruthy()
@@ -77,7 +77,7 @@ describe('PoisPage', () => {
   })
 
   it('should calculate correct language change paths', () => {
-    mockUseLoadFromEndpointWithData(pois)
+    mockUseQueryFromEndpointWithData(pois)
     const { getAllByText, getByRole } = renderPois('/locations/test')
     fireEvent.click(getByRole('button', { name: 'layout:changeLanguage' }))
 

--- a/web/src/routes/__tests__/TuNewsPage.spec.tsx
+++ b/web/src/routes/__tests__/TuNewsPage.spec.tsx
@@ -2,20 +2,16 @@ import React from 'react'
 
 import { NEWS_ROUTE, pathnameFromRouteInformation, TU_NEWS_TYPE } from 'shared'
 import { RegionModelBuilder, LanguageModelBuilder } from 'shared/api'
-import {
-  mockUseLoadFromEndpointWithData,
-  mockUseLoadFromEndpointWithError,
-} from 'shared/api/endpoints/testing/mockUseLoadFromEndpoint'
 
+import {
+  mockUseQueryFromEndpointWithData,
+  mockUseQueryFromEndpointWithError,
+} from '../../testing/mockUseQueryFromEndpoint'
 import { renderRoute } from '../../testing/render'
 import TuNewsPage from '../TuNewsPage'
 import { RoutePatterns, TU_NEWS_ROUTE } from '../index'
 
-jest.mock('shared/api', () => ({
-  ...jest.requireActual('shared/api'),
-  loadFromEndpoint: jest.fn(),
-  useLoadFromEndpoint: jest.fn(),
-}))
+jest.mock('../../hooks/useQueryFromEndpoint')
 jest.mock('react-i18next')
 jest.mock('../../components/InfiniteScrollList', () => () => 'List')
 jest.mock('../../components/RegionContentHeader', () => () => null)
@@ -48,13 +44,13 @@ describe('TuNewsPage', () => {
     )
 
   it('should render error if loading languages fails', () => {
-    mockUseLoadFromEndpointWithError('my lang error')
+    mockUseQueryFromEndpointWithError('my lang error')
     const { getByText } = renderTuNewsRoute(language)
     expect(getByText('error:unknownError')).toBeTruthy()
   })
 
   it('should render language failure if language is not available', () => {
-    mockUseLoadFromEndpointWithData(tuNewsLanguages)
+    mockUseQueryFromEndpointWithData(tuNewsLanguages)
     const { getAllByText, getByRole } = renderTuNewsRoute(region.languages[2]!)
     expect(getAllByText('error:notFound.language')).toBeTruthy()
     // Available languages
@@ -70,7 +66,7 @@ describe('TuNewsPage', () => {
   })
 
   it('should render list', () => {
-    mockUseLoadFromEndpointWithData(tuNewsLanguages)
+    mockUseQueryFromEndpointWithData(tuNewsLanguages)
     const { getByText } = renderTuNewsRoute()
     expect(getByText('List')).toBeTruthy()
   })

--- a/web/src/testing/mockUseQueryFromEndpoint.ts
+++ b/web/src/testing/mockUseQueryFromEndpoint.ts
@@ -1,0 +1,21 @@
+import useQueryFromEndpoint from '../hooks/useQueryFromEndpoint'
+
+const { mocked } = jest
+
+export const mockUseQueryFromEndpointWithData = <T>(data: T): void => {
+  mocked(useQueryFromEndpoint).mockImplementation(() => ({ data, error: null, isPending: false }) as never)
+}
+
+export const mockUseQueryFromEndpointOnceWithData = <T>(data: T): void => {
+  mocked(useQueryFromEndpoint).mockImplementationOnce(() => ({ data, error: null, isPending: false }) as never)
+}
+
+export const mockUseQueryFromEndpointWithError = (error: string): void => {
+  mocked(useQueryFromEndpoint).mockImplementation(
+    () => ({ data: undefined, error: new Error(error), isPending: false }) as never,
+  )
+}
+
+export const mockUseQueryFromEndpointLoading = <T>({ data }: { data?: T } = {}): void => {
+  mocked(useQueryFromEndpoint).mockImplementationOnce(() => ({ data, error: null, isPending: true }) as never)
+}

--- a/web/src/testing/render.tsx
+++ b/web/src/testing/render.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, RenderResult } from '@testing-library/react'
 import React, { ReactElement, ReactNode } from 'react'
 import { createMemoryRouter, MemoryRouter, Route, RouterProvider, Routes } from 'react-router'
@@ -6,16 +7,22 @@ import ThemeContainer from '../components/ThemeContainer'
 import { regionContentPattern, RoutePatterns, RouteType } from '../routes'
 
 const AllTheProviders = ({ children, options }: { children: ReactNode; options?: { pathname: string } }) => (
-  <MemoryRouter initialEntries={options ? [options.pathname] : ['/']}>
-    <ThemeContainer contentDirection='ltr'>{children}</ThemeContainer>
-  </MemoryRouter>
+  <QueryClientProvider client={new QueryClient()}>
+    <MemoryRouter initialEntries={options ? [options.pathname] : ['/']}>
+      <ThemeContainer contentDirection='ltr'>{children}</ThemeContainer>
+    </MemoryRouter>
+  </QueryClientProvider>
 )
 
 export const renderWithRouterAndTheme = (ui: ReactElement, options?: { pathname: string }): RenderResult =>
   render(ui, { wrapper: (props: { children: ReactNode }) => <AllTheProviders {...props} options={options} /> })
 
 export const renderWithTheme = (ui: ReactElement): RenderResult =>
-  render(<ThemeContainer contentDirection='ltr'>{ui}</ThemeContainer>)
+  render(
+    <QueryClientProvider client={new QueryClient()}>
+      <ThemeContainer contentDirection='ltr'>{ui}</ThemeContainer>
+    </QueryClientProvider>,
+  )
 
 export const renderWithRouter = (ui: ReactElement): RenderResult =>
   render(ui, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6683,6 +6683,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tanstack/query-core@npm:5.100.10":
+  version: 5.100.10
+  resolution: "@tanstack/query-core@npm:5.100.10"
+  checksum: 10c0/fd220485b8223d44877324b0229a7d664c5840f3daf177c4a76e67d1d0be1a78a908b0649b3e275b9cfa7a31250c0770688cc37bb439a90c5b1d7a07974d8828
+  languageName: node
+  linkType: hard
+
+"@tanstack/react-query@npm:^5.100.10":
+  version: 5.100.10
+  resolution: "@tanstack/react-query@npm:5.100.10"
+  dependencies:
+    "@tanstack/query-core": "npm:5.100.10"
+  peerDependencies:
+    react: ^18 || ^19
+  checksum: 10c0/d25e67e78b28463a6db9d48027e194891365e3f21c5278f83f71af6c683951b979853b755388c0eca9e4510bd24c8a59e5d7920c2d7a42bd293bddd2900f901b
+  languageName: node
+  linkType: hard
+
 "@testing-library/dom@npm:^10.4.1":
   version: 10.4.1
   resolution: "@testing-library/dom@npm:10.4.1"
@@ -23926,6 +23944,7 @@ __metadata:
     "@pmmmwh/react-refresh-webpack-plugin": "npm:^0.6.2"
     "@sentry/react": "npm:^10.46.0"
     "@sentry/types": "npm:^10.46.0"
+    "@tanstack/react-query": "npm:^5.100.10"
     "@testing-library/dom": "npm:^10.4.1"
     "@testing-library/jest-dom": "npm:6.9.1"
     "@testing-library/react": "npm:^16.3.2"


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
<!-- Make sure to correctly set PR labels if necessary: `Native`/`Web` for native/web only PRs and `maintenance` for non-user-facing changes. -->
Add caching for web requests to reduce loading times and network traffic.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Add `useQueryFromEndpoint` hook and replace `useLoadFromEndpoint` usages in web
- Use `@tanstack/react-query` for caching
- Keep native as it is

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Check web and all changed endpoints. Verify that caching works and loading times are reduced.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2691

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
