### PR TITLE
4124: Fix licenses for web

### DIFF
--- a/build-configs/package.json
+++ b/build-configs/package.json
@@ -9,7 +9,6 @@
   },
   "devDependencies": {
     "@types/flat": "^5.0.5",
-    "commander": "^14.0.3",
     "csstype": "^3.2.3",
     "decamelize": "^5.0.1",
     "flat": "^5.0.2"

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -285,6 +285,7 @@ export default defineConfig([
 
     rules: {
       'no-console': 'off',
+      'no-param-reassign': 'off',
       'import-x/no-extraneous-dependencies': 'off',
     },
   },

--- a/native/package.json
+++ b/native/package.json
@@ -38,8 +38,7 @@
     "prettier:check": "yarn run -T prettier --ignore-path  ../.prettierignore --check .",
     "prettier:write": "yarn run -T prettier --ignore-path  ../.prettierignore --write .",
     "circleci:update-config": "yarn run -T circleci:update-config",
-    "license-crawler": "license-checker-rseidelsohn --excludePrivatePackages --production --json --out src/assets/licenses.json",
-    "postinstall": "yarn license-crawler"
+    "postinstall": "yarn run -T tsx ../tools/licenses.ts"
   },
   "dependencies": {
     "@dr.pogodin/react-native-fs": "^2.37.0",
@@ -120,7 +119,6 @@
     "babel-jest": "^30.3.0",
     "commander": "^14.0.3",
     "cross-env": "^10.1.0",
-    "license-checker-rseidelsohn": "^4.4.2",
     "react-native-svg-transformer": "^1.5.3",
     "react-test-renderer": "19.2.3"
   },

--- a/native/src/routes/Licenses.tsx
+++ b/native/src/routes/Licenses.tsx
@@ -15,13 +15,13 @@ import openExternalUrl from '../utils/openExternalUrl'
 type LicenseItemProps = {
   name: string
   version: string | undefined
-  publisher: string | undefined
+  author: string | undefined
   license: string
   onPress: () => void
 }
 
 const LicenseItem = (props: LicenseItemProps): ReactElement => {
-  const { name, version, license, publisher, onPress } = props
+  const { name, version, license, author, onPress } = props
   const { t } = useTranslation('licenses')
   const theme = useTheme()
 
@@ -42,7 +42,7 @@ const LicenseItem = (props: LicenseItemProps): ReactElement => {
       <View>
         <Text variant='body1'>{name}</Text>
         <Text variant='body2' style={styles.description}>
-          {publisher}
+          {author}
         </Text>
         <Text variant='body2' style={styles.description}>
           {t('version')} {version}
@@ -63,18 +63,9 @@ const Licenses = (): ReactElement => {
   const showSnackbar = useSnackbar()
 
   const renderItem = ({ item }: { item: License }) => {
-    const { licenses, name, repository, version, publisher } = item
+    const { license, name, repository, version, author } = item
     const openLink = () => (repository ? openExternalUrl(repository, showSnackbar) : undefined)
-    return (
-      <LicenseItem
-        key={name}
-        name={name}
-        publisher={publisher}
-        version={version}
-        license={licenses}
-        onPress={openLink}
-      />
-    )
+    return <LicenseItem key={name} name={name} author={author} version={version} license={license} onPress={openLink} />
   }
 
   return (

--- a/native/src/routes/Licenses.tsx
+++ b/native/src/routes/Licenses.tsx
@@ -1,16 +1,16 @@
-import React, { ReactElement, useEffect, useState } from 'react'
+import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 import { FlatList, StyleSheet, View } from 'react-native'
 import { TouchableRipple, useTheme } from 'react-native-paper'
 
 import { License, parseLicenses } from 'shared'
+import { useLoadAsync } from 'shared/api'
 
 import Caption from '../components/Caption'
 import Layout from '../components/Layout'
 import Text from '../components/base/Text'
 import useSnackbar from '../hooks/useSnackbar'
 import openExternalUrl from '../utils/openExternalUrl'
-import { reportError } from '../utils/sentry'
 
 type LicenseItemProps = {
   name: string
@@ -55,17 +55,13 @@ const LicenseItem = (props: LicenseItemProps): ReactElement => {
   )
 }
 
+const loadLicenses = async () => parseLicenses((await import('../assets/licenses.json')).default)
+
 const Licenses = (): ReactElement => {
-  const [licenses, setLicenses] = useState<License[] | null>(null)
+  const { data: licenses } = useLoadAsync(loadLicenses)
+  const { t } = useTranslation('settings')
   const showSnackbar = useSnackbar()
 
-  useEffect(() => {
-    import('../assets/licenses.json')
-      .then(licenseFile => setLicenses(parseLicenses(licenseFile.default)))
-      .catch(error => reportError(`error while importing licenses ${error}`))
-  }, [])
-
-  const { t } = useTranslation('settings')
   const renderItem = ({ item }: { item: License }) => {
     const { licenses, name, repository, version, publisher } = item
     const openLink = () => (repository ? openExternalUrl(repository, showSnackbar) : undefined)

--- a/native/src/routes/__tests__/Licenses.spec.tsx
+++ b/native/src/routes/__tests__/Licenses.spec.tsx
@@ -1,0 +1,80 @@
+import { fireEvent } from '@testing-library/react-native'
+import React from 'react'
+
+import { useLoadAsync } from 'shared/api'
+
+import render from '../../testing/render'
+import Licenses from '../Licenses'
+
+jest.mock('shared/api', () => ({
+  ...jest.requireActual('shared/api'),
+  useLoadAsync: jest.fn(),
+}))
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+jest.mock('../../hooks/useSnackbar', () => ({ __esModule: true, default: () => jest.fn() }))
+jest.mock('../../utils/openExternalUrl', () => ({ __esModule: true, default: jest.fn() }))
+
+const { mocked } = jest
+
+const mockUseLoadAsync = (data: unknown) =>
+  mocked(useLoadAsync).mockReturnValue({
+    data,
+    error: null,
+    loading: false,
+    refresh: jest.fn(),
+    setData: jest.fn(),
+  } as never)
+
+describe('Licenses', () => {
+  beforeEach(jest.clearAllMocks)
+
+  it('should render the page title', () => {
+    mockUseLoadAsync([])
+    const { getByText } = render(<Licenses />)
+    expect(getByText('openSourceLicenses')).toBeTruthy()
+  })
+
+  it('should render license items', () => {
+    mockUseLoadAsync([
+      {
+        name: 'react',
+        version: '18.2.0',
+        license: 'MIT',
+        repository: 'https://github.com/facebook/react',
+        author: 'Meta',
+      },
+      { name: 'lodash', version: '4.17.21', license: 'MIT', repository: undefined, author: undefined },
+    ])
+    const { getByText } = render(<Licenses />)
+    expect(getByText('react')).toBeTruthy()
+    expect(getByText('lodash')).toBeTruthy()
+  })
+
+  it('should open repository url when pressing a license item with a repository', () => {
+    const openExternalUrl = jest.mocked(require('../../utils/openExternalUrl').default)
+    mockUseLoadAsync([
+      {
+        name: 'react',
+        version: '18.2.0',
+        license: 'MIT',
+        repository: 'https://github.com/facebook/react',
+        author: 'Meta',
+      },
+    ])
+    const { getAllByRole } = render(<Licenses />)
+    fireEvent.press(getAllByRole('link')[0]!)
+    expect(openExternalUrl).toHaveBeenCalledWith('https://github.com/facebook/react', expect.any(Function))
+  })
+
+  it('should not open url when repository is not provided', () => {
+    const openExternalUrl = jest.mocked(require('../../utils/openExternalUrl').default)
+    mockUseLoadAsync([{ name: 'some-lib', version: '1.0.0', license: 'MIT', repository: undefined, author: undefined }])
+    const { getAllByRole } = render(<Licenses />)
+    fireEvent.press(getAllByRole('link')[0]!)
+    expect(openExternalUrl).not.toHaveBeenCalled()
+  })
+})

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@typescript-eslint/eslint-plugin": "^8.57.2",
     "@typescript-eslint/parser": "^8.57.2",
     "app-toolbelt": "github:digitalfabrik/app-toolbelt#semver:1.0.0",
+    "commander": "^14.0.3",
     "eslint": "^9.39.4",
     "eslint-config-airbnb-extended": "^3.0.1",
     "eslint-config-prettier": "^10.1.8",

--- a/shared/utils/__tests__/licences.spec.ts
+++ b/shared/utils/__tests__/licences.spec.ts
@@ -1,0 +1,44 @@
+import { parseLicenses } from '../licences'
+
+describe('parseLicenses', () => {
+  it('should return empty array for empty input', () => {
+    expect(parseLicenses({})).toEqual([])
+  })
+
+  it('should parse name, version, license, repository and author', () => {
+    expect(
+      parseLicenses({
+        'react@18.2.0': { license: 'MIT', repository: 'https://github.com/facebook/react', author: 'Meta' },
+      }),
+    ).toEqual([
+      {
+        name: 'react',
+        version: '18.2.0',
+        license: 'MIT',
+        repository: 'https://github.com/facebook/react',
+        author: 'Meta',
+      },
+    ])
+  })
+
+  it('should handle missing optional fields', () => {
+    expect(parseLicenses({ 'some-lib@1.0.0': { license: 'Apache-2.0' } })).toEqual([
+      { name: 'some-lib', version: '1.0.0', license: 'Apache-2.0', repository: undefined, author: undefined },
+    ])
+  })
+
+  it('should handle scoped packages', () => {
+    expect(parseLicenses({ '@emotion/react@11.10.5': { license: 'MIT' } })).toEqual([
+      { name: '@emotion/react', version: '11.10.5', license: 'MIT', repository: undefined, author: undefined },
+    ])
+  })
+
+  it('should parse multiple licenses', () => {
+    const result = parseLicenses({
+      'react@18.2.0': { license: 'MIT' },
+      'lodash@4.17.21': { license: 'MIT' },
+    })
+    expect(result).toHaveLength(2)
+    expect(result.map(l => l.name)).toEqual(['react', 'lodash'])
+  })
+})

--- a/shared/utils/licences.ts
+++ b/shared/utils/licences.ts
@@ -1,17 +1,17 @@
 export type JsonLicenses = {
   [name: string]: {
-    licenses: string
+    license: string
     repository?: string
-    publisher?: string
+    author?: string
   }
 }
 
 export type License = {
   name: string
   version: string | undefined
-  licenses: string
+  license: string
   repository: string | undefined
-  publisher: string | undefined
+  author: string | undefined
 }
 
 // matches version number e.g. 1.0.2
@@ -21,8 +21,8 @@ const versionNumberRegex = /\d+(\.\d+)*/
 const versionRegex = /(?:@)\d+(\.\d+)*/
 
 export const parseLicenses = (licenseFile: JsonLicenses): License[] =>
-  Object.entries(licenseFile).map(([name, { licenses, repository, publisher }]) => {
+  Object.entries(licenseFile).map(([name, { license, repository, author }]) => {
     const version = name.match(versionNumberRegex)?.[0] ?? ''
     const nameWithoutVersion = name.replace(versionRegex, '')
-    return { name: nameWithoutVersion, version, repository, licenses, publisher }
+    return { name: nameWithoutVersion, version, repository, license, author }
   })

--- a/tools/licenses.ts
+++ b/tools/licenses.ts
@@ -16,9 +16,9 @@ type PackageJson = {
 }
 
 type LicenseEntry = {
-  licenses: string
+  license: string
   repository?: string
-  publisher?: string
+  author?: string
 }
 
 const readPackageJson = (pkgDir: string): PackageJson | null => {
@@ -82,7 +82,7 @@ export default program
 
         const repo = typeof pkg.repository === 'string' ? pkg.repository : pkg.repository?.url
         // Convert git to https urls
-        const repoUrl = repo
+        const repository = repo
           ?.replace(/^git\+/, '')
           .replace(/\.git$/, '')
           .replace(/^git:\/\//, 'https://')
@@ -95,9 +95,9 @@ export default program
           .trim()
 
         licenses[key] = {
-          licenses: pkg.license ?? 'UNKNOWN',
-          repository: repoUrl,
-          publisher: author,
+          license: pkg.license ?? 'UNKNOWN',
+          repository,
+          author,
         }
         return licenses
       }, {})

--- a/tools/licenses.ts
+++ b/tools/licenses.ts
@@ -1,0 +1,108 @@
+#!/usr/bin/env tsx
+// Generates src/assets/licenses.json for Yarn v4 workspaces where web deps are hoisted to root.
+// license-checker-rseidelsohn --production is broken in this setup because it relies on local node_modules.
+import { program } from 'commander'
+import fs from 'node:fs'
+import path from 'node:path'
+
+type PackageJson = {
+  name?: string
+  version?: string
+  private?: boolean
+  license?: string
+  dependencies?: Record<string, string>
+  repository?: string | { url: string }
+  author?: string | { name: string }
+}
+
+type LicenseEntry = {
+  licenses: string
+  repository?: string
+  publisher?: string
+}
+
+const readPackageJson = (pkgDir: string): PackageJson | null => {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(pkgDir, 'package.json'), 'utf8')) as PackageJson
+  } catch {
+    return null
+  }
+}
+
+const collectDependencies = (pkgName: string, pkgDir: string, dependencies: Set<string>): Set<string> => {
+  if (dependencies.has(pkgName)) {
+    return dependencies
+  }
+  dependencies.add(pkgName)
+
+  const pkg = readPackageJson(path.join(pkgDir, pkgName))
+  if (!pkg) {
+    return dependencies
+  }
+
+  Object.keys(pkg.dependencies ?? {}).forEach(dependency => collectDependencies(dependency, pkgDir, dependencies))
+  return dependencies
+}
+
+type LicensesOptions = {
+  nodeModules: string
+}
+
+export default program
+  .description('Generate the licenses for the current workspace')
+  .option('--node-modules <node-modules>', 'The directory of the node_modules relative to the workspace', '.')
+  .action(async ({ nodeModules }: LicensesOptions) => {
+    const workspaceDir = process.cwd()
+    const nodeModulesDir = path.join(workspaceDir, nodeModules, 'node_modules')
+    const outFile = path.join(workspaceDir, 'src/assets/licenses.json')
+
+    const workspacePackage = readPackageJson(workspaceDir)
+    if (!workspacePackage) {
+      throw new Error('Workspace package.json not found!')
+    }
+
+    const dependencies = new Set<string>()
+    Object.keys(workspacePackage.dependencies ?? {}).forEach(dependency =>
+      collectDependencies(dependency, nodeModulesDir, dependencies),
+    )
+
+    if (dependencies.size === 0) {
+      throw new Error('No dependencies found for workspace!')
+    }
+
+    const licenses = Array.from(dependencies)
+      .sort()
+      .reduce<Record<string, LicenseEntry>>((licenses, pkgName) => {
+        const pkg = readPackageJson(path.join(nodeModulesDir, pkgName))
+        if (!pkg || pkg.private) {
+          return licenses
+        }
+
+        const key = `${pkg.name}@${pkg.version}`
+
+        const repo = typeof pkg.repository === 'string' ? pkg.repository : pkg.repository?.url
+        // Convert git to https urls
+        const repoUrl = repo
+          ?.replace(/^git\+/, '')
+          .replace(/\.git$/, '')
+          .replace(/^git:\/\//, 'https://')
+
+        const rawAuthor = typeof pkg.author === 'string' ? pkg.author : pkg.author?.name
+        // Replace email addresses and websites in author
+        const author = rawAuthor
+          ?.replace(/<.*>/g, '')
+          .replace(/\(.*\)/g, '')
+          .trim()
+
+        licenses[key] = {
+          licenses: pkg.license ?? 'UNKNOWN',
+          repository: repoUrl,
+          publisher: author,
+        }
+        return licenses
+      }, {})
+
+    fs.writeFileSync(outFile, JSON.stringify(licenses, null, 2))
+    console.log(`Wrote ${Object.keys(licenses).length} licenses to ${outFile}`)
+  })
+program.parse(process.argv)

--- a/translations/package.json
+++ b/translations/package.json
@@ -23,7 +23,6 @@
   "devDependencies": {
     "@types/flat": "^5.0.5",
     "@types/lodash": "^4.17.24",
-    "commander": "^14.0.3",
     "csv-parse": "^6.2.1",
     "csv-stringify": "^6.7.0",
     "flat": "^5.0.2",

--- a/web/package.json
+++ b/web/package.json
@@ -27,8 +27,7 @@
     "prettier:check": "yarn run -T prettier --ignore-path  ../.prettierignore --check .",
     "prettier:write": "yarn run -T prettier --ignore-path  ../.prettierignore --write .",
     "circleci:update-config": "yarn run -T circleci:update-config",
-    "license-crawler": "license-checker-rseidelsohn --excludePrivatePackages --production --json --out src/assets/licenses.json",
-    "postinstall": "yarn license-crawler"
+    "postinstall": "yarn run -T tsx ../tools/licenses.ts --node-modules='..'"
   },
   "dependencies": {
     "@emotion/cache": "^11.14.0",
@@ -89,7 +88,6 @@
     "img-loader": "^4.0.0",
     "jest-environment-jsdom": "^30.3.0",
     "jest-fetch-mock": "^3.0.3",
-    "license-checker-rseidelsohn": "^4.4.2",
     "raf": "^3.4.1",
     "react-refresh": "^0.18.0",
     "react-refresh-typescript": "^2.0.12",

--- a/web/src/components/LicenseItem.tsx
+++ b/web/src/components/LicenseItem.tsx
@@ -14,12 +14,12 @@ const StyledParagraph = styled('p')`
 type LicenseItemProps = {
   name: string
   version: string | undefined
-  publisher: string | undefined
+  author: string | undefined
   license: string
   url: string | undefined
 }
 
-const LicenseItem = ({ license, name, url, version, publisher }: LicenseItemProps): ReactElement => {
+const LicenseItem = ({ license, name, url, version, author }: LicenseItemProps): ReactElement => {
   const { t } = useTranslation('licenses')
   const Content = (
     <ListItemText
@@ -27,7 +27,7 @@ const LicenseItem = ({ license, name, url, version, publisher }: LicenseItemProp
       primary={name}
       secondary={
         <>
-          <StyledParagraph>{publisher}</StyledParagraph>
+          <StyledParagraph>{author}</StyledParagraph>
           <StyledParagraph>
             {t('version')} {version}
           </StyledParagraph>

--- a/web/src/components/__tests__/LicenseItem.spec.tsx
+++ b/web/src/components/__tests__/LicenseItem.spec.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+
+import { renderWithTheme } from '../../testing/render'
+import LicenseItem from '../LicenseItem'
+
+jest.mock('react-i18next', () => ({
+  ...jest.requireActual('react-i18next'),
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+const defaultProps = {
+  name: 'react',
+  version: '18.2.0',
+  author: 'Meta Platforms, Inc.',
+  license: 'MIT',
+  url: 'https://github.com/facebook/react',
+}
+
+describe('LicenseItem', () => {
+  it('should render name, author, version and license', () => {
+    const { getByText } = renderWithTheme(<LicenseItem {...defaultProps} />)
+    expect(getByText('react')).toBeTruthy()
+    expect(getByText('Meta Platforms, Inc.')).toBeTruthy()
+    expect(getByText('version 18.2.0')).toBeTruthy()
+    expect(getByText('license MIT')).toBeTruthy()
+  })
+
+  it('should render as a link when url is provided', () => {
+    const { getByRole } = renderWithTheme(<LicenseItem {...defaultProps} />)
+    const link = getByRole('link')
+    expect(link).toBeTruthy()
+    expect(link).toHaveAttribute('href', defaultProps.url)
+  })
+
+  it('should not render a link when url is not provided', () => {
+    const { queryByRole } = renderWithTheme(<LicenseItem {...defaultProps} url={undefined} />)
+    expect(queryByRole('link')).toBeNull()
+  })
+
+  it('should not render author when author is not provided', () => {
+    const { queryByText } = renderWithTheme(<LicenseItem {...defaultProps} author={undefined} />)
+    expect(queryByText('Meta Platforms, Inc.')).toBeNull()
+  })
+})

--- a/web/src/routes/LicensesPage.tsx
+++ b/web/src/routes/LicensesPage.tsx
@@ -1,7 +1,8 @@
-import React, { ReactElement, useEffect, useState } from 'react'
+import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { License, parseLicenses } from 'shared'
+import { parseLicenses } from 'shared'
+import { useLoadAsync } from 'shared/api'
 
 import Footer from '../components/Footer'
 import GeneralHeader from '../components/GeneralHeader'
@@ -9,18 +10,14 @@ import Layout from '../components/Layout'
 import LicenseItem from '../components/LicenseItem'
 import H1 from '../components/base/H1'
 import List from '../components/base/List'
-import { reportError } from '../utils/sentry'
+
+const loadLicenses = async () => parseLicenses((await import('../assets/licenses.json')).default)
 
 type LicensesPageProps = { languageCode: string }
-const LicensesPage = ({ languageCode }: LicensesPageProps): ReactElement => {
-  const { t } = useTranslation(['settings', 'licenses'])
-  const [licenses, setLicenses] = useState<License[] | null>(null)
 
-  useEffect(() => {
-    import('../assets/licenses.json')
-      .then(licenseFile => setLicenses(parseLicenses(licenseFile.default)))
-      .catch(error => reportError(`error while importing licenses ${error}`))
-  }, [])
+const LicensesPage = ({ languageCode }: LicensesPageProps): ReactElement => {
+  const { data: licenses } = useLoadAsync(loadLicenses)
+  const { t } = useTranslation(['settings', 'licenses'])
 
   const items = (licenses ?? []).map(license => (
     <LicenseItem

--- a/web/src/routes/LicensesPage.tsx
+++ b/web/src/routes/LicensesPage.tsx
@@ -23,8 +23,8 @@ const LicensesPage = ({ languageCode }: LicensesPageProps): ReactElement => {
     <LicenseItem
       key={license.name}
       name={license.name}
-      publisher={license.publisher}
-      license={license.licenses}
+      author={license.author}
+      license={license.license}
       version={license.version}
       url={license.repository}
     />

--- a/web/src/routes/LicensesPage.tsx
+++ b/web/src/routes/LicensesPage.tsx
@@ -16,7 +16,7 @@ const loadLicenses = async () => parseLicenses((await import('../assets/licenses
 type LicensesPageProps = { languageCode: string }
 
 const LicensesPage = ({ languageCode }: LicensesPageProps): ReactElement => {
-  const { data: licenses } = useLoadAsync(loadLicenses)
+  const { data: licenses, loading } = useLoadAsync(loadLicenses)
   const { t } = useTranslation(['settings', 'licenses'])
 
   const items = (licenses ?? []).map(license => (
@@ -33,7 +33,7 @@ const LicensesPage = ({ languageCode }: LicensesPageProps): ReactElement => {
   return (
     <Layout header={<GeneralHeader languageCode={languageCode} />} footer={<Footer />}>
       <H1>{t('settings:openSourceLicenses')}</H1>
-      <List items={items} NoItemsMessage={t('licenses:noLicensesMessage')} />
+      {!loading && <List items={items} NoItemsMessage='licenses:noLicensesMessage' />}
     </Layout>
   )
 }

--- a/web/src/routes/__tests__/LicensesPage.spec.tsx
+++ b/web/src/routes/__tests__/LicensesPage.spec.tsx
@@ -1,0 +1,54 @@
+import React from 'react'
+
+import { useLoadAsync } from 'shared/api'
+
+import { renderWithRouterAndTheme } from '../../testing/render'
+import LicensesPage from '../LicensesPage'
+
+jest.mock('shared/api', () => ({
+  ...jest.requireActual('shared/api'),
+  useLoadAsync: jest.fn(),
+}))
+
+jest.mock('react-i18next', () => ({
+  ...jest.requireActual('react-i18next'),
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+const { mocked } = jest
+
+const mockUseLoadAsync = (data: unknown) =>
+  mocked(useLoadAsync).mockReturnValue({
+    data,
+    error: null,
+    loading: false,
+    refresh: jest.fn(),
+    setData: jest.fn(),
+  } as never)
+
+describe('LicensesPage', () => {
+  beforeEach(jest.clearAllMocks)
+
+  it('should render license items', () => {
+    mockUseLoadAsync([
+      {
+        name: 'react',
+        version: '18.2.0',
+        license: 'MIT',
+        repository: 'https://github.com/facebook/react',
+        author: 'Meta',
+      },
+      { name: 'lodash', version: '4.17.21', license: 'MIT', repository: undefined, author: undefined },
+    ])
+    const { getByText, getAllByText } = renderWithRouterAndTheme(<LicensesPage languageCode='de' />)
+    expect(getAllByText('settings:openSourceLicenses')).toHaveLength(2)
+    expect(getByText('react')).toBeTruthy()
+    expect(getByText('lodash')).toBeTruthy()
+  })
+
+  it('should show empty message when no licenses are loaded', () => {
+    mockUseLoadAsync([])
+    const { getByRole } = renderWithRouterAndTheme(<LicensesPage languageCode='de' />)
+    expect(getByRole('alert')).toHaveTextContent('licenses:noLicensesMessage')
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -4878,15 +4878,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@npmcli/fs@npm:^3.1.0":
-  version: 3.1.1
-  resolution: "@npmcli/fs@npm:3.1.1"
-  dependencies:
-    semver: "npm:^7.3.5"
-  checksum: 10c0/c37a5b4842bfdece3d14dfdb054f73fe15ed2d3da61b34ff76629fb5b1731647c49166fd2a8bf8b56fcfa51200382385ea8909a3cbecdad612310c114d3f6c99
-  languageName: node
-  linkType: hard
-
 "@npmcli/fs@npm:^5.0.0":
   version: 5.0.0
   resolution: "@npmcli/fs@npm:5.0.0"
@@ -8640,13 +8631,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"abbrev@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "abbrev@npm:2.0.0"
-  checksum: 10c0/f742a5a107473946f426c691c08daba61a1d15942616f300b5d32fd735be88fef5cba24201757b6c407fd564555fb48c751cfa33519b2605c8a7aadd22baf372
-  languageName: node
-  linkType: hard
-
 "abbrev@npm:^4.0.0":
   version: 4.0.0
   resolution: "abbrev@npm:4.0.0"
@@ -9078,13 +9062,6 @@ __metadata:
     call-bound: "npm:^1.0.3"
     is-array-buffer: "npm:^3.0.5"
   checksum: 10c0/74e1d2d996941c7a1badda9cabb7caab8c449db9086407cad8a1b71d2604cc8abf105db8ca4e02c04579ec58b7be40279ddb09aea4784832984485499f48432d
-  languageName: node
-  linkType: hard
-
-"array-find-index@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "array-find-index@npm:1.0.2"
-  checksum: 10c0/86b9485c74ddd324feab807e10a6de3f9c1683856267236fac4bb4d4667ada6463e106db3f6c540ae6b720e0442b590ec701d13676df4c6af30ebf4da09b4f57
   languageName: node
   linkType: hard
 
@@ -9990,7 +9967,6 @@ __metadata:
   resolution: "build-configs@workspace:build-configs"
   dependencies:
     "@types/flat": "npm:^5.0.5"
-    commander: "npm:^14.0.3"
     csstype: "npm:^3.2.3"
     decamelize: "npm:^5.0.1"
     flat: "npm:^5.0.2"
@@ -10155,7 +10131,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:4.1.2, chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.2":
+"chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -14499,15 +14475,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hosted-git-info@npm:^6.0.0":
-  version: 6.1.3
-  resolution: "hosted-git-info@npm:6.1.3"
-  dependencies:
-    lru-cache: "npm:^7.5.1"
-  checksum: 10c0/a1fc10faf67d04d575ebabf89cd5c9e3ebca041d99f42f31143bc8027684da4612c2f6deaf7cf2c09ac3b04dd502ad3957caa49d913628f0558964b2e1e7b414
-  languageName: node
-  linkType: hard
-
 "hosted-git-info@npm:^7.0.0":
   version: 7.0.2
   resolution: "hosted-git-info@npm:7.0.2"
@@ -15063,6 +15030,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": "npm:^8.57.2"
     "@typescript-eslint/parser": "npm:^8.57.2"
     app-toolbelt: "github:digitalfabrik/app-toolbelt#semver:1.0.0"
+    commander: "npm:^14.0.3"
     eslint: "npm:^9.39.4"
     eslint-config-airbnb-extended: "npm:^3.0.1"
     eslint-config-prettier: "npm:^10.1.8"
@@ -15242,7 +15210,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-core-module@npm:^2.16.1, is-core-module@npm:^2.8.1":
+"is-core-module@npm:^2.16.1":
   version: 2.16.1
   resolution: "is-core-module@npm:2.16.1"
   dependencies:
@@ -16816,27 +16784,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"license-checker-rseidelsohn@npm:^4.4.2":
-  version: 4.4.2
-  resolution: "license-checker-rseidelsohn@npm:4.4.2"
-  dependencies:
-    chalk: "npm:4.1.2"
-    debug: "npm:^4.3.4"
-    lodash.clonedeep: "npm:^4.5.0"
-    mkdirp: "npm:^1.0.4"
-    nopt: "npm:^7.2.0"
-    read-installed-packages: "npm:^2.0.1"
-    semver: "npm:^7.3.5"
-    spdx-correct: "npm:^3.1.1"
-    spdx-expression-parse: "npm:^3.0.1"
-    spdx-satisfies: "npm:^5.0.1"
-    treeify: "npm:^1.1.0"
-  bin:
-    license-checker-rseidelsohn: bin/license-checker-rseidelsohn.js
-  checksum: 10c0/776be6c81151bd215c3ee428fe90d4a44ca57433669720575928f4b262bcd025b5988dddc91e489fca6a19fb360b5374c1bd888e9ee5111401d4bbd086ed0396
-  languageName: node
-  linkType: hard
-
 "lie@npm:~3.3.0":
   version: 3.3.0
   resolution: "lie@npm:3.3.0"
@@ -17162,7 +17109,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:^7.14.1, lru-cache@npm:^7.5.1":
+"lru-cache@npm:^7.14.1":
   version: 7.18.3
   resolution: "lru-cache@npm:7.18.3"
   checksum: 10c0/b3a452b491433db885beed95041eb104c157ef7794b9c9b4d647be503be91769d11206bb573849a16b4cc0d03cbd15ffd22df7960997788b74c1d399ac7a4fed
@@ -18055,7 +18002,6 @@ __metadata:
     i18next: "npm:^26.0.1"
     intl-pluralrules: "npm:^2.0.1"
     js-sha256: "npm:^0.11.1"
-    license-checker-rseidelsohn: "npm:^4.4.2"
     lodash: "npm:^4.17.23"
     luxon: "npm:^3.7.2"
     react: "npm:19.2.3"
@@ -18265,17 +18211,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nopt@npm:^7.2.0":
-  version: 7.2.1
-  resolution: "nopt@npm:7.2.1"
-  dependencies:
-    abbrev: "npm:^2.0.0"
-  bin:
-    nopt: bin/nopt.js
-  checksum: 10c0/a069c7c736767121242037a22a788863accfa932ab285a1eb569eb8cd534b09d17206f68c37f096ae785647435e0c5a5a0a67b42ec743e481a455e5ae6a6df81
-  languageName: node
-  linkType: hard
-
 "nopt@npm:^9.0.0":
   version: 9.0.0
   resolution: "nopt@npm:9.0.0"
@@ -18284,18 +18219,6 @@ __metadata:
   bin:
     nopt: bin/nopt.js
   checksum: 10c0/1822eb6f9b020ef6f7a7516d7b64a8036e09666ea55ac40416c36e4b2b343122c3cff0e2f085675f53de1d2db99a2a89a60ccea1d120bcd6a5347bf6ceb4a7fd
-  languageName: node
-  linkType: hard
-
-"normalize-package-data@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "normalize-package-data@npm:5.0.0"
-  dependencies:
-    hosted-git-info: "npm:^6.0.0"
-    is-core-module: "npm:^2.8.1"
-    semver: "npm:^7.3.5"
-    validate-npm-package-license: "npm:^3.0.4"
-  checksum: 10c0/705fe66279edad2f93f6e504d5dc37984e404361a3df921a76ab61447eb285132d20ff261cc0bee9566b8ce895d75fcfec913417170add267e2873429fe38392
   languageName: node
   linkType: hard
 
@@ -18343,13 +18266,6 @@ __metadata:
   version: 8.0.1
   resolution: "normalize.css@npm:8.0.1"
   checksum: 10c0/4ddf56d1af5ca755fa5e692e718316d8758ecb792aa96e1ad206824b5810a043763d681d6f7697d46573515f5e9690038b4c91a95c1997567128815545fb8cd7
-  languageName: node
-  linkType: hard
-
-"npm-normalize-package-bin@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "npm-normalize-package-bin@npm:3.0.1"
-  checksum: 10c0/f1831a7f12622840e1375c785c3dab7b1d82dd521211c17ee5e9610cd1a34d8b232d3fdeebf50c170eddcb321d2c644bf73dbe35545da7d588c6b3fa488db0a5
   languageName: node
   linkType: hard
 
@@ -20370,35 +20286,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"read-installed-packages@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "read-installed-packages@npm:2.0.1"
-  dependencies:
-    "@npmcli/fs": "npm:^3.1.0"
-    debug: "npm:^4.3.4"
-    graceful-fs: "npm:^4.1.2"
-    read-package-json: "npm:^6.0.0"
-    semver: "npm:2 || 3 || 4 || 5 || 6 || 7"
-    slide: "npm:~1.1.3"
-  dependenciesMeta:
-    graceful-fs:
-      optional: true
-  checksum: 10c0/e59ab7340c35f0ec3c936254649ef7829dc75658cc19ed9c1da98f2a23ce89e4ff70022fbb9d9b328537f4244d77730926f9e2f3ba58ef9f343037830ceec3e5
-  languageName: node
-  linkType: hard
-
-"read-package-json@npm:^6.0.0":
-  version: 6.0.4
-  resolution: "read-package-json@npm:6.0.4"
-  dependencies:
-    glob: "npm:^10.2.2"
-    json-parse-even-better-errors: "npm:^3.0.0"
-    normalize-package-data: "npm:^5.0.0"
-    npm-normalize-package-bin: "npm:^3.0.0"
-  checksum: 10c0/0eb1110b35bc109a8d2789358a272c66b0fb8fd335a98df2ea9ff3423be564e2908f27d98f3f4b41da35495e04dc1763b33aad7cc24bfd58dfc6d60cca7d70c9
-  languageName: node
-  linkType: hard
-
 "read-pkg-up@npm:^10.0.0, read-pkg-up@npm:^10.1.0":
   version: 10.1.0
   resolution: "read-pkg-up@npm:10.1.0"
@@ -21184,7 +21071,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:2 || 3 || 4 || 5 || 6 || 7, semver@npm:7.7.4, semver@npm:^7.1.3, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.5.2, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.3, semver@npm:^7.7.1, semver@npm:^7.7.2, semver@npm:^7.7.3, semver@npm:^7.7.4":
+"semver@npm:7.7.4, semver@npm:^7.1.3, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.5.2, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.3, semver@npm:^7.7.1, semver@npm:^7.7.2, semver@npm:^7.7.3, semver@npm:^7.7.4":
   version: 7.7.4
   resolution: "semver@npm:7.7.4"
   bin:
@@ -21689,13 +21576,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"slide@npm:~1.1.3":
-  version: 1.1.6
-  resolution: "slide@npm:1.1.6"
-  checksum: 10c0/f3bde70fd4c0a2ba6c23c674f010849865ddfacbc0ae3a57522d7ce88e4cc6c186d627943c34004d4f009a3fb477c03307b247ab69a266de4b3c72b271a6a03a
-  languageName: node
-  linkType: hard
-
 "smart-buffer@npm:^4.2.0":
   version: 4.2.0
   resolution: "smart-buffer@npm:4.2.0"
@@ -21828,18 +21708,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"spdx-compare@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "spdx-compare@npm:1.0.0"
-  dependencies:
-    array-find-index: "npm:^1.0.2"
-    spdx-expression-parse: "npm:^3.0.0"
-    spdx-ranges: "npm:^2.0.0"
-  checksum: 10c0/39d584129b00eaf0bb314984e5d662e511980c1fc6c4eb1d80677044a7b2b9cc3f84f6838695cf988807bf81ea0fce7438e33b0ee54fa87d302635bd143b7fc7
-  languageName: node
-  linkType: hard
-
-"spdx-correct@npm:^3.0.0, spdx-correct@npm:^3.1.1":
+"spdx-correct@npm:^3.0.0":
   version: 3.2.0
   resolution: "spdx-correct@npm:3.2.0"
   dependencies:
@@ -21856,7 +21725,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"spdx-expression-parse@npm:^3.0.0, spdx-expression-parse@npm:^3.0.1":
+"spdx-expression-parse@npm:^3.0.0":
   version: 3.0.1
   resolution: "spdx-expression-parse@npm:3.0.1"
   dependencies:
@@ -21870,24 +21739,6 @@ __metadata:
   version: 3.0.23
   resolution: "spdx-license-ids@npm:3.0.23"
   checksum: 10c0/8495620f6f2a237749cce922ea2d593a66f7885c301b1a0f5542183e7041182f27f616a8f13345cefdea0c9b3e0899328e0aa8cec100cf4f3fac4bb3bd975515
-  languageName: node
-  linkType: hard
-
-"spdx-ranges@npm:^2.0.0":
-  version: 2.1.1
-  resolution: "spdx-ranges@npm:2.1.1"
-  checksum: 10c0/2d6bf9ec8e0f509c1a119361ff784f0bfa8ebbd8cfbc8e10f79579def54af060bb5058b36372f19770e659051082c451145c1284d2980419a720675accdb4a3d
-  languageName: node
-  linkType: hard
-
-"spdx-satisfies@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "spdx-satisfies@npm:5.0.1"
-  dependencies:
-    spdx-compare: "npm:^1.0.0"
-    spdx-expression-parse: "npm:^3.0.0"
-    spdx-ranges: "npm:^2.0.0"
-  checksum: 10c0/47bf163108e64fe4c179a5e2f8dc5fd4ece1665739fc61eae3157a9d4b9b2eb389df7f645223192557659155dda9071ceaa3dfd06ecab65cc3862032c20f2e61
   languageName: node
   linkType: hard
 
@@ -22924,7 +22775,6 @@ __metadata:
   dependencies:
     "@types/flat": "npm:^5.0.5"
     "@types/lodash": "npm:^4.17.24"
-    commander: "npm:^14.0.3"
     csv-parse: "npm:^6.2.1"
     csv-stringify: "npm:^6.7.0"
     deepmerge-ts: "npm:^7.1.5"
@@ -22949,13 +22799,6 @@ __metadata:
   bin:
     tree-kill: cli.js
   checksum: 10c0/7b1b7c7f17608a8f8d20a162e7957ac1ef6cd1636db1aba92f4e072dc31818c2ff0efac1e3d91064ede67ed5dc57c565420531a8134090a12ac10cf792ab14d2
-  languageName: node
-  linkType: hard
-
-"treeify@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "treeify@npm:1.1.0"
-  checksum: 10c0/2f0dea9e89328b8a42296a3963d341ab19897a05b723d6b0bced6b28701a340d2a7b03241aef807844198e46009aaf3755139274eb082cfce6fdc1935cbd69dd
   languageName: node
   linkType: hard
 
@@ -23972,7 +23815,6 @@ __metadata:
     img-loader: "npm:^4.0.0"
     jest-environment-jsdom: "npm:^30.3.0"
     jest-fetch-mock: "npm:^3.0.3"
-    license-checker-rseidelsohn: "npm:^4.4.2"
     luxon: "npm:^3.7.2"
     maplibre-gl: "npm:^5.21.1"
     normalize.css: "npm:^8.0.1"


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
<!-- Make sure to correctly set PR labels if necessary: `Native`/`Web` for native/web only PRs and `maintenance` for non-user-facing changes. -->
Fix licenses for web.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Replace license-checker-rseidelsohn with custom script for both native and web
- Streamline internal naming
- Use `useLoadAsync` instead of custom useState/useEffect logic to load licenses

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Check the licenses on both web and native.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4124

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
