### PR TITLE
3770: Add timezone for OfficeHours

### DIFF
--- a/native/src/components/__tests__/OfficeHours.spec.tsx
+++ b/native/src/components/__tests__/OfficeHours.spec.tsx
@@ -1,0 +1,94 @@
+import { fireEvent } from '@testing-library/react-native'
+import React from 'react'
+
+import { isCurrentlyOpen } from 'shared'
+import { OpeningHoursModel } from 'shared/api'
+
+import renderWithTheme from '../../testing/render'
+import OfficeHours from '../OfficeHours'
+
+jest.mock('react-i18next')
+jest.mock('shared', () => ({
+  ...jest.requireActual('shared'),
+  isCurrentlyOpen: jest.fn(),
+}))
+
+describe('OfficeHours', () => {
+  const officeHours = Array.from(
+    { length: 7 },
+    () =>
+      new OpeningHoursModel({
+        openAllDay: false,
+        closedAllDay: false,
+        timeSlots: [{ end: '18:00', start: '08:00', timezone: 'Europe/Berlin' }],
+        appointmentOnly: false,
+      }),
+  )
+
+  const renderOfficeHours = (hours: OpeningHoursModel[] | null = officeHours) =>
+    renderWithTheme(<OfficeHours officeHours={hours} />)
+
+  beforeEach(() => {
+    jest.mocked(isCurrentlyOpen).mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should display that the office is open', () => {
+    const { getByText, getAllByText, queryByText } = renderOfficeHours()
+
+    expect(getByText('opened')).toBeTruthy()
+    expect(queryByText(officeHours[0]!.timeSlots[0]!.start, { exact: false })).toBeFalsy()
+
+    fireEvent.press(getByText('opened'))
+
+    expect(getAllByText(officeHours[0]!.timeSlots[0]!.start, { exact: false })).toHaveLength(7)
+    expect(getAllByText(officeHours[0]!.timeSlots[0]!.end, { exact: false })).toHaveLength(7)
+  })
+
+  it('should display that the office is closed', () => {
+    jest.mocked(isCurrentlyOpen).mockReturnValue(false)
+
+    const { getByText } = renderOfficeHours()
+
+    expect(getByText('closed')).toBeTruthy()
+  })
+
+  it('should display all day if the office is open all day', () => {
+    const allDayOfficeHours = Array.from(
+      { length: 7 },
+      () =>
+        new OpeningHoursModel({
+          openAllDay: true,
+          closedAllDay: false,
+          timeSlots: [],
+          appointmentOnly: false,
+        }),
+    )
+
+    const { getByText, queryByText } = renderOfficeHours(allDayOfficeHours)
+
+    expect(getByText('allDay')).toBeTruthy()
+    expect(queryByText('opened')).toBeFalsy()
+  })
+
+  it('should display temporarily closed if the office is closed all day', () => {
+    const closedOfficeHours = Array.from(
+      { length: 7 },
+      () =>
+        new OpeningHoursModel({
+          openAllDay: false,
+          closedAllDay: true,
+          timeSlots: [],
+          appointmentOnly: false,
+        }),
+    )
+
+    const { getByText, queryByText } = renderOfficeHours(closedOfficeHours)
+
+    expect(getByText('temporarilyClosed')).toBeTruthy()
+    expect(queryByText('opened')).toBeFalsy()
+  })
+})

--- a/native/src/utils/DatabaseConnector.ts
+++ b/native/src/utils/DatabaseConnector.ts
@@ -145,7 +145,7 @@ type ContactJsonType = {
     | {
         openAllDay: boolean
         closedAllDay: boolean
-        timeSlots: { start: string; end: string }[]
+        timeSlots: { start: string; end: string; timezone: string }[]
         appointmentOnly: boolean
       }[]
     | null
@@ -166,7 +166,7 @@ type ContentPoiJsonType = {
     | {
         openAllDay: boolean
         closedAllDay: boolean
-        timeSlots: { start: string; end: string; timezone?: string }[]
+        timeSlots: { start: string; end: string; timezone: string }[]
         appointmentOnly: boolean
       }[]
     | null
@@ -223,7 +223,7 @@ const mapOpeningHoursToJson = (
 ): {
   openAllDay: boolean
   closedAllDay: boolean
-  timeSlots: { start: string; end: string; timezone: string | undefined }[]
+  timeSlots: { start: string; end: string; timezone: string }[]
   appointmentOnly: boolean
 } => ({
   openAllDay: hours.openAllDay,
@@ -231,7 +231,7 @@ const mapOpeningHoursToJson = (
   timeSlots: hours.timeSlots.map(timeslot => ({
     start: timeslot.start,
     end: timeslot.end,
-    timezone: timeslot.timezone ?? undefined,
+    timezone: timeslot.timezone,
   })),
   appointmentOnly: hours.appointmentOnly,
 })
@@ -239,7 +239,7 @@ const mapOpeningHoursToJson = (
 const mapJsonToOpeningHours = (hours: {
   openAllDay: boolean
   closedAllDay: boolean
-  timeSlots: { start: string; end: string; timezone?: string }[]
+  timeSlots: { start: string; end: string; timezone: string }[]
   appointmentOnly: boolean
 }): OpeningHoursModel =>
   new OpeningHoursModel({
@@ -248,7 +248,7 @@ const mapJsonToOpeningHours = (hours: {
     timeSlots: hours.timeSlots.map(timeslot => ({
       start: timeslot.start,
       end: timeslot.end,
-      timezone: timeslot.timezone ?? undefined,
+      timezone: timeslot.timezone,
     })),
     appointmentOnly: hours.appointmentOnly,
   })

--- a/shared/api/types.ts
+++ b/shared/api/types.ts
@@ -214,5 +214,5 @@ export type JsonRegionType = {
 export type TimeSlot = {
   end: string
   start: string
-  timezone: string | undefined
+  timezone: string
 }

--- a/web/src/components/__tests__/OfficeHours.spec.tsx
+++ b/web/src/components/__tests__/OfficeHours.spec.tsx
@@ -1,0 +1,90 @@
+import React from 'react'
+
+import { isCurrentlyOpen } from 'shared'
+import { OpeningHoursModel } from 'shared/api'
+
+import { renderWithTheme } from '../../testing/render'
+import OfficeHours from '../OfficeHours'
+
+jest.mock('react-i18next')
+jest.mock('shared', () => ({
+  ...jest.requireActual('shared'),
+  isCurrentlyOpen: jest.fn(),
+}))
+
+describe('OfficeHours', () => {
+  const officeHours = Array.from(
+    { length: 7 },
+    () =>
+      new OpeningHoursModel({
+        openAllDay: false,
+        closedAllDay: false,
+        timeSlots: [{ end: '18:00', start: '08:00', timezone: 'Europe/Berlin' }],
+        appointmentOnly: false,
+      }),
+  )
+
+  const renderOfficeHours = (hours: OpeningHoursModel[] | null = officeHours) =>
+    renderWithTheme(<OfficeHours officeHours={hours} />)
+
+  beforeEach(() => {
+    jest.mocked(isCurrentlyOpen).mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should display that the office is open', () => {
+    const { getByText, getAllByText } = renderOfficeHours()
+
+    expect(getByText('pois:opened')).toBeTruthy()
+
+    expect(getAllByText(officeHours[0]!.timeSlots[0]!.start, { exact: false })).toHaveLength(7)
+    expect(getAllByText(officeHours[0]!.timeSlots[0]!.end, { exact: false })).toHaveLength(7)
+  })
+
+  it('should display that the office is closed', () => {
+    jest.mocked(isCurrentlyOpen).mockReturnValue(false)
+
+    const { getByText } = renderOfficeHours()
+
+    expect(getByText('pois:closed')).toBeTruthy()
+  })
+
+  it('should display all day if the office is open all day', () => {
+    const allDayOfficeHours = Array.from(
+      { length: 7 },
+      () =>
+        new OpeningHoursModel({
+          openAllDay: true,
+          closedAllDay: false,
+          timeSlots: [],
+          appointmentOnly: false,
+        }),
+    )
+
+    const { getByText, queryByText } = renderOfficeHours(allDayOfficeHours)
+
+    expect(getByText('pois:allDay')).toBeTruthy()
+    expect(queryByText('pois:opened')).toBeFalsy()
+  })
+
+  it('should display temporarily closed if the office is closed all day', () => {
+    const closedOfficeHours = Array.from(
+      { length: 7 },
+      () =>
+        new OpeningHoursModel({
+          openAllDay: false,
+          closedAllDay: true,
+          timeSlots: [],
+          appointmentOnly: false,
+        }),
+    )
+
+    const { getByText, queryByText } = renderOfficeHours(closedOfficeHours)
+
+    expect(getByText('pois:temporarilyClosed')).toBeTruthy()
+    expect(queryByText('pois:opened')).toBeFalsy()
+  })
+})


### PR DESCRIPTION
### Short Description

We currently get the timezone in the opening hours in the POIs, but not yet in the OfficeHours in contacts. However, we use the same type for both opening hours in the app.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Removed optional typing for timezone.
- Added `timezone` for officeHours at DatabaseConnector.ts
- Created 2 new test files for openingHours.
- Already the `TimeSlot` uses `timezone` for both officeHours and openingHours for web.

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

None.

### Testing

- Go to map/poi http://localhost:9000/testumgebung/en/locations/eisdiele
- check the officeHours and try to change the location from chrome(developer settings => 3dots at the bottom corner => sensors)
- Also check openingHours http://localhost:9000/testumgebung/en/locations/laras-zweites-testcenter
- Smoke test Native.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3770

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
