### PR TITLE
4126: Fix opening chat at search

### DIFF
--- a/web/src/routes/SearchPage.tsx
+++ b/web/src/routes/SearchPage.tsx
@@ -69,7 +69,17 @@ const SearchPage = ({ region, regionCode, languageCode }: RegionRouteProps): Rea
   const debouncedQuery = useDebounce(query)
 
   useEffect(() => {
-    setQueryParams(debouncedQuery.length > 0 ? { query: debouncedQuery } : undefined, { replace: true })
+    setQueryParams(
+      previous => {
+        if (debouncedQuery.length > 0) {
+          previous.set(SEARCH_QUERY_KEY, debouncedQuery)
+        } else {
+          previous.delete(SEARCH_QUERY_KEY)
+        }
+        return previous
+      },
+      { replace: true },
+    )
   }, [debouncedQuery, setQueryParams])
 
   const {

--- a/web/src/routes/__tests__/SearchPage.spec.tsx
+++ b/web/src/routes/__tests__/SearchPage.spec.tsx
@@ -163,4 +163,14 @@ describe('SearchPage', () => {
 
     expect(global.window.location.href).toMatch(/^((?!\?query=).)*$/)
   })
+
+  it('should allow opening chat on the search page', async () => {
+    const { router } = renderRoute(searchPage, { routePattern, pathname })
+
+    await router.navigate({ pathname, search: '?chat=true' })
+
+    await waitFor(() => {
+      expect(router.state.location.search).toBe('?chat=true')
+    })
+  })
 })


### PR DESCRIPTION
### Short Description

Currently the chat can't be opened at the searchPage.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Before it was setting a whole new params object that overrides the `chat=true` so I used adjusted the useEffect at SearchPage to mutate only the query key on the existing params.

### Side Effects

None.

### Testing

- Go to testumgebung.
- Open the search page from clicking the search button form the header then open the frag-integreat chat.
- Test how the query params changes on different pages .


### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4126

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
