### PR TITLE
4133: Disable codescene's code duplication checks for test files

### DIFF
--- a/.codescene/code-health-rules.json
+++ b/.codescene/code-health-rules.json
@@ -1,0 +1,12 @@
+{
+  "rule_sets": [
+    {
+      "matching_content_path": "**/*.spec.ts",
+      "rules": [{ "name": "Code Duplication", "weight": 0.0 }]
+    },
+    {
+      "matching_content_path": "**/*.spec.tsx",
+      "rules": [{ "name": "Code Duplication", "weight": 0.0 }]
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
   "typescript.preferences.autoImportSpecifierExcludeRegexes": [
     "^@mui/[^/]+$",
     "(?=^|[^/])shared/((?!api)|api/(?!endpoints/testing)).+"
-  ]
+  ],
+  "codescene.enableTelemetry": false
 }


### PR DESCRIPTION
### Short Description

We currently have frequent ❌ New issue: Code Duplication in our PRs concerning added tests. Since it is in the nature of tests that they have a similar structure with duplications, we just ignore those but that also causes us to ignore actual finds.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Added a `.codescene/code-health-rules.json` file to the repo.
- Disabled the "Code Duplication" rule for `spec.tsx` and `spec.ts`.
https://codescene.io/docs/guides/technical/code-health.html#customize-the-code-health-rules-via-json
- Disabled codescene Telemetry for vsCode settings.

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

None.

### Testing

- Go to this branch https://github.com/digitalfabrik/integreat-app/pull/4132/changes or main if it got merged.
- install the CodeScene extension https://codescene.com/product/integrations/ide-extensions
- The `OfficeHours.spec.tsx` should no longer have issues.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4133

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
