### PR TITLE
Fix console warning

### DIFF
--- a/native/src/utils/renderHtml.ts
+++ b/native/src/utils/renderHtml.ts
@@ -455,11 +455,11 @@ const renderHtml = (
           position: relative;
         }
 
-        ul.details li:has(img:first-child) {
+        ul.details li:has(img:first-of-type) {
           list-style: none;
         }
 
-        ul.details li img:first-child {
+        ul.details li img:first-of-type {
           position: absolute;
           left: -24px;
           top: 1px;

--- a/web/src/components/RemoteContentSandBox.ts
+++ b/web/src/components/RemoteContentSandBox.ts
@@ -183,11 +183,11 @@ const RemoteContentSandBox = styled('div')<{ centered: boolean; smallText: boole
       li {
         position: relative;
 
-        &:has(img:first-child) {
+        &:has(img:first-of-type) {
           list-style: none;
         }
 
-        img:first-child {
+        img:first-of-type {
           position: absolute;
           inset-inline-start: -24px;
           top: 1px;


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
<!-- Make sure to correctly set PR labels if necessary: `Native`/`Web` for native/web only PRs and `maintenance` for non-user-facing changes. -->
Replace `first-child` pseudo class css selector with `first-of-type` to fix console warning:
```
The pseudo class ":first-child" is potentially unsafe when doing server-side rendering. Try changing it to ":first-of-type".
```

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Replace `first-child` with `first-of-type`

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Check that the design of the contact card stays the same (e.g. no bullet points) at http://localhost:9000/testumgebung/de/gesundheit/allgemeine-informationen on web and native.

### Related Issues

https://github.com/digitalfabrik/integreat-app/pull/4000

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: N/A

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
