### PR TITLE
4094: Add space between last update and date

### DIFF
--- a/native/src/components/TimeStamp.tsx
+++ b/native/src/components/TimeStamp.tsx
@@ -30,7 +30,8 @@ export const TimeStamp = ({ lastUpdate, showText = true, format = 'DDD' }: TimeS
   return (
     <DirectionContainer language={i18n.language}>
       <Text variant='caption' style={styles.timeStampText}>
-        {showText && `${t('lastUpdate')} `}
+        {showText && t('lastUpdate')}
+        {showText && ' '}
         {lastUpdate.setLocale(i18n.language).toFormat(format)}
       </Text>
     </DirectionContainer>

--- a/native/src/components/TimeStamp.tsx
+++ b/native/src/components/TimeStamp.tsx
@@ -29,12 +29,8 @@ export const TimeStamp = ({ lastUpdate, showText = true, format = 'DDD' }: TimeS
 
   return (
     <DirectionContainer language={i18n.language}>
-      {showText && (
-        <Text variant='caption' style={styles.timeStampText}>
-          {t('lastUpdate')}
-        </Text>
-      )}
       <Text variant='caption' style={styles.timeStampText}>
+        {showText && `${t('lastUpdate')} `}
         {lastUpdate.setLocale(i18n.language).toFormat(format)}
       </Text>
     </DirectionContainer>

--- a/native/src/components/__tests__/TimeStamp.spec.tsx
+++ b/native/src/components/__tests__/TimeStamp.spec.tsx
@@ -21,15 +21,13 @@ describe('TimeStamp', () => {
     render(<TimeStamp lastUpdate={lastUpdate} format={format ?? undefined} showText={showText ?? undefined} />)
 
   it('should display last update text and formatted timestamp', () => {
-    const { findByText } = renderTimeStamp(null, null)
-    expect(findByText(/lastUpdate/)).toBeTruthy()
-    expect(findByText(lastUpdate.setLocale('en').toFormat('DDD'))).toBeTruthy()
+    const { getByText } = renderTimeStamp(null, null)
+    expect(getByText(`lastUpdate ${lastUpdate.setLocale('en').toFormat('DDD')}`)).toBeTruthy()
   })
 
   it('should display last update text and formatted timestamp explicitly', () => {
-    const { findByText } = renderTimeStamp(null, true)
-    expect(findByText(/lastUpdate/)).toBeTruthy()
-    expect(findByText(lastUpdate.setLocale('en').toFormat('DDD'))).toBeTruthy()
+    const { getByText } = renderTimeStamp(null, true)
+    expect(getByText(`lastUpdate ${lastUpdate.setLocale('en').toFormat('DDD')}`)).toBeTruthy()
   })
 
   it('should only display formatted timestamp', () => {

--- a/native/src/components/__tests__/TimeStamp.spec.tsx
+++ b/native/src/components/__tests__/TimeStamp.spec.tsx
@@ -21,15 +21,15 @@ describe('TimeStamp', () => {
     render(<TimeStamp lastUpdate={lastUpdate} format={format ?? undefined} showText={showText ?? undefined} />)
 
   it('should display last update text and formatted timestamp', () => {
-    const { getByText } = renderTimeStamp(null, null)
-    expect(getByText(/lastUpdate/)).toBeTruthy()
-    expect(getByText(lastUpdate.setLocale('en').toFormat('DDD'))).toBeTruthy()
+    const { findByText } = renderTimeStamp(null, null)
+    expect(findByText(/lastUpdate/)).toBeTruthy()
+    expect(findByText(lastUpdate.setLocale('en').toFormat('DDD'))).toBeTruthy()
   })
 
   it('should display last update text and formatted timestamp explicitly', () => {
-    const { getByText } = renderTimeStamp(null, true)
-    expect(getByText(/lastUpdate/)).toBeTruthy()
-    expect(getByText(lastUpdate.setLocale('en').toFormat('DDD'))).toBeTruthy()
+    const { findByText } = renderTimeStamp(null, true)
+    expect(findByText(/lastUpdate/)).toBeTruthy()
+    expect(findByText(lastUpdate.setLocale('en').toFormat('DDD'))).toBeTruthy()
   })
 
   it('should only display formatted timestamp', () => {


### PR DESCRIPTION
### Short Description

This PR adds space between last update text and date in native

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Combine `Text` into one and add space between the last update and the date
- Adjust test

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

Check pages where last update and date exist in native

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4094

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
