### PR TITLE
3059: Use endless spinner

### DIFF
--- a/native/src/components/ProgressSpinner.tsx
+++ b/native/src/components/ProgressSpinner.tsx
@@ -1,10 +1,8 @@
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Dimensions } from 'react-native'
-import Svg, { Circle, G } from 'react-native-svg'
+import { ActivityIndicator } from 'react-native-paper'
 import styled, { useTheme } from 'styled-components/native'
 
-import { buildConfigAssets } from '../constants/buildConfig'
 import Text from './base/Text'
 
 const Container = styled.View`
@@ -16,50 +14,16 @@ const Container = styled.View`
   align-items: center;
 `
 
-const LoadingImage = styled(buildConfigAssets().LoadingImage)`
-  shadow-color: #000;
-  shadow-offset: 0 2px;
-  shadow-opacity: 0.25;
-  shadow-radius: 3.84px;
-  elevation: 5;
-`
-
-const SVG_SIZE_FRACTION = 0.333
-const svgSize = Dimensions.get('window').width * SVG_SIZE_FRACTION
-const LOGO_SIZE_FRACTION = 0.8
-const logoSize = svgSize * LOGO_SIZE_FRACTION
-const logoXY = (svgSize - logoSize) / 2
-const STROKE_WIDTH_FRACTION = 0.09
-const DIAMETER_FRACTION = 1.2
-const strokeWidth = svgSize * STROKE_WIDTH_FRACTION
-const radius = (svgSize - strokeWidth * DIAMETER_FRACTION) / 2
-const circumference = radius * 2 * Math.PI
-
-type ProgressSpinnerProps = {
-  progress?: number
-}
-
-const ProgressSpinner = ({ progress = 0 }: ProgressSpinnerProps): ReactElement => {
+const ProgressSpinner = (): ReactElement => {
   const { t } = useTranslation('common')
   const theme = useTheme()
   return (
     <Container>
-      <Svg width={svgSize} height={svgSize} testID='loading-image'>
-        <G transform={`translate(${logoXY}, ${logoXY})`}>
-          <LoadingImage width={logoSize} height={logoSize} />
-        </G>
-        <Circle
-          fill='none'
-          stroke={theme.colors.secondary}
-          strokeDasharray={circumference}
-          strokeDashoffset={circumference - progress * circumference}
-          strokeWidth={svgSize * STROKE_WIDTH_FRACTION}
-          cx={svgSize / 2}
-          cy={svgSize / 2}
-          r={radius}
-        />
-      </Svg>
+      <ActivityIndicator size='large' color={theme.colors.primary} />
       <Text
+        accessibilityLiveRegion='assertive'
+        accessibilityState={{ busy: true }}
+        accessibilityLabel={t('loading')}
         variant='h4'
         style={{
           paddingTop: 24,

--- a/native/src/components/ProgressSpinner.tsx
+++ b/native/src/components/ProgressSpinner.tsx
@@ -19,7 +19,7 @@ const ProgressSpinner = (): ReactElement => {
   const theme = useTheme()
   return (
     <Container>
-      <ActivityIndicator size='large' color={theme.colors.primary} />
+      <ActivityIndicator size='large' />
       <Text
         accessibilityLiveRegion='assertive'
         accessibilityState={{ busy: true }}

--- a/native/src/components/__tests__/ProgressSpinner.spec.tsx
+++ b/native/src/components/__tests__/ProgressSpinner.spec.tsx
@@ -7,12 +7,22 @@ jest.mock('styled-components')
 jest.mock('react-i18next')
 
 describe('ProgressSpinner', () => {
-  it('should display a progress text', () => {
-    const { queryByText } = render(<ProgressSpinner progress={0.9} />)
-    expect(queryByText(/loading/)).toBeTruthy()
+  it('should display the loading text', () => {
+    const { getByText } = render(<ProgressSpinner />)
+    expect(getByText('loading')).toBeTruthy()
   })
-  it('should display a progress image', () => {
-    const { getByTestId } = render(<ProgressSpinner progress={0.9} />)
-    expect(getByTestId('loading-image')).toBeTruthy()
+
+  it('should label the loading text for screen readers', () => {
+    const { getByText } = render(<ProgressSpinner />)
+    expect(getByText('loading').props.accessibilityLabel).toBe('loading')
+  })
+
+  it('should expose a busy accessibility state', () => {
+    const { getByText } = render(<ProgressSpinner />)
+    expect(getByText('loading').props.accessibilityState).toEqual(expect.objectContaining({ busy: true }))
+  })
+  it('should announce the loading state to screen reader', () => {
+    const { getByText } = render(<ProgressSpinner />)
+    expect(getByText('loading').props.accessibilityLiveRegion).toBe('assertive')
   })
 })


### PR DESCRIPTION
### Short Description

This PR replaces the previous with svg loading indicator with endless spinner mui like

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Use ActivityIndicator from react-native-paper
- Make loading text accessible to screen reader by announcing it, ActivityIndicator is not detected by screen readers
- Adjust a test file for it

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

Go to any region and see new loading spinner

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3059 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
