### PR TITLE
4045: Change places path to places

### DIFF
--- a/native/src/utils/__tests__/DatabaseConnector.spec.ts
+++ b/native/src/utils/__tests__/DatabaseConnector.spec.ts
@@ -264,7 +264,7 @@ describe('DatabaseConnector', () => {
         location: null,
         lastUpdate: DateTime.fromISO('2022-06-29T09:19:57.443+02:00'),
         featuredImage: null,
-        placePath: '/testumgebung/de/locations/testort/',
+        placePath: '/testumgebung/de/places/testort/',
         meetingUrl: null,
       })
 

--- a/shared/api/endpoints/__tests__/createEventsEndpoint.spec.ts
+++ b/shared/api/endpoints/__tests__/createEventsEndpoint.spec.ts
@@ -72,7 +72,7 @@ describe('events', () => {
       ],
     },
     recurrence_rule: rrule,
-    location_path: '/testumgebung/de/locations/testort/',
+    location_path: '/testumgebung/de/places/testort/',
   })
 
   const createEventModel = (allDay: boolean, startDate: DateTime, endDate: DateTime, rrule?: string): EventModel =>
@@ -125,7 +125,7 @@ describe('events', () => {
           height: 500,
         },
       }),
-      placePath: '/testumgebung/de/locations/testort/',
+      placePath: '/testumgebung/de/places/testort/',
     })
 
   const event1 = createEvent(false, '2016-01-31T10:00:00+01:00', '2016-01-31T13:00:00+01:00')

--- a/shared/api/endpoints/testing/EventModelBuilder.ts
+++ b/shared/api/endpoints/testing/EventModelBuilder.ts
@@ -120,7 +120,7 @@ class EventModelBuilder {
                     <img src='${resourceUrl2}'/>`,
             thumbnail,
             featuredImage: null,
-            placePath: '/testumgebung/de/locations/testort/',
+            placePath: '/testumgebung/de/places/testort/',
           }),
           resources: {
             [resourceUrl1]: this.createResource(resourceUrl1, index, lastUpdate),

--- a/shared/api/endpoints/testing/PlaceModelBuilder.ts
+++ b/shared/api/endpoints/testing/PlaceModelBuilder.ts
@@ -9,13 +9,13 @@ import PlaceModel from '../../models/PlaceModel.js'
 
 const places = [
   new PlaceModel({
-    path: '/augsburg/de/locations/test',
+    path: '/augsburg/de/places/test',
     title: 'Test Title',
     content: 'My extremely long test content',
     thumbnail: 'test',
     availableLanguages: {
-      de: '/augsburg/de/locations/test',
-      en: '/augsburg/en/locations/test-translated',
+      de: '/augsburg/de/places/test',
+      en: '/augsburg/en/places/test-translated',
     },
     excerpt: 'excerpt',
     metaDescription: 'meta',
@@ -65,13 +65,13 @@ const places = [
     barrierFree: true,
   }),
   new PlaceModel({
-    path: '/augsburg/en/locations/test_path_2',
+    path: '/augsburg/en/places/test_path_2',
     title: 'test title 2',
     content: 'test content 2',
     thumbnail: 'test thumbnail 2',
     availableLanguages: {
-      de: '/augsburg/de/locations/test',
-      en: '/augsburg/en/locations/test-translated',
+      de: '/augsburg/de/places/test',
+      en: '/augsburg/en/places/test-translated',
     },
     excerpt: 'test excerpt 2',
     metaDescription: 'meta 2',
@@ -108,13 +108,13 @@ const places = [
     barrierFree: false,
   }),
   new PlaceModel({
-    path: '/augsburg/en/locations/another_test_path',
+    path: '/augsburg/en/places/another_test_path',
     title: 'Another test title',
     content: 'another test content',
     thumbnail: 'another test thumbnail',
     availableLanguages: {
-      de: '/augsburg/de/locations/test',
-      en: '/augsburg/en/locations/test-translated',
+      de: '/augsburg/de/places/test',
+      en: '/augsburg/en/places/test-translated',
     },
     excerpt: 'Another test excerpt',
     metaDescription: null,

--- a/shared/api/models/__tests__/EventModel.spec.ts
+++ b/shared/api/models/__tests__/EventModel.spec.ts
@@ -36,7 +36,7 @@ describe('EventModel', () => {
     availableLanguages: {},
     lastUpdate: DateTime.fromISO('2022-06-05T17:50:00+02:00'),
     featuredImage: null,
-    placePath: '/testumgebung/de/locations/testort/',
+    placePath: '/testumgebung/de/places/testort/',
   }
   const event = new EventModel(params)
   const baseUrl = 'https://example.com'
@@ -108,6 +108,6 @@ describe('EventModel', () => {
   })
 
   it('should have a location path', () => {
-    expect(event.placePath).toBe('/testumgebung/de/locations/testort/')
+    expect(event.placePath).toBe('/testumgebung/de/places/testort/')
   })
 })

--- a/shared/routes/InternalPathnameParser.ts
+++ b/shared/routes/InternalPathnameParser.ts
@@ -13,6 +13,7 @@ import {
   SEARCH_ROUTE,
   TU_NEWS_TYPE,
   LEGACY_REGIONS_ROUTE,
+  LEGACY_PLACES_ROUTE,
 } from './index.js'
 import { parseQueryParams } from './query.js'
 
@@ -129,7 +130,7 @@ class InternalPathnameParser {
   }
 
   places = (): RouteInformationType => {
-    const params = this.regionContentParams(PLACES_ROUTE)
+    const params = this.regionContentParams(PLACES_ROUTE) ?? this.regionContentParams(LEGACY_PLACES_ROUTE)
 
     if (!params) {
       return null

--- a/shared/routes/RouteInformationTypes.ts
+++ b/shared/routes/RouteInformationTypes.ts
@@ -66,7 +66,7 @@ export type EventsRouteInformationType = ParamsType & {
 }
 
 export type PlacesRouteInformationType = ParamsType & {
-  // Route with customizable ids and search params, e.g. '/augsburg/de/locations/1234?multiplace=2'
+  // Route with customizable ids and search params, e.g. '/augsburg/de/places/1234?multiplace=2'
   route: PlacesRouteType
   slug?: string
   multiPlace?: number

--- a/shared/routes/__tests__/InternalPathnameParser.spec.ts
+++ b/shared/routes/__tests__/InternalPathnameParser.spec.ts
@@ -10,6 +10,7 @@ import {
   SEARCH_ROUTE,
   TU_NEWS_TYPE,
   LEGACY_REGIONS_ROUTE,
+  LEGACY_PLACES_ROUTE,
 } from '../index.js'
 import { MULTI_PLACE_QUERY_KEY, PLACE_CATEGORY_QUERY_KEY, SEARCH_QUERY_KEY, ZOOM_QUERY_KEY } from '../query.js'
 
@@ -122,6 +123,41 @@ describe('InternalPathnameParser', () => {
 
   it('should match multiPlace route', () => {
     const pathname = `/${regionCode}/${languageCode}/${PLACES_ROUTE}`
+    const query = `?${MULTI_PLACE_QUERY_KEY}=1&${PLACE_CATEGORY_QUERY_KEY}=8`
+    const parser = new InternalPathnameParser(pathname, languageCode, null, query)
+    expect(parser.route()).toEqual({
+      route: PLACES_ROUTE,
+      languageCode,
+      regionCode,
+      multiPlace: 1,
+      placeCategoryId: 8,
+    })
+  })
+
+  it('should match places route if pathname uses the legacy places slug', () => {
+    const pathname = `/${regionCode}/${languageCode}/${LEGACY_PLACES_ROUTE}`
+    const parser = new InternalPathnameParser(pathname, languageCode, null)
+    expect(parser.route()).toEqual({
+      route: PLACES_ROUTE,
+      languageCode,
+      regionCode,
+    })
+  })
+
+  it('should match single places route if pathname uses the legacy places slug', () => {
+    const slug = 'tuer-an-tuer'
+    const pathname = `/${regionCode}/${languageCode}/${LEGACY_PLACES_ROUTE}/${slug}`
+    const parser = new InternalPathnameParser(pathname, languageCode, null)
+    expect(parser.route()).toEqual({
+      route: PLACES_ROUTE,
+      languageCode,
+      regionCode,
+      slug,
+    })
+  })
+
+  it('should match multiPlace route if pathname uses the legacy places slug', () => {
+    const pathname = `/${regionCode}/${languageCode}/${LEGACY_PLACES_ROUTE}`
     const query = `?${MULTI_PLACE_QUERY_KEY}=1&${PLACE_CATEGORY_QUERY_KEY}=8`
     const parser = new InternalPathnameParser(pathname, languageCode, null, query)
     expect(parser.route()).toEqual({
@@ -548,6 +584,28 @@ describe('InternalPathnameParser', () => {
         regionCode,
         multiPlace: 1,
         placeCategoryId: 8,
+      })
+    })
+
+    it('should match places route if pathname uses the legacy places slug', () => {
+      const pathname = `/${regionCode}/${LEGACY_PLACES_ROUTE}`
+      const parser = new InternalPathnameParser(pathname, languageCode, null)
+      expect(parser.route()).toEqual({
+        route: PLACES_ROUTE,
+        languageCode,
+        regionCode,
+      })
+    })
+
+    it('should match single places route if pathname uses the legacy places slug', () => {
+      const slug = 'tuer-an-tuer'
+      const pathname = `/${regionCode}/${LEGACY_PLACES_ROUTE}/${slug}`
+      const parser = new InternalPathnameParser(pathname, languageCode, null)
+      expect(parser.route()).toEqual({
+        route: PLACES_ROUTE,
+        languageCode,
+        regionCode,
+        slug,
       })
     })
 

--- a/shared/routes/index.ts
+++ b/shared/routes/index.ts
@@ -8,8 +8,8 @@ export const SUGGEST_TO_REGION_ROUTE: SuggestToRegionRouteType = 'recommend'
 export type CategoriesRouteType = 'categories'
 export const CATEGORIES_ROUTE: CategoriesRouteType = 'categories'
 
-export type PlacesRouteType = 'locations'
-export const PLACES_ROUTE: PlacesRouteType = 'locations'
+export type PlacesRouteType = 'places'
+export const PLACES_ROUTE: PlacesRouteType = 'places'
 
 export type EventsRouteType = 'events'
 export const EVENTS_ROUTE: EventsRouteType = 'events'
@@ -28,6 +28,7 @@ export const LICENSES_ROUTE: LicensesRouteType = 'licenses'
 
 // Legacy routes
 export const LEGACY_REGIONS_ROUTE = 'landing'
+export const LEGACY_PLACES_ROUTE = 'locations'
 
 // News types
 export type LocalNewsType = 'local'
@@ -102,4 +103,5 @@ export const RESERVED_REGION_CONTENT_SLUGS: string[] = [
   EVENTS_ROUTE,
   NEWS_ROUTE,
   PLACES_ROUTE,
+  LEGACY_PLACES_ROUTE,
 ]

--- a/shared/routes/pathname.ts
+++ b/shared/routes/pathname.ts
@@ -50,7 +50,7 @@ export const pathnameFromRouteInformation = (routeInformation: NonNullableRouteI
   }
   if (routeInformation.route === EVENTS_ROUTE || routeInformation.route === PLACES_ROUTE) {
     const { regionCode, languageCode, route, slug } = routeInformation
-    // https://integreat.app/augsburg/de/locations, https://integreat.app/augsburg/de/events/my-event-1234
+    // https://integreat.app/augsburg/de/places, https://integreat.app/augsburg/de/events/my-event-1234
     return constructPathname([regionCode, languageCode, route, slug])
   }
   if (

--- a/web/src/RootNavigator.tsx
+++ b/web/src/RootNavigator.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Navigate, Route, Routes, useMatch } from 'react-router'
+import { Navigate, Route, Routes, useLocation, useMatch, useParams } from 'react-router'
 
 import {
   SUGGEST_TO_REGION_ROUTE,
@@ -12,6 +12,9 @@ import {
   NOT_FOUND_ROUTE,
   pathnameFromRouteInformation,
   RESERVED_REGION_CONTENT_SLUGS,
+  LEGACY_REGIONS_ROUTE,
+  LEGACY_PLACES_ROUTE,
+  PLACES_ROUTE,
 } from 'shared'
 
 import FixedRegionContentNavigator from './FixedRegionContentNavigator'
@@ -23,14 +26,20 @@ import ConsentPage from './routes/ConsentPage'
 import SuggestToRegionPage from './routes/SuggestToRegionPage'
 import lazyWithRetry from './utils/retryImport'
 
-type RootNavigatorProps = {
-  setContentLanguage: (languageCode: string) => void
-}
-
 const MainImprintPage = lazyWithRetry(() => import('./routes/MainImprintPage'))
 const RegionsPage = lazyWithRetry(() => import('./routes/RegionsPage'))
 const NotFoundPage = lazyWithRetry(() => import('./routes/NotFoundPage'))
 const LicensesPage = lazyWithRetry(() => import('./routes/LicensesPage'))
+
+const LegacyPlacesRedirect = (): ReactElement => {
+  const { regionCode, languageCode, '*': splat } = useParams()
+  const { search } = useLocation()
+  return <Navigate to={`/${regionCode}/${languageCode}/${PLACES_ROUTE}/${splat ?? ''}${search}`} replace />
+}
+
+type RootNavigatorProps = {
+  setContentLanguage: (languageCode: string) => void
+}
 
 const RootNavigator = ({ setContentLanguage }: RootNavigatorProps): ReactElement => {
   const { i18n } = useTranslation()
@@ -75,8 +84,13 @@ const RootNavigator = ({ setContentLanguage }: RootNavigatorProps): ReactElement
       )}
 
       {/* Redirects */}
+      <Route
+        path={`/${LEGACY_REGIONS_ROUTE}/*`}
+        element={<Navigate to={`/${REGIONS_ROUTE}/${splat ?? ''}`} replace />}
+      />
+      <Route path={`/:regionCode/:languageCode/${LEGACY_PLACES_ROUTE}/*`} element={<LegacyPlacesRedirect />} />
+
       <Route path='/' element={<Navigate to={fixedRegionPath ?? regionsPath} replace />} />
-      <Route path='/landing/*' element={<Navigate to={`/${REGIONS_ROUTE}`} replace />} />
       {!!fixedRegionPath && (
         <Route path={RoutePatterns[REGIONS_ROUTE]} element={<Navigate to={fixedRegionPath} replace />} />
       )}

--- a/web/src/RootNavigator.tsx
+++ b/web/src/RootNavigator.tsx
@@ -34,7 +34,8 @@ const LicensesPage = lazyWithRetry(() => import('./routes/LicensesPage'))
 const LegacyPlacesRedirect = (): ReactElement => {
   const { regionCode, languageCode, '*': splat } = useParams()
   const { search } = useLocation()
-  return <Navigate to={`/${regionCode}/${languageCode}/${PLACES_ROUTE}/${splat ?? ''}${search}`} replace />
+  const lastSegment = splat ? `/${splat}` : ''
+  return <Navigate to={`/${regionCode}/${languageCode}/${PLACES_ROUTE}${lastSegment}${search}`} replace />
 }
 
 type RootNavigatorProps = {
@@ -45,10 +46,12 @@ const RootNavigator = ({ setContentLanguage }: RootNavigatorProps): ReactElement
   const { i18n } = useTranslation()
   const { fixedRegion, suggestToRegion } = buildConfig().featureFlags
   const { routeParam0, routeParam1, '*': splat } = useMatch('/:routeParam0/:routeParam1/*')?.params ?? {}
+  const { search } = useLocation()
   useScrollToTop()
 
   const detectedLanguageCode = i18n.language
   const language = routeParam1 ?? detectedLanguageCode
+  const lastSegment = splat ? `/${splat}` : ''
 
   useEffect(() => {
     if (language !== detectedLanguageCode) {
@@ -58,6 +61,7 @@ const RootNavigator = ({ setContentLanguage }: RootNavigatorProps): ReactElement
 
   const regionsPath = pathnameFromRouteInformation({ route: REGIONS_ROUTE, languageCode: language })
   const fixedRegionPath = fixedRegion ? regionContentPath({ regionCode: fixedRegion, languageCode: language }) : null
+
   return (
     <Routes>
       {!fixedRegion && <Route path={RoutePatterns[REGIONS_ROUTE]} element={<RegionsPage languageCode={language} />} />}
@@ -86,7 +90,7 @@ const RootNavigator = ({ setContentLanguage }: RootNavigatorProps): ReactElement
       {/* Redirects */}
       <Route
         path={`/${LEGACY_REGIONS_ROUTE}/*`}
-        element={<Navigate to={`/${REGIONS_ROUTE}/${splat ?? ''}`} replace />}
+        element={<Navigate to={`/${REGIONS_ROUTE}/${lastSegment}`} replace />}
       />
       <Route path={`/:regionCode/:languageCode/${LEGACY_PLACES_ROUTE}/*`} element={<LegacyPlacesRedirect />} />
 
@@ -102,7 +106,7 @@ const RootNavigator = ({ setContentLanguage }: RootNavigatorProps): ReactElement
         <Route
           key={slug}
           path={`/:regionCode/${slug}/*`}
-          element={<Navigate to={`/${routeParam0}/${detectedLanguageCode}/${slug}/${splat ?? ''}`} replace />}
+          element={<Navigate to={`/${routeParam0}/${detectedLanguageCode}/${slug}${lastSegment}${search}`} replace />}
         />
       ))}
     </Routes>

--- a/web/src/__tests__/RootNavigator.spec.tsx
+++ b/web/src/__tests__/RootNavigator.spec.tsx
@@ -60,24 +60,45 @@ describe('RootNavigator', () => {
 
   describe('redirects', () => {
     it.each`
-      from                          | to
-      ${'/'}                        | ${'/regions/de'}
-      ${'/regions'}                 | ${'/regions/de'}
-      ${'/landing'}                 | ${'/regions/de'}
-      ${'/landing/de'}              | ${'/regions/de'}
-      ${'/augsburg'}                | ${'/augsburg/de'}
-      ${'/augsburg/de'}             | ${'/augsburg/de'}
-      ${'/augsburg/events'}         | ${'/augsburg/de/events'}
-      ${'/augsburg/events/event-1'} | ${'/augsburg/de/events/event-1'}
-      ${'/augsburg/news'}           | ${'/augsburg/de/news'}
-      ${'/augsburg/news/local'}     | ${'/augsburg/de/news/local'}
-      ${'/augsburg/news/tu-news'}   | ${'/augsburg/de/news/tu-news'}
+      from                                   | to
+      ${'/'}                                 | ${'/regions/de'}
+      ${'/regions'}                          | ${'/regions/de'}
+      ${'/landing'}                          | ${'/regions/de'}
+      ${'/landing/de'}                       | ${'/regions/de'}
+      ${'/augsburg'}                         | ${'/augsburg/de'}
+      ${'/augsburg/de'}                      | ${'/augsburg/de'}
+      ${'/augsburg/events'}                  | ${'/augsburg/de/events'}
+      ${'/augsburg/events/event-1'}          | ${'/augsburg/de/events/event-1'}
+      ${'/augsburg/news'}                    | ${'/augsburg/de/news'}
+      ${'/augsburg/news/local'}              | ${'/augsburg/de/news/local'}
+      ${'/augsburg/news/tu-news'}            | ${'/augsburg/de/news/tu-news'}
+      ${'/augsburg/de/locations'}            | ${'/augsburg/de/places'}
+      ${'/augsburg/de/locations/some-place'} | ${'/augsburg/de/places/some-place'}
+      ${'/augsburg/locations'}               | ${'/augsburg/de/places'}
     `('should redirect from $from to $to', ({ from, to }) => {
       mockUseQueryFromEndpointWithData(regions)
 
       const { getByText } = renderRootNavigator(from)
 
       expect(getByText(to)).toBeTruthy()
+    })
+
+    it('should preserve query params when redirecting from the legacy places slug', () => {
+      mockUseQueryFromEndpointWithData(regions)
+
+      const LocationDisplay = () => {
+        const { pathname, search } = useLocation()
+        return <div>{`${normalizePath(pathname)}${search}`}</div>
+      }
+      const { getByText } = renderWithRouterAndTheme(
+        <>
+          <RootNavigator setContentLanguage={setContentLanguage} />
+          <LocationDisplay />
+        </>,
+        { pathname: '/augsburg/de/locations?multiplace=1&category=8' },
+      )
+
+      expect(getByText('/augsburg/de/places?multiplace=1&category=8')).toBeTruthy()
     })
 
     describe('fixedRegion', () => {

--- a/web/src/__tests__/RootNavigator.spec.tsx
+++ b/web/src/__tests__/RootNavigator.spec.tsx
@@ -29,8 +29,9 @@ jest.mock('shared/api', () => ({
 jest.mock('../RegionContentNavigator')
 
 const MockComponent = () => {
-  const pathname = normalizePath(useLocation().pathname)
-  return <div>{pathname}</div>
+  const { search, pathname } = useLocation()
+  const normalizedPathname = normalizePath(pathname)
+  return <div>{`${normalizedPathname}${search}`}</div>
 }
 
 describe('RootNavigator', () => {
@@ -67,14 +68,15 @@ describe('RootNavigator', () => {
       ${'/landing/de'}                       | ${'/regions/de'}
       ${'/augsburg'}                         | ${'/augsburg/de'}
       ${'/augsburg/de'}                      | ${'/augsburg/de'}
-      ${'/augsburg/events'}                  | ${'/augsburg/de/events'}
+      ${'/augsburg/events?query=asdf'}       | ${'/augsburg/de/events?query=asdf'}
       ${'/augsburg/events/event-1'}          | ${'/augsburg/de/events/event-1'}
       ${'/augsburg/news'}                    | ${'/augsburg/de/news'}
       ${'/augsburg/news/local'}              | ${'/augsburg/de/news/local'}
       ${'/augsburg/news/tu-news'}            | ${'/augsburg/de/news/tu-news'}
       ${'/augsburg/de/locations'}            | ${'/augsburg/de/places'}
       ${'/augsburg/de/locations/some-place'} | ${'/augsburg/de/places/some-place'}
-      ${'/augsburg/locations'}               | ${'/augsburg/de/places'}
+      ${'/augsburg/locations?zoom=11'}       | ${'/augsburg/de/places?zoom=11'}
+      ${'/augsburg/locations/1234?zoom=11'}  | ${'/augsburg/de/places/1234?zoom=11'}
     `('should redirect from $from to $to', ({ from, to }) => {
       mockUseQueryFromEndpointWithData(regions)
 

--- a/web/src/components/__tests__/FailureSwitcher.spec.tsx
+++ b/web/src/components/__tests__/FailureSwitcher.spec.tsx
@@ -26,7 +26,7 @@ describe('FailureSwitcher', () => {
     ${'event'}         | ${'1234'}       | ${'event'}    | ${'events'}     | ${'/augsburg/de/events'}
     ${LOCAL_NEWS_TYPE} | ${'1'}          | ${'news'}     | ${'news'}       | ${'/augsburg/de/news/local'}
     ${TU_NEWS_TYPE}    | ${'1'}          | ${'news'}     | ${'news'}       | ${'/augsburg/de/news/tu-news'}
-    ${'place'}         | ${'1234'}       | ${'place'}    | ${'places'}     | ${'/augsburg/de/locations'}
+    ${'place'}         | ${'1234'}       | ${'place'}    | ${'places'}     | ${'/augsburg/de/places'}
   `('should render $type not found failure', ({ type, id, notFoundKey, goToKey, goToPath }) => {
     const error = new NotFoundError({ type, id, language, region })
     const { getByText } = renderWithRouterAndTheme(<FailureSwitcherWithHelmet error={error} />)

--- a/web/src/components/__tests__/NavigationTabs.spec.tsx
+++ b/web/src/components/__tests__/NavigationTabs.spec.tsx
@@ -128,7 +128,7 @@ describe('NavigationTabs', () => {
   })
 
   it('should highlight places tab', () => {
-    const { getByRole } = renderAllRoutes('/augsburg/de/locations', {
+    const { getByRole } = renderAllRoutes('/augsburg/de/places', {
       RegionContentElement: (
         <NavigationTabs languageCode={languageCode} regionModel={regionModel(true, true, true, true)} />
       ),

--- a/web/src/hooks/__tests__/useRegionContentParams.spec.tsx
+++ b/web/src/hooks/__tests__/useRegionContentParams.spec.tsx
@@ -34,7 +34,7 @@ describe('useRegionContentParams', () => {
     ${'/augsburg/de'}                  | ${CATEGORIES_ROUTE}
     ${'/augsburg/de/willkommen/hallo'} | ${CATEGORIES_ROUTE}
     ${'/augsburg/de/events'}           | ${EVENTS_ROUTE}
-    ${'/augsburg/de/locations'}        | ${PLACES_ROUTE}
+    ${'/augsburg/de/places'}           | ${PLACES_ROUTE}
     ${'/augsburg/de/imprint'}          | ${IMPRINT_ROUTE}
     ${'/augsburg/de/news'}             | ${NEWS_ROUTE}
     ${'/augsburg/de/news/local'}       | ${NEWS_ROUTE}

--- a/web/src/routes/__tests__/PlacesPage.spec.tsx
+++ b/web/src/routes/__tests__/PlacesPage.spec.tsx
@@ -51,7 +51,7 @@ describe('PlacesPage', () => {
           <Route element={null} path=':slug' />
         </Route>
       </Routes>,
-      { pathname: path ?? '/locations' },
+      { pathname: path ?? '/places' },
     )
 
   it('should render a list with all places', () => {
@@ -78,7 +78,7 @@ describe('PlacesPage', () => {
 
   it('should calculate correct language change paths', () => {
     mockUseQueryFromEndpointWithData(places)
-    const { getAllByText, getByRole } = renderPlaces('/locations/test')
+    const { getAllByText, getByRole } = renderPlaces('/places/test')
     fireEvent.click(getByRole('button', { name: 'layout:changeLanguage' }))
 
     expect(getAllByText('English')[0]?.closest('a')).toHaveAttribute('href', place0.availableLanguages.en)

--- a/web/src/utils/__tests__/createJsonLdEvent.spec.ts
+++ b/web/src/utils/__tests__/createJsonLdEvent.spec.ts
@@ -57,7 +57,7 @@ describe('createJsonLdEvent', () => {
           height: 40,
         },
       }),
-      placePath: '/testumgebung/de/locations/testort/',
+      placePath: '/testumgebung/de/places/testort/',
     })
     expect(createJsonLdEvent(eventModel)).toEqual({
       '@context': 'https://schema.org',


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
<!-- Make sure to correctly set PR labels if necessary: `Native`/`Web` for native/web only PRs and `maintenance` for non-user-facing changes. -->
This PR aligns the path of the places to the internal and user facing naming `places` (follow up for #4155).
The new slug is added to the CMS in https://github.com/digitalfabrik/integreat-cms/pull/4328.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Change the path of the places from https://integreat.app/testumgebung/de/locations to https://integreat.app/testumgebung/de/places
- Add redirects for the legacy path `locations`

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Check that the places feature still works as expected in both native and web. Check that both the new `places` path as well as the legacy `locations` path works in both web and native.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Part of: #4045

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
