### PR TITLE
4154: Improve region search to match exact and prefix strings

### DIFF
--- a/native/src/components/Highlighter.tsx
+++ b/native/src/components/Highlighter.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement } from 'react'
 import { StyleProp, TextStyle } from 'react-native'
 import { useTheme } from 'styled-components/native'
 
-import { findAllMatches, findNormalizedMatches, normalizeString } from 'shared'
+import { findAllMatches, findNormalizedMatches, normalizeString, Chunk, FindChunks } from 'shared'
 
 import Text from './base/Text'
 
@@ -10,16 +10,17 @@ type HighlighterProps = {
   search: string
   text: string
   style?: StyleProp<TextStyle>
+  findChunks?: (props: FindChunks) => Chunk[]
 }
 
-const Highlighter = ({ search, text, style }: HighlighterProps): ReactElement => {
+const Highlighter = ({ search, text, style, findChunks = findNormalizedMatches }: HighlighterProps): ReactElement => {
   const theme = useTheme()
   const chunks = findAllMatches({
     textToHighlight: text,
     searchWords: [search],
     sanitize: normalizeString,
     autoEscape: true,
-    findChunks: findNormalizedMatches,
+    findChunks,
   })
 
   return (

--- a/native/src/components/Highlighter.tsx
+++ b/native/src/components/Highlighter.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement } from 'react'
 import { StyleProp, TextStyle } from 'react-native'
 import { useTheme } from 'styled-components/native'
 
-import { findAllMatches, findNormalizedMatches, normalizeString, Chunk, FindChunks } from 'shared'
+import { findAllMatches, findNormalizedMatches, normalizeString, FindChunks } from 'shared'
 
 import Text from './base/Text'
 
@@ -10,17 +10,17 @@ type HighlighterProps = {
   search: string
   text: string
   style?: StyleProp<TextStyle>
-  findChunks?: (props: FindChunks) => Chunk[]
+  wordStartOnly?: boolean
 }
 
-const Highlighter = ({ search, text, style, findChunks = findNormalizedMatches }: HighlighterProps): ReactElement => {
+const Highlighter = ({ search, text, style, wordStartOnly = false }: HighlighterProps): ReactElement => {
   const theme = useTheme()
   const chunks = findAllMatches({
     textToHighlight: text,
     searchWords: [search],
     sanitize: normalizeString,
     autoEscape: true,
-    findChunks,
+    findChunks: (props: FindChunks) => findNormalizedMatches(props, { wordStartOnly }),
   })
 
   return (

--- a/native/src/components/RegionEntry.tsx
+++ b/native/src/components/RegionEntry.tsx
@@ -3,7 +3,7 @@ import { StyleSheet, View } from 'react-native'
 import { List as PaperList } from 'react-native-paper'
 import styled, { useTheme } from 'styled-components/native'
 
-import { getMatchingAliases, MAX_NUMBER_OF_ALIASES_SHOWN, normalizeString } from 'shared'
+import { getMatchingAliases, MAX_NUMBER_OF_ALIASES_SHOWN, findWordStartMatches } from 'shared'
 import { RegionModel } from 'shared/api'
 
 import { AppContext } from '../contexts/AppContext'
@@ -39,8 +39,7 @@ const RegionEntry = ({ region, query, navigateToDashboard }: RegionEntryProps): 
       color: theme.colors.onSurfaceVariant,
     },
   })
-  const normalizedQuery = normalizeString(query)
-  const matchingAliases = getMatchingAliases(region.aliases, normalizedQuery)
+  const matchingAliases = getMatchingAliases(region.aliases, query)
   const aliases = matchingAliases.slice(0, MAX_NUMBER_OF_ALIASES_SHOWN)
   const { languageCode } = useContext(AppContext)
 
@@ -49,7 +48,7 @@ const RegionEntry = ({ region, query, navigateToDashboard }: RegionEntryProps): 
       <AliasesWrapper>
         {aliases.map((it, index) => (
           <Fragment key={it}>
-            <AliasLabel search={normalizedQuery} text={it} />
+            <AliasLabel search={query} text={it} findChunks={findWordStartMatches} />
             {index !== aliases.length - 1 && (
               <Text variant='body3' style={styles.separator}>
                 ,{' '}
@@ -71,7 +70,7 @@ const RegionEntry = ({ region, query, navigateToDashboard }: RegionEntryProps): 
       titleNumberOfLines={0}
       title={
         <View>
-          <Label search={normalizedQuery} text={region.name} />
+          <Label search={query} text={region.name} findChunks={findWordStartMatches} />
         </View>
       }
       description={Aliases}

--- a/native/src/components/RegionEntry.tsx
+++ b/native/src/components/RegionEntry.tsx
@@ -3,15 +3,13 @@ import { StyleSheet, View } from 'react-native'
 import { List as PaperList } from 'react-native-paper'
 import styled, { useTheme } from 'styled-components/native'
 
-import { normalizeString } from 'shared'
+import { getMatchingAliases, MAX_NUMBER_OF_ALIASES_SHOWN, normalizeString } from 'shared'
 import { RegionModel } from 'shared/api'
 
 import { AppContext } from '../contexts/AppContext'
 import testID from '../testing/testID'
 import Highlighter from './Highlighter'
 import Text from './base/Text'
-
-const MAX_NUMBER_OF_ALIASES_SHOWN = 3
 
 const Label = styled(Highlighter)`
   color: ${props => props.theme.colors.onSurface};
@@ -42,10 +40,7 @@ const RegionEntry = ({ region, query, navigateToDashboard }: RegionEntryProps): 
     },
   })
   const normalizedQuery = normalizeString(query)
-  const matchingAliases =
-    region.aliases && normalizedQuery.length >= 1
-      ? Object.keys(region.aliases).filter(alias => normalizeString(alias).startsWith(normalizedQuery))
-      : []
+  const matchingAliases = getMatchingAliases(region.aliases, normalizedQuery)
   const aliases = matchingAliases.slice(0, MAX_NUMBER_OF_ALIASES_SHOWN)
   const { languageCode } = useContext(AppContext)
 

--- a/native/src/components/RegionEntry.tsx
+++ b/native/src/components/RegionEntry.tsx
@@ -44,7 +44,7 @@ const RegionEntry = ({ region, query, navigateToDashboard }: RegionEntryProps): 
   const normalizedQuery = normalizeString(query)
   const matchingAliases =
     region.aliases && normalizedQuery.length >= 1
-      ? Object.keys(region.aliases).filter(alias => normalizeString(alias).includes(normalizedQuery))
+      ? Object.keys(region.aliases).filter(alias => normalizeString(alias).startsWith(normalizedQuery))
       : []
   const aliases = matchingAliases.slice(0, MAX_NUMBER_OF_ALIASES_SHOWN)
   const { languageCode } = useContext(AppContext)

--- a/native/src/components/RegionEntry.tsx
+++ b/native/src/components/RegionEntry.tsx
@@ -3,7 +3,7 @@ import { StyleSheet, View } from 'react-native'
 import { List as PaperList } from 'react-native-paper'
 import styled, { useTheme } from 'styled-components/native'
 
-import { getMatchingAliases, MAX_NUMBER_OF_ALIASES_SHOWN, findWordStartMatches } from 'shared'
+import { getMatchingAliases, MAX_NUMBER_OF_ALIASES_SHOWN } from 'shared'
 import { RegionModel } from 'shared/api'
 
 import { AppContext } from '../contexts/AppContext'
@@ -48,7 +48,7 @@ const RegionEntry = ({ region, query, navigateToDashboard }: RegionEntryProps): 
       <AliasesWrapper>
         {aliases.map((it, index) => (
           <Fragment key={it}>
-            <AliasLabel search={query} text={it} findChunks={findWordStartMatches} />
+            <AliasLabel search={query} text={it} wordStartOnly />
             {index !== aliases.length - 1 && (
               <Text variant='body3' style={styles.separator}>
                 ,{' '}
@@ -70,7 +70,7 @@ const RegionEntry = ({ region, query, navigateToDashboard }: RegionEntryProps): 
       titleNumberOfLines={0}
       title={
         <View>
-          <Label search={query} text={region.name} findChunks={findWordStartMatches} />
+          <Label search={query} text={region.name} wordStartOnly />
         </View>
       }
       description={Aliases}

--- a/shared/api/models/RegionModel.ts
+++ b/shared/api/models/RegionModel.ts
@@ -2,7 +2,7 @@ import type { BBox } from 'geojson'
 
 import LanguageModel from './LanguageModel.js'
 
-type CoordinateType = { latitude: number; longitude: number }
+export type CoordinateType = { latitude: number; longitude: number }
 
 class RegionModel {
   _name: string

--- a/shared/api/models/RegionModel.ts
+++ b/shared/api/models/RegionModel.ts
@@ -2,7 +2,7 @@ import type { BBox } from 'geojson'
 
 import LanguageModel from './LanguageModel.js'
 
-export type CoordinateType = { latitude: number; longitude: number }
+type CoordinateType = { latitude: number; longitude: number }
 
 class RegionModel {
   _name: string

--- a/shared/constants/index.ts
+++ b/shared/constants/index.ts
@@ -1,5 +1,6 @@
 export const MAX_DATE_RECURRENCES = 3
 export const MAX_SEARCH_RESULTS = 75
+export const MAX_NUMBER_OF_ALIASES_SHOWN = 3
 export const DEFAULT_ROWS_NUMBER = 4
 export const SNACKBAR_AUTO_HIDE_DURATION = 5000
 export const SPRUNGBRETT_OFFER_ALIAS = 'sprungbrett'

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -1,8 +1,8 @@
 import { PreparePlacesReturn as ImportedPreparePlacesReturn } from './utils/places.js'
 
-export { Chunk, findAll, findChunks, FindChunks } from 'highlight-words-core'
 export type PreparePlacesReturn = ImportedPreparePlacesReturn
 export type { Chunk, FindAll, FindChunks } from 'highlight-words-core'
+export { findAll, findChunks } from 'highlight-words-core'
 export { default as useSearch, prepareSearchDocuments } from './hooks/useSearch.js'
 export { default as useDebounce } from './hooks/useDebounce.js'
 export { default as useDateFilter } from './hooks/useDateFilter.js'
@@ -16,7 +16,7 @@ export * from './utils/licences.js'
 export * from './utils/places.js'
 export * from './utils/replaceLinks.js'
 export * from './utils/normalizeString.js'
-export { findNormalizedMatches, findAllMatches, findWordStartMatches } from './utils/findNormalizedMatches.js'
+export { default as findNormalizedMatches, findAllMatches } from './utils/findNormalizedMatches.js'
 export * from './utils/index.js'
 export { getCategoryTiles } from './utils/categories.js'
 export * from './constants/map.js'

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -1,5 +1,6 @@
 import { PreparePlacesReturn as ImportedPreparePlacesReturn } from './utils/places.js'
 
+export { Chunk, findAll, findChunks, FindChunks } from 'highlight-words-core'
 export type PreparePlacesReturn = ImportedPreparePlacesReturn
 export type { Chunk, FindAll, FindChunks } from 'highlight-words-core'
 export { default as useSearch, prepareSearchDocuments } from './hooks/useSearch.js'
@@ -15,7 +16,7 @@ export * from './utils/licences.js'
 export * from './utils/places.js'
 export * from './utils/replaceLinks.js'
 export * from './utils/normalizeString.js'
-export { default as findNormalizedMatches, findAllMatches } from './utils/findNormalizedMatches.js'
+export { findNormalizedMatches, findAllMatches, findWordStartMatches } from './utils/findNormalizedMatches.js'
 export * from './utils/index.js'
 export { getCategoryTiles } from './utils/categories.js'
 export * from './constants/map.js'

--- a/shared/utils/__tests__/findNormalizedMatches.spec.ts
+++ b/shared/utils/__tests__/findNormalizedMatches.spec.ts
@@ -1,4 +1,4 @@
-import { findNormalizedMatches, findWordStartMatches } from '../findNormalizedMatches.js'
+import findNormalizedMatches from '../findNormalizedMatches.js'
 import normalizeString from '../normalizeString.js'
 
 describe('findNormalizedMatches', () => {
@@ -40,36 +40,44 @@ describe('findNormalizedMatches', () => {
   })
 
   it('should find a match at the start of the string', () => {
-    expect(findWordStartMatches({ searchWords: ['land'], textToHighlight: 'Landkreis', sanitize })).toEqual([
-      { start: 0, end: 4, highlight: false },
-    ])
+    expect(
+      findNormalizedMatches({ searchWords: ['land'], textToHighlight: 'Landkreis', sanitize }, { wordStartOnly: true }),
+    ).toEqual([{ start: 0, end: 4, highlight: false }])
   })
 
   it('should find a match after a space', () => {
-    expect(findWordStartMatches({ searchWords: ['b'], textToHighlight: 'Landkreis Birkenfeld', sanitize })).toEqual([
-      { start: 10, end: 11, highlight: false },
-    ])
+    expect(
+      findNormalizedMatches(
+        { searchWords: ['b'], textToHighlight: 'Landkreis Birkenfeld', sanitize },
+        { wordStartOnly: true },
+      ),
+    ).toEqual([{ start: 10, end: 11, highlight: false }])
   })
 
   it('should find a match after a dash', () => {
     expect(
-      findWordStartMatches({ searchWords: ['hoch'], textToHighlight: 'Breisgau-Hochschwarzwald', sanitize }),
+      findNormalizedMatches(
+        { searchWords: ['hoch'], textToHighlight: 'Breisgau-Hochschwarzwald', sanitize },
+        { wordStartOnly: true },
+      ),
     ).toEqual([{ start: 9, end: 13, highlight: false }])
   })
 
   it('should not find a mid-word match', () => {
-    expect(findWordStartMatches({ searchWords: ['a'], textToHighlight: 'Landkreis', sanitize })).toEqual([])
+    expect(
+      findNormalizedMatches({ searchWords: ['a'], textToHighlight: 'Landkreis', sanitize }, { wordStartOnly: true }),
+    ).toEqual([])
   })
 
   it('should find word containing ss with search word ß', () => {
-    expect(findWordStartMatches({ searchWords: ['Straße'], textToHighlight: 'Strasse', sanitize })).toEqual([
-      { start: 0, end: 7, highlight: false },
-    ])
+    expect(
+      findNormalizedMatches({ searchWords: ['Straße'], textToHighlight: 'Strasse', sanitize }, { wordStartOnly: true }),
+    ).toEqual([{ start: 0, end: 7, highlight: false }])
   })
 
   it('should find word containing ß with search word ss', () => {
-    expect(findWordStartMatches({ searchWords: ['Strasse'], textToHighlight: 'Straße', sanitize })).toEqual([
-      { start: 0, end: 6, highlight: false },
-    ])
+    expect(
+      findNormalizedMatches({ searchWords: ['Strasse'], textToHighlight: 'Straße', sanitize }, { wordStartOnly: true }),
+    ).toEqual([{ start: 0, end: 6, highlight: false }])
   })
 })

--- a/shared/utils/__tests__/findNormalizedMatches.spec.ts
+++ b/shared/utils/__tests__/findNormalizedMatches.spec.ts
@@ -4,38 +4,37 @@ import normalizeString from '../normalizeString.js'
 describe('findNormalizedMatches', () => {
   const sanitize = normalizeString
 
-  it('should find sections with ß', () => {
-    expect(findNormalizedMatches({ searchWords: ['ß'], textToHighlight: 'aßaßaß', sanitize })).toEqual([
-      { start: 1, end: 2, highlight: false },
-      { start: 3, end: 4, highlight: false },
-      { start: 5, end: 6, highlight: false },
+  it('should find a match at the start of the string', () => {
+    expect(findNormalizedMatches({ searchWords: ['land'], textToHighlight: 'Landkreis', sanitize })).toEqual([
+      { start: 0, end: 4, highlight: false },
     ])
-    expect(findNormalizedMatches({ searchWords: ['ß'], textToHighlight: 'wasserstraße', sanitize })).toEqual([
-      { start: 2, end: 4, highlight: false },
+  })
+
+  it('should find a match after a space', () => {
+    expect(findNormalizedMatches({ searchWords: ['b'], textToHighlight: 'Landkreis Birkenfeld', sanitize })).toEqual([
       { start: 10, end: 11, highlight: false },
     ])
   })
 
-  it('should find sections with ss', () => {
-    expect(findNormalizedMatches({ searchWords: ['ss'], textToHighlight: 'aßaßaß', sanitize })).toEqual([
-      { start: 1, end: 2, highlight: false },
-      { start: 3, end: 4, highlight: false },
-      { start: 5, end: 6, highlight: false },
-    ])
-    expect(findNormalizedMatches({ searchWords: ['ss'], textToHighlight: 'wasserstraße', sanitize })).toEqual([
-      { start: 2, end: 4, highlight: false },
-      { start: 10, end: 11, highlight: false },
-    ])
+  it('should find a match after a dash', () => {
+    expect(
+      findNormalizedMatches({ searchWords: ['hoch'], textToHighlight: 'Breisgau-Hochschwarzwald', sanitize }),
+    ).toEqual([{ start: 9, end: 13, highlight: false }])
   })
 
-  it('should find sections of words', () => {
-    expect(findNormalizedMatches({ searchWords: ['straße'], textToHighlight: 'Strassenstraße', sanitize })).toEqual([
+  it('should not find a mid-word match', () => {
+    expect(findNormalizedMatches({ searchWords: ['a'], textToHighlight: 'Landkreis', sanitize })).toEqual([])
+  })
+
+  it('should find word containing ss with search word ß', () => {
+    expect(findNormalizedMatches({ searchWords: ['Straße'], textToHighlight: 'Strasse', sanitize })).toEqual([
       { start: 0, end: 7, highlight: false },
-      { start: 8, end: 14, highlight: false },
     ])
-    expect(findNormalizedMatches({ searchWords: ['städt'], textToHighlight: 'stadt städtchen', sanitize })).toEqual([
-      { start: 0, end: 5, highlight: false },
-      { start: 6, end: 11, highlight: false },
+  })
+
+  it('should find word containing ß with search word ss', () => {
+    expect(findNormalizedMatches({ searchWords: ['Strasse'], textToHighlight: 'Straße', sanitize })).toEqual([
+      { start: 0, end: 6, highlight: false },
     ])
   })
 })

--- a/shared/utils/__tests__/findNormalizedMatches.spec.ts
+++ b/shared/utils/__tests__/findNormalizedMatches.spec.ts
@@ -1,39 +1,74 @@
-import findNormalizedMatches from '../findNormalizedMatches.js'
+import { findNormalizedMatches, findWordStartMatches } from '../findNormalizedMatches.js'
 import normalizeString from '../normalizeString.js'
 
 describe('findNormalizedMatches', () => {
   const sanitize = normalizeString
 
+  it('should find sections with ß', () => {
+    expect(findNormalizedMatches({ searchWords: ['ß'], textToHighlight: 'aßaßaß', sanitize })).toEqual([
+      { start: 1, end: 2, highlight: false },
+      { start: 3, end: 4, highlight: false },
+      { start: 5, end: 6, highlight: false },
+    ])
+    expect(findNormalizedMatches({ searchWords: ['ß'], textToHighlight: 'wasserstraße', sanitize })).toEqual([
+      { start: 2, end: 4, highlight: false },
+      { start: 10, end: 11, highlight: false },
+    ])
+  })
+
+  it('should find sections with ss', () => {
+    expect(findNormalizedMatches({ searchWords: ['ss'], textToHighlight: 'aßaßaß', sanitize })).toEqual([
+      { start: 1, end: 2, highlight: false },
+      { start: 3, end: 4, highlight: false },
+      { start: 5, end: 6, highlight: false },
+    ])
+    expect(findNormalizedMatches({ searchWords: ['ss'], textToHighlight: 'wasserstraße', sanitize })).toEqual([
+      { start: 2, end: 4, highlight: false },
+      { start: 10, end: 11, highlight: false },
+    ])
+  })
+
+  it('should find sections of words', () => {
+    expect(findNormalizedMatches({ searchWords: ['straße'], textToHighlight: 'Strassenstraße', sanitize })).toEqual([
+      { start: 0, end: 7, highlight: false },
+      { start: 8, end: 14, highlight: false },
+    ])
+    expect(findNormalizedMatches({ searchWords: ['städt'], textToHighlight: 'stadt städtchen', sanitize })).toEqual([
+      { start: 0, end: 5, highlight: false },
+      { start: 6, end: 11, highlight: false },
+    ])
+  })
+
   it('should find a match at the start of the string', () => {
-    expect(findNormalizedMatches({ searchWords: ['land'], textToHighlight: 'Landkreis', sanitize })).toEqual([
+    expect(findWordStartMatches({ searchWords: ['land'], textToHighlight: 'Landkreis', sanitize })).toEqual([
       { start: 0, end: 4, highlight: false },
     ])
   })
 
   it('should find a match after a space', () => {
-    expect(findNormalizedMatches({ searchWords: ['b'], textToHighlight: 'Landkreis Birkenfeld', sanitize })).toEqual([
+    expect(findWordStartMatches({ searchWords: ['b'], textToHighlight: 'Landkreis Birkenfeld', sanitize })).toEqual([
       { start: 10, end: 11, highlight: false },
     ])
   })
 
   it('should find a match after a dash', () => {
     expect(
-      findNormalizedMatches({ searchWords: ['hoch'], textToHighlight: 'Breisgau-Hochschwarzwald', sanitize }),
+      findWordStartMatches({ searchWords: ['hoch'], textToHighlight: 'Breisgau-Hochschwarzwald', sanitize }),
     ).toEqual([{ start: 9, end: 13, highlight: false }])
   })
 
   it('should not find a mid-word match', () => {
-    expect(findNormalizedMatches({ searchWords: ['a'], textToHighlight: 'Landkreis', sanitize })).toEqual([])
+    expect(findWordStartMatches({ searchWords: ['a'], textToHighlight: 'Landkreis', sanitize })).toEqual([])
   })
 
   it('should find word containing ss with search word ß', () => {
-    expect(findNormalizedMatches({ searchWords: ['Straße'], textToHighlight: 'Strasse', sanitize })).toEqual([
+    expect(findWordStartMatches({ searchWords: ['Straße'], textToHighlight: 'Strasse', sanitize })).toEqual([
       { start: 0, end: 7, highlight: false },
     ])
   })
 
   it('should find word containing ß with search word ss', () => {
-    expect(findNormalizedMatches({ searchWords: ['Strasse'], textToHighlight: 'Straße', sanitize })).toEqual([
+    expect(findWordStartMatches({ searchWords: ['Strasse'], textToHighlight: 'Straße', sanitize })).toEqual([
       { start: 0, end: 6, highlight: false },
     ])
   })

--- a/shared/utils/__tests__/search.spec.ts
+++ b/shared/utils/__tests__/search.spec.ts
@@ -109,5 +109,22 @@ describe('search', () => {
       ]
       expect(filterSortRegions(regions, 'ba')).toEqual([regions[3], regions[4], regions[5]])
     })
+
+    it('should not return live regions when the string is mid-word of the names or aliases', () => {
+      const regions = [
+        region({ sortingName: 'Aichach' }),
+        region({ sortingName: 'Stadtbaden' }),
+        region({
+          sortingName: 'Dillingen',
+          aliases: {
+            Musterstadtbäden: {
+              latitude: 48.267499,
+              longitude: 10.889586,
+            },
+          },
+        }),
+      ]
+      expect(filterSortRegions(regions, 'ba')).toEqual([])
+    })
   })
 })

--- a/shared/utils/__tests__/search.spec.ts
+++ b/shared/utils/__tests__/search.spec.ts
@@ -68,7 +68,7 @@ describe('search', () => {
         region({ sortingName: 'Augsburg', prefix: 'Stadt', live: true }),
         region({ sortingName: 'Dillingen', live: false }),
       ]
-      expect(filterSortRegions(regions, 'a', true)).toEqual([regions[0], regions[1], regions[2], regions[3]])
+      expect(filterSortRegions(regions, 'a', true)).toEqual([regions[0], regions[1], regions[2]])
     })
 
     it('should return all non live regions if filter text is wirschaffendas', () => {
@@ -84,9 +84,9 @@ describe('search', () => {
     it('should only return live regions with matching names or aliases', () => {
       const regions = [
         region({ sortingName: 'Aichach' }),
-        region({ sortingName: 'Aichach', prefix: 'Landkreis', live: false }),
+        region({ sortingName: 'Bad Kissingen', prefix: 'Landkreis', live: false }),
         region({ sortingName: 'Augsburg', prefix: 'Stadt' }),
-        region({ sortingName: 'Dachau' }),
+        region({ sortingName: 'Baden-Baden' }),
         region({
           sortingName: 'Dillingen',
           aliases: {
@@ -107,7 +107,7 @@ describe('search', () => {
         }),
         region({ sortingName: 'Nürnberg' }),
       ]
-      expect(filterSortRegions(regions, 'äch')).toEqual([regions[0], regions[3], regions[4], regions[5]])
+      expect(filterSortRegions(regions, 'ba')).toEqual([regions[3], regions[4], regions[5]])
     })
   })
 })

--- a/shared/utils/findNormalizedMatches.ts
+++ b/shared/utils/findNormalizedMatches.ts
@@ -1,5 +1,8 @@
 import { Chunk, FindAll, findAll, findChunks, FindChunks } from 'highlight-words-core'
 
+import normalizeString from './normalizeString'
+import { MATCH_WHITESPACE_AND_DASHES } from './search'
+
 const charsAddedByNormalization = (text: string, until: number) => {
   let charsAdded = 0
   for (let i = 0; i < until - charsAdded; i += 1) {
@@ -11,16 +14,21 @@ const charsAddedByNormalization = (text: string, until: number) => {
 }
 
 const findNormalizedMatches = (props: FindChunks): Chunk[] => {
-  const chunks: Chunk[] = findChunks(props)
-  return chunks.map(chunk => {
-    const charsAddedBeforeMatch = charsAddedByNormalization(props.textToHighlight, chunk.start)
-    const charsAddedIncludingMatch = charsAddedByNormalization(props.textToHighlight, chunk.end)
-    return {
-      ...chunk,
-      start: chunk.start - charsAddedBeforeMatch,
-      end: chunk.end - charsAddedIncludingMatch,
-    }
-  })
+  const normalized = normalizeString(props.textToHighlight)
+  return (
+    findChunks(props)
+      // Match at the beginning or in the middle where the new word starts
+      .filter(chunk => chunk.start === 0 || MATCH_WHITESPACE_AND_DASHES.test(normalized[chunk.start - 1] ?? ''))
+      .map(chunk => {
+        const charsAddedBeforeMatch = charsAddedByNormalization(props.textToHighlight, chunk.start)
+        const charsAddedIncludingMatch = charsAddedByNormalization(props.textToHighlight, chunk.end)
+        return {
+          ...chunk,
+          start: chunk.start - charsAddedBeforeMatch,
+          end: chunk.end - charsAddedIncludingMatch,
+        }
+      })
+  )
 }
 
 export const findAllMatches: (args: FindAll) => Chunk[] = findAll

--- a/shared/utils/findNormalizedMatches.ts
+++ b/shared/utils/findNormalizedMatches.ts
@@ -13,24 +13,32 @@ const charsAddedByNormalization = (text: string, until: number) => {
   return charsAdded
 }
 
-const findNormalizedMatches = (props: FindChunks): Chunk[] => {
+const buildMatches = (props: FindChunks, wordStartOnly: boolean): Chunk[] => {
+  const normalizedMatches = (chunk: Chunk): Chunk => {
+    const charsAddedBeforeMatch = charsAddedByNormalization(props.textToHighlight, chunk.start)
+    const charsAddedIncludingMatch = charsAddedByNormalization(props.textToHighlight, chunk.end)
+    return {
+      ...chunk,
+      start: chunk.start - charsAddedBeforeMatch,
+      end: chunk.end - charsAddedIncludingMatch,
+    }
+  }
+
+  const chunks = findChunks(props)
+  if (!wordStartOnly) {
+    return chunks.map(normalizedMatches)
+  }
+
   const normalized = normalizeString(props.textToHighlight)
   return (
-    findChunks(props)
+    chunks
       // Match at the beginning or in the middle where the new word starts
       .filter(chunk => chunk.start === 0 || MATCH_WHITESPACE_AND_DASHES.test(normalized[chunk.start - 1] ?? ''))
-      .map(chunk => {
-        const charsAddedBeforeMatch = charsAddedByNormalization(props.textToHighlight, chunk.start)
-        const charsAddedIncludingMatch = charsAddedByNormalization(props.textToHighlight, chunk.end)
-        return {
-          ...chunk,
-          start: chunk.start - charsAddedBeforeMatch,
-          end: chunk.end - charsAddedIncludingMatch,
-        }
-      })
+      .map(normalizedMatches)
   )
 }
 
 export const findAllMatches: (args: FindAll) => Chunk[] = findAll
 
-export default findNormalizedMatches
+export const findNormalizedMatches = (props: FindChunks): Chunk[] => buildMatches(props, false)
+export const findWordStartMatches = (props: FindChunks): Chunk[] => buildMatches(props, true)

--- a/shared/utils/findNormalizedMatches.ts
+++ b/shared/utils/findNormalizedMatches.ts
@@ -3,10 +3,6 @@ import { Chunk, FindAll, findAll, findChunks, FindChunks } from 'highlight-words
 import normalizeString from './normalizeString.js'
 import { MATCH_WHITESPACE_AND_DASHES } from './search.js'
 
-type FindNormalizedMatchesOptions = {
-  wordStartOnly?: boolean
-}
-
 const charsAddedByNormalization = (text: string, until: number) => {
   let charsAdded = 0
   for (let i = 0; i < until - charsAdded; i += 1) {
@@ -19,7 +15,7 @@ const charsAddedByNormalization = (text: string, until: number) => {
 
 const findNormalizedMatches = (
   props: FindChunks,
-  { wordStartOnly = false }: FindNormalizedMatchesOptions = {},
+  { wordStartOnly = false }: { wordStartOnly?: boolean } = {},
 ): Chunk[] => {
   const normalizedMatches = (chunk: Chunk): Chunk => {
     const charsAddedBeforeMatch = charsAddedByNormalization(props.textToHighlight, chunk.start)

--- a/shared/utils/findNormalizedMatches.ts
+++ b/shared/utils/findNormalizedMatches.ts
@@ -1,7 +1,11 @@
 import { Chunk, FindAll, findAll, findChunks, FindChunks } from 'highlight-words-core'
 
-import normalizeString from './normalizeString'
-import { MATCH_WHITESPACE_AND_DASHES } from './search'
+import normalizeString from './normalizeString.js'
+import { MATCH_WHITESPACE_AND_DASHES } from './search.js'
+
+type FindNormalizedMatchesOptions = {
+  wordStartOnly?: boolean
+}
 
 const charsAddedByNormalization = (text: string, until: number) => {
   let charsAdded = 0
@@ -13,7 +17,10 @@ const charsAddedByNormalization = (text: string, until: number) => {
   return charsAdded
 }
 
-const buildMatches = (props: FindChunks, wordStartOnly: boolean): Chunk[] => {
+const findNormalizedMatches = (
+  props: FindChunks,
+  { wordStartOnly = false }: FindNormalizedMatchesOptions = {},
+): Chunk[] => {
   const normalizedMatches = (chunk: Chunk): Chunk => {
     const charsAddedBeforeMatch = charsAddedByNormalization(props.textToHighlight, chunk.start)
     const charsAddedIncludingMatch = charsAddedByNormalization(props.textToHighlight, chunk.end)
@@ -40,5 +47,4 @@ const buildMatches = (props: FindChunks, wordStartOnly: boolean): Chunk[] => {
 
 export const findAllMatches: (args: FindAll) => Chunk[] = findAll
 
-export const findNormalizedMatches = (props: FindChunks): Chunk[] => buildMatches(props, false)
-export const findWordStartMatches = (props: FindChunks): Chunk[] => buildMatches(props, true)
+export default findNormalizedMatches

--- a/shared/utils/search.ts
+++ b/shared/utils/search.ts
@@ -10,8 +10,14 @@ const regionFilter =
     }
 
     const validRegion = regionModel.live || developerFriendly
+
+    // Matches with all three string start cases, for ex. Landkreis Breisgau-Hochschwarzwald
+    const matchesWordStart = (region: string) =>
+      normalizeString(region)
+        .split(/[\s-]+/)
+        .some(word => word.startsWith(normalizedFilter))
     const aliases = Object.keys(regionModel.aliases ?? {})
-    const matchesFilter = [regionModel.name, ...aliases].some(it => normalizeString(it).includes(normalizedFilter))
+    const matchesFilter = matchesWordStart(regionModel.name) || aliases.some(matchesWordStart)
     return validRegion && matchesFilter
   }
 

--- a/shared/utils/search.ts
+++ b/shared/utils/search.ts
@@ -1,5 +1,13 @@
-import RegionModel from '../api/models/RegionModel.js'
+import RegionModel, { CoordinateType } from '../api/models/RegionModel.js'
 import { normalizeString } from './normalizeString.js'
+
+export const MATCH_WHITESPACE_AND_DASHES = /[\s-]+/
+
+// Matches with all three string start cases, for ex. Landkreis Breisgau-Hochschwarzwald
+const matchesWordStart = (text: string, normalizedFilter: string): boolean =>
+  normalizeString(text)
+    .split(MATCH_WHITESPACE_AND_DASHES)
+    .some(word => word.startsWith(normalizedFilter))
 
 const regionFilter =
   (filterText: string, developerFriendly: boolean) =>
@@ -10,14 +18,10 @@ const regionFilter =
     }
 
     const validRegion = regionModel.live || developerFriendly
-
-    // Matches with all three string start cases, for ex. Landkreis Breisgau-Hochschwarzwald
-    const matchesWordStart = (region: string) =>
-      normalizeString(region)
-        .split(/[\s-]+/)
-        .some(word => word.startsWith(normalizedFilter))
     const aliases = Object.keys(regionModel.aliases ?? {})
-    const matchesFilter = matchesWordStart(regionModel.name) || aliases.some(matchesWordStart)
+    const matchesFilter =
+      matchesWordStart(regionModel.name, normalizedFilter) ||
+      aliases.some(alias => matchesWordStart(alias, normalizedFilter))
     return validRegion && matchesFilter
   }
 
@@ -32,3 +36,13 @@ export const filterSortRegions = (
   filterText: string,
   developerFriendly = false,
 ): RegionModel[] => regions.filter(regionFilter(filterText, developerFriendly)).sort(regionSort)
+
+export const getMatchingAliases = (
+  aliases: Record<string, CoordinateType> | null,
+  normalizedFilter: string,
+): string[] => {
+  if (!aliases) {
+    return []
+  }
+  return Object.keys(aliases).filter(alias => matchesWordStart(alias, normalizedFilter))
+}

--- a/shared/utils/search.ts
+++ b/shared/utils/search.ts
@@ -1,4 +1,4 @@
-import RegionModel, { CoordinateType } from '../api/models/RegionModel.js'
+import RegionModel from '../api/models/RegionModel.js'
 import { normalizeString } from './normalizeString.js'
 
 export const MATCH_WHITESPACE_AND_DASHES = /[\s-]+/
@@ -37,10 +37,8 @@ export const filterSortRegions = (
   developerFriendly = false,
 ): RegionModel[] => regions.filter(regionFilter(filterText, developerFriendly)).sort(regionSort)
 
-export const getMatchingAliases = (
-  aliases: Record<string, CoordinateType> | null,
-  normalizedFilter: string,
-): string[] => {
+export const getMatchingAliases = (aliases: Record<string, unknown> | null, filterText: string): string[] => {
+  const normalizedFilter = normalizeString(filterText)
   if (!aliases) {
     return []
   }

--- a/shared/utils/search.ts
+++ b/shared/utils/search.ts
@@ -38,9 +38,11 @@ export const filterSortRegions = (
 ): RegionModel[] => regions.filter(regionFilter(filterText, developerFriendly)).sort(regionSort)
 
 export const getMatchingAliases = (aliases: Record<string, unknown> | null, filterText: string): string[] => {
-  const normalizedFilter = normalizeString(filterText)
   if (!aliases) {
     return []
   }
+
+  const normalizedFilter = normalizeString(filterText)
+
   return Object.keys(aliases).filter(alias => matchesWordStart(alias, normalizedFilter))
 }

--- a/web/src/components/Highlighter.tsx
+++ b/web/src/components/Highlighter.tsx
@@ -1,29 +1,19 @@
 import { useTheme } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
-import ReactHighlightWords from 'react-highlight-words'
-import type { HighlighterProps as ReactHighlighterProps } from 'react-highlight-words'
+import ReactHighlighter from 'react-highlight-words'
 
-import { Chunk, FindChunks, findNormalizedMatches, normalizeString } from 'shared'
+import { findNormalizedMatches, normalizeString, FindChunks } from 'shared'
 import { UiDirectionType } from 'translations'
-
-// To fix CJS interop to not being recognized as a React component
-const ReactHighlighter = ReactHighlightWords as unknown as React.ComponentClass<ReactHighlighterProps>
 
 type HighlighterProps = {
   search: string
   text: string
   className?: string
   dir?: UiDirectionType | 'auto'
-  findChunks?: (props: FindChunks) => Chunk[]
+  wordStartOnly?: boolean
 }
 
-const Highlighter = ({
-  search,
-  text,
-  className,
-  dir,
-  findChunks = findNormalizedMatches,
-}: HighlighterProps): ReactElement => {
+const Highlighter = ({ search, text, className, dir, wordStartOnly = false }: HighlighterProps): ReactElement => {
   const theme = useTheme()
   return (
     <ReactHighlighter
@@ -31,7 +21,7 @@ const Highlighter = ({
       textToHighlight={text}
       searchWords={[search]}
       sanitize={normalizeString}
-      findChunks={findChunks}
+      findChunks={(props: FindChunks) => findNormalizedMatches(props, { wordStartOnly })}
       highlightStyle={{
         backgroundColor: theme.palette.tertiary.light,
         fontWeight: 'bold',

--- a/web/src/components/Highlighter.tsx
+++ b/web/src/components/Highlighter.tsx
@@ -3,7 +3,7 @@ import React, { ReactElement } from 'react'
 import ReactHighlightWords from 'react-highlight-words'
 import type { HighlighterProps as ReactHighlighterProps } from 'react-highlight-words'
 
-import { findNormalizedMatches, normalizeString } from 'shared'
+import { Chunk, FindChunks, findNormalizedMatches, normalizeString } from 'shared'
 import { UiDirectionType } from 'translations'
 
 // To fix CJS interop to not being recognized as a React component
@@ -14,9 +14,16 @@ type HighlighterProps = {
   text: string
   className?: string
   dir?: UiDirectionType | 'auto'
+  findChunks?: (props: FindChunks) => Chunk[]
 }
 
-const Highlighter = ({ search, text, className, dir }: HighlighterProps): ReactElement => {
+const Highlighter = ({
+  search,
+  text,
+  className,
+  dir,
+  findChunks = findNormalizedMatches,
+}: HighlighterProps): ReactElement => {
   const theme = useTheme()
   return (
     <ReactHighlighter
@@ -24,7 +31,7 @@ const Highlighter = ({ search, text, className, dir }: HighlighterProps): ReactE
       textToHighlight={text}
       searchWords={[search]}
       sanitize={normalizeString}
-      findChunks={findNormalizedMatches}
+      findChunks={findChunks}
       highlightStyle={{
         backgroundColor: theme.palette.tertiary.light,
         fontWeight: 'bold',

--- a/web/src/components/RegionListItem.tsx
+++ b/web/src/components/RegionListItem.tsx
@@ -21,7 +21,7 @@ const RegionListItem = ({ filterText, region, language }: RegionEntryProps): Rea
   const normalizedFilter = normalizeString(filterText)
   const aliases =
     region.aliases && normalizedFilter.length >= 1
-      ? Object.keys(region.aliases).filter(alias => normalizeString(alias).includes(normalizedFilter))
+      ? Object.keys(region.aliases).filter(alias => normalizeString(alias).startsWith(normalizedFilter))
       : []
   const aliasesText = aliases.slice(0, MAX_NUMBER_OF_ALIASES).join(', ')
 

--- a/web/src/components/RegionListItem.tsx
+++ b/web/src/components/RegionListItem.tsx
@@ -3,7 +3,7 @@ import ListItemButton from '@mui/material/ListItemButton'
 import ListItemText from '@mui/material/ListItemText'
 import React, { ReactElement } from 'react'
 
-import { regionContentPath, getMatchingAliases, MAX_NUMBER_OF_ALIASES_SHOWN, findWordStartMatches } from 'shared'
+import { regionContentPath, getMatchingAliases, MAX_NUMBER_OF_ALIASES_SHOWN } from 'shared'
 import { RegionModel } from 'shared/api'
 
 import Highlighter from './Highlighter'
@@ -23,10 +23,10 @@ const RegionListItem = ({ filterText, region, language }: RegionEntryProps): Rea
     <ListItem alignItems='flex-start' disablePadding>
       <ListItemButton component={Link} to={regionContentPath({ regionCode: region.code, languageCode: language })}>
         <ListItemText
-          primary={<Highlighter search={filterText} text={region.name} findChunks={findWordStartMatches} />}
+          primary={<Highlighter search={filterText} text={region.name} wordStartOnly />}
           secondary={
             <>
-              <Highlighter search={filterText} text={aliasesText} findChunks={findWordStartMatches} />
+              <Highlighter search={filterText} text={aliasesText} wordStartOnly />
               {aliases.length > MAX_NUMBER_OF_ALIASES_SHOWN && <span> ... </span>}
             </>
           }

--- a/web/src/components/RegionListItem.tsx
+++ b/web/src/components/RegionListItem.tsx
@@ -3,7 +3,7 @@ import ListItemButton from '@mui/material/ListItemButton'
 import ListItemText from '@mui/material/ListItemText'
 import React, { ReactElement } from 'react'
 
-import { regionContentPath, normalizeString } from 'shared'
+import { regionContentPath, getMatchingAliases, MAX_NUMBER_OF_ALIASES_SHOWN, normalizeString } from 'shared'
 import { RegionModel } from 'shared/api'
 
 import Highlighter from './Highlighter'
@@ -19,11 +19,8 @@ type RegionEntryProps = {
 
 const RegionListItem = ({ filterText, region, language }: RegionEntryProps): ReactElement => {
   const normalizedFilter = normalizeString(filterText)
-  const aliases =
-    region.aliases && normalizedFilter.length >= 1
-      ? Object.keys(region.aliases).filter(alias => normalizeString(alias).startsWith(normalizedFilter))
-      : []
-  const aliasesText = aliases.slice(0, MAX_NUMBER_OF_ALIASES).join(', ')
+  const aliases = getMatchingAliases(region.aliases, normalizedFilter)
+  const aliasesText = aliases.slice(0, MAX_NUMBER_OF_ALIASES_SHOWN).join(', ')
 
   return (
     <ListItem alignItems='flex-start' disablePadding>
@@ -33,7 +30,7 @@ const RegionListItem = ({ filterText, region, language }: RegionEntryProps): Rea
           secondary={
             <>
               <Highlighter search={filterText} text={aliasesText} />
-              {aliases.length > MAX_NUMBER_OF_ALIASES && <span> ... </span>}
+              {aliases.length > MAX_NUMBER_OF_ALIASES_SHOWN && <span> ... </span>}
             </>
           }
           slotProps={{

--- a/web/src/components/RegionListItem.tsx
+++ b/web/src/components/RegionListItem.tsx
@@ -3,13 +3,11 @@ import ListItemButton from '@mui/material/ListItemButton'
 import ListItemText from '@mui/material/ListItemText'
 import React, { ReactElement } from 'react'
 
-import { regionContentPath, getMatchingAliases, MAX_NUMBER_OF_ALIASES_SHOWN, normalizeString } from 'shared'
+import { regionContentPath, getMatchingAliases, MAX_NUMBER_OF_ALIASES_SHOWN, findWordStartMatches } from 'shared'
 import { RegionModel } from 'shared/api'
 
 import Highlighter from './Highlighter'
 import Link from './base/Link'
-
-const MAX_NUMBER_OF_ALIASES = 3
 
 type RegionEntryProps = {
   language: string
@@ -18,18 +16,17 @@ type RegionEntryProps = {
 }
 
 const RegionListItem = ({ filterText, region, language }: RegionEntryProps): ReactElement => {
-  const normalizedFilter = normalizeString(filterText)
-  const aliases = getMatchingAliases(region.aliases, normalizedFilter)
+  const aliases = getMatchingAliases(region.aliases, filterText)
   const aliasesText = aliases.slice(0, MAX_NUMBER_OF_ALIASES_SHOWN).join(', ')
 
   return (
     <ListItem alignItems='flex-start' disablePadding>
       <ListItemButton component={Link} to={regionContentPath({ regionCode: region.code, languageCode: language })}>
         <ListItemText
-          primary={<Highlighter search={filterText} text={region.name} />}
+          primary={<Highlighter search={filterText} text={region.name} findChunks={findWordStartMatches} />}
           secondary={
             <>
-              <Highlighter search={filterText} text={aliasesText} />
+              <Highlighter search={filterText} text={aliasesText} findChunks={findWordStartMatches} />
               {aliases.length > MAX_NUMBER_OF_ALIASES_SHOWN && <span> ... </span>}
             </>
           }


### PR DESCRIPTION
### Short Description
This PR improves region search by matching exact regions or aliases by using `startsWith` string method to match whether this string begins with the exact string

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Adjust search.ts to always return beginning string matches for region names or aliases
- Create shared helpers `matchesWordStart` and `getMatchingAliases`
- Adjust `findNormalizedMatches` to match at the beginning or in the middle where the new word starts
- Add additional test cases

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

Go to region selection and look for `Mu` and see that it returns exact region or alias beginning names

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4154 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
