### PR TITLE
Downgrade webpack-dev-server

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -100,6 +100,6 @@
     "webpack": "^5.105.4",
     "webpack-bundle-analyzer": "^5.3.0",
     "webpack-cli": "^7.0.2",
-    "webpack-dev-server": "5.2.4"
+    "webpack-dev-server": "5.2.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -23842,7 +23842,7 @@ __metadata:
     webpack: "npm:^5.105.4"
     webpack-bundle-analyzer: "npm:^5.3.0"
     webpack-cli: "npm:^7.0.2"
-    webpack-dev-server: "npm:5.2.4"
+    webpack-dev-server: "npm:5.2.3"
   languageName: unknown
   linkType: soft
 
@@ -23991,9 +23991,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-dev-server@npm:5.2.4":
-  version: 5.2.4
-  resolution: "webpack-dev-server@npm:5.2.4"
+"webpack-dev-server@npm:5.2.3":
+  version: 5.2.3
+  resolution: "webpack-dev-server@npm:5.2.3"
   dependencies:
     "@types/bonjour": "npm:^3.5.13"
     "@types/connect-history-api-fallback": "npm:^1.5.4"
@@ -24032,7 +24032,7 @@ __metadata:
       optional: true
   bin:
     webpack-dev-server: bin/webpack-dev-server.js
-  checksum: 10c0/42f8afe11b7bfe65d72e30d861ddf1e4d05f27202c4c1162d204cb41a4a858dffc91c5a02bf44ec08acc8c02b4a57aaf46924ec12a5e5b97c307991379282669
+  checksum: 10c0/a716f1d509635ad9f2779baf242657740e6ad516ce210fe094cbf3b16f25f114e477c45a751ad2bbf1c601cbbe67b6ba9b8b43159b7c01fc3342c95b985fe963
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
<!-- Make sure to correctly set PR labels if necessary: `Native`/`Web` for native/web only PRs and `maintenance` for non-user-facing changes. -->
Our e2e tests in the CI currently fail. Perhaps this is due to the webpack-dev-server upgrade. Therefore try to downgrade and revert #4131.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Downgrade wepack-dev-server to v5.2.3

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

https://github.com/webpack/webpack-dev-server/security/advisories/GHSA-79cf-xcqc-c78w
https://github.com/webpack/webpack-dev-server/security/advisories/GHSA-79cf-xcqc-c78w

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
N/A

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: N/A

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
