### PR TITLE
Switch to port 9001 to fix e2e tests

### DIFF
--- a/e2e-tests/native/wdio-browserstack.conf.ts
+++ b/e2e-tests/native/wdio-browserstack.conf.ts
@@ -28,7 +28,7 @@ export const config: WebdriverIO.Config = {
 
   logLevel: 'info',
 
-  baseUrl: 'http://localhost:9000',
+  baseUrl: 'http://localhost:9001',
 
   specFileRetries: 2,
   bail: 1,

--- a/e2e-tests/web/waitForLocalhost.ts
+++ b/e2e-tests/web/waitForLocalhost.ts
@@ -6,7 +6,7 @@ const STATUS_CODE_OK = 200
 
 const waitForLocalhost = (timeout: number): Promise<void> =>
   new Promise((resolve, reject) => {
-    const request = http.request({ method: 'head', port: 9000, family: 4, timeout }, response => {
+    const request = http.request({ method: 'head', port: 9001, family: 4, timeout }, response => {
       if (response.statusCode === STATUS_CODE_OK) {
         resolve()
       }

--- a/e2e-tests/web/wdio.conf.ts
+++ b/e2e-tests/web/wdio.conf.ts
@@ -20,7 +20,7 @@ export const config: WebdriverIO.Config = {
   capabilities: getCapabilities(),
   logLevel: 'info',
   bail: 0,
-  baseUrl: 'http://localhost:9000',
+  baseUrl: 'http://localhost:9001',
   waitforTimeout: 2_000,
   connectionRetryTimeout: 120_000,
   connectionRetryCount: 3,

--- a/web/tools/webpack.config.ts
+++ b/web/tools/webpack.config.ts
@@ -209,7 +209,7 @@ const createConfig = (
     devServer: {
       static: { directory: distDirectory },
       compress: true,
-      port: 9000,
+      port: 9001,
       host: '0.0.0.0', // This enables devices in the same network to connect to the dev server
       hot: true,
       client: {


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
<!-- Make sure to correctly set PR labels if necessary: `Native`/`Web` for native/web only PRs and `maintenance` for non-user-facing changes. -->
Somehow we get [port already in use for port 9000](https://circleci.com/gh/digitalfabrik/integreat-app/76708). Absolutely no clue what causes that all of a sudden, but switching the port to 9001 fixes the issue.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Change the webpack dev server port to 9001

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

localhost:9000 won't work anymore.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
See https://app.circleci.com/pipelines/github/digitalfabrik/integreat-app/16636/workflows/1bfbc2f3-4a8b-42f7-a4dd-f0688b70f4bd.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: N/A

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
