### PR TITLE
2404: Fix circleci dist folder build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,6 +266,9 @@ jobs:
                 name: '[FL] Prepare Android Keystore'
                 working_directory: native/android
             - run:
+                command: yarn ts:check
+                name: Check TypeScript
+            - run:
                 command: bundle exec fastlane android build build_config_name:<< parameters.build_config_name >> version_name:${NEW_VERSION_NAME} version_code:${NEW_VERSION_CODE}
                 name: '[FL] << parameters.build_config_name >> Android Build'
                 working_directory: native/android
@@ -348,6 +351,9 @@ jobs:
                 command: brew install cmake
                 name: Install CMake
             - run:
+                command: yarn ts:check
+                name: Check TypeScript
+            - run:
                 command: bundle exec fastlane ios build build_config_name:<< parameters.build_config_name >> version_name:${NEW_VERSION_NAME} version_code:${NEW_VERSION_CODE}
                 name: '[FL] << parameters.build_config_name >> iOS Build'
                 working_directory: native/ios
@@ -407,6 +413,9 @@ jobs:
             - restore_yarn_cache
             - prepare_workspace
             - restore_environment_variables
+            - run:
+                command: yarn ts:check
+                name: Check TypeScript
             - run:
                 command: yarn workspace web build:<< parameters.build_config_name >> --env commit_sha=${CIRCLE_SHA1} --env version_name=${NEW_VERSION_NAME}
                 name: << parameters.build_config_name >> build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -267,7 +267,7 @@ jobs:
                 working_directory: native/android
             - run:
                 command: yarn ts:check
-                name: Check TypeScript
+                name: Build files
             - run:
                 command: bundle exec fastlane android build build_config_name:<< parameters.build_config_name >> version_name:${NEW_VERSION_NAME} version_code:${NEW_VERSION_CODE}
                 name: '[FL] << parameters.build_config_name >> Android Build'
@@ -352,7 +352,7 @@ jobs:
                 name: Install CMake
             - run:
                 command: yarn ts:check
-                name: Check TypeScript
+                name: Build files
             - run:
                 command: bundle exec fastlane ios build build_config_name:<< parameters.build_config_name >> version_name:${NEW_VERSION_NAME} version_code:${NEW_VERSION_CODE}
                 name: '[FL] << parameters.build_config_name >> iOS Build'
@@ -415,7 +415,7 @@ jobs:
             - restore_environment_variables
             - run:
                 command: yarn ts:check
-                name: Check TypeScript
+                name: Build files
             - run:
                 command: yarn workspace web build:<< parameters.build_config_name >> --env commit_sha=${CIRCLE_SHA1} --env version_name=${NEW_VERSION_NAME}
                 name: << parameters.build_config_name >> build
@@ -763,6 +763,9 @@ jobs:
             - checkout
             - prepare_workspace
             - restore_yarn_cache
+            - run:
+                command: yarn ts:check
+                name: Build files
             - run:
                 background: true
                 command: yarn workspace web start:integreat-e2e

--- a/.circleci/src/jobs/build_android.yml
+++ b/.circleci/src/jobs/build_android.yml
@@ -30,7 +30,7 @@ steps:
       command: bundle exec fastlane android keystore
       working_directory: native/android
   - run:
-      name: Check TypeScript
+      name: Build files
       command: yarn ts:check
   - run:
       name: '[FL] << parameters.build_config_name >> Android Build'

--- a/.circleci/src/jobs/build_android.yml
+++ b/.circleci/src/jobs/build_android.yml
@@ -30,6 +30,9 @@ steps:
       command: bundle exec fastlane android keystore
       working_directory: native/android
   - run:
+      name: Check TypeScript
+      command: yarn ts:check
+  - run:
       name: '[FL] << parameters.build_config_name >> Android Build'
       command: bundle exec fastlane android build build_config_name:<< parameters.build_config_name >> version_name:${NEW_VERSION_NAME} version_code:${NEW_VERSION_CODE}
       working_directory: native/android

--- a/.circleci/src/jobs/build_ios.yml
+++ b/.circleci/src/jobs/build_ios.yml
@@ -24,6 +24,9 @@ steps:
       name: Install CMake
       command: brew install cmake
   - run:
+      name: Check TypeScript
+      command: yarn ts:check
+  - run:
       name: '[FL] << parameters.build_config_name >> iOS Build'
       command: bundle exec fastlane ios build build_config_name:<< parameters.build_config_name >> version_name:${NEW_VERSION_NAME} version_code:${NEW_VERSION_CODE}
       working_directory: native/ios

--- a/.circleci/src/jobs/build_ios.yml
+++ b/.circleci/src/jobs/build_ios.yml
@@ -24,7 +24,7 @@ steps:
       name: Install CMake
       command: brew install cmake
   - run:
-      name: Check TypeScript
+      name: Build files
       command: yarn ts:check
   - run:
       name: '[FL] << parameters.build_config_name >> iOS Build'

--- a/.circleci/src/jobs/build_web.yml
+++ b/.circleci/src/jobs/build_web.yml
@@ -15,6 +15,9 @@ steps:
   - prepare_workspace
   - restore_environment_variables
   - run:
+      name: Check TypeScript
+      command: yarn ts:check
+  - run:
       name: << parameters.build_config_name >> build
       command: yarn workspace web build:<< parameters.build_config_name >> --env commit_sha=${CIRCLE_SHA1} --env version_name=${NEW_VERSION_NAME}
   - store_artifacts:

--- a/.circleci/src/jobs/build_web.yml
+++ b/.circleci/src/jobs/build_web.yml
@@ -15,7 +15,7 @@ steps:
   - prepare_workspace
   - restore_environment_variables
   - run:
-      name: Check TypeScript
+      name: Build files
       command: yarn ts:check
   - run:
       name: << parameters.build_config_name >> build

--- a/.circleci/src/jobs/e2e_web.yml
+++ b/.circleci/src/jobs/e2e_web.yml
@@ -8,6 +8,9 @@ steps:
   - prepare_workspace
   - restore_yarn_cache
   - run:
+      name: Build files
+      command: yarn ts:check
+  - run:
       name: 'Start WebApp'
       command: yarn workspace web start:integreat-e2e
       background: true


### PR DESCRIPTION
### Short Description

Fixes the error where the file is not found in dist folder of the packages by circleci caused by #2404 
### Proposed Changes

<!-- Describe this PR in more detail. -->

- Add ts:check to circleci builds to generate dist folder for workspaces

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

N/A

### Resolved Issues

Fixes: #4093 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
