### PR TITLE
2404: Fix web build check

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -19,7 +19,7 @@
     "build:aschaffenburg": "yarn run webpack-ts --env config_name=aschaffenburg",
     "build:integreat-test-cms": "yarn run webpack-ts --env config_name=integreat-test-cms",
     "build:obdach": "yarn run webpack-ts --env config_name=obdach",
-    "check:build": "yarn es-check es2022 ./dist/**/*.js --verbose",
+    "check:build": "yarn es-check es2022 ./dist/**/*.js --verbose --module",
     "test": "yarn run -T jest",
     "lint": " yarn stylelint && yarn run -T eslint --cache --cache-location ../.eslintcache .",
     "stylelint": "npx stylelint --config stylelint.config.js \"src/**/*.{ts,tsx,css}\"",


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
<!-- Make sure to correctly set PR labels if necessary: `Native`/`Web` for native/web only PRs and `maintenance` for non-user-facing changes. -->
Since our switch to ESM in #2502 the web build check fails. Fix this by adding the `--module` flag.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Add the `--module` flag to the web build check

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Run `yarn workspace web check:build`.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2404

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
