### PR TITLE
2404: Fix jest test at web

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,11 +17,11 @@ N/A
 
 ### Checklist
 
-- [ ] Followed the [contributing guidelines](../docs/contributing.md) and [conventions](../docs/conventions.md)
+- [ ] Followed the [contributing guidelines](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md) and [conventions](https://github.com/digitalfabrik/integreat-app/blob/main/docs/conventions.md)
 - [ ] Considered accessibility impacts and made the necessary adjustments
 - [ ] Added or updated unit tests (if applicable)
 - [ ] Added or updated documentation (if applicable)
-- [ ] Added a [release note](../release-notes) for native (if [applicable](../docs/contributing.md#release-notes))
+- [ ] Added a [release note](https://github.com/digitalfabrik/integreat-app/tree/main/release-notes) for native (if [applicable](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes))
 
 ### Testing
 

--- a/web/jest.config.ts
+++ b/web/jest.config.ts
@@ -1,8 +1,6 @@
 /** @jest-config-loader ts-node */
 import { type JestConfigWithTsJest, createDefaultEsmPreset } from 'ts-jest'
 
-import { webIntegreatTestCmsBuildConfig } from 'build-configs/integreat-test-cms'
-
 const transformNodeModules = ['shared', 'build-configs', 'translations', 'qr']
 process.env.TZ = 'Europe/Berlin'
 const config: JestConfigWithTsJest = {
@@ -27,7 +25,7 @@ const config: JestConfigWithTsJest = {
   testEnvironment: 'jsdom',
   globals: {
     __BUILD_CONFIG_NAME__: 'integreat-test-cms',
-    __BUILD_CONFIG__: webIntegreatTestCmsBuildConfig,
+    // __BUILD_CONFIG__ is set in jest.setup.ts because importing the (ESM-only) build-configs package here would break ts-node.
     __VERSION_NAME__: '0.0.0',
     __COMMIT_SHA__: 123456789,
   },

--- a/web/jest.setup.ts
+++ b/web/jest.setup.ts
@@ -6,6 +6,10 @@ import * as path from 'node:path'
 import { TextDecoder, TextEncoder } from 'node:util'
 import 'raf/polyfill'
 
+import { webIntegreatTestCmsBuildConfig } from 'build-configs/integreat-test-cms'
+
+Object.assign(globalThis, { __BUILD_CONFIG__: webIntegreatTestCmsBuildConfig })
+
 // Fixes Type error "Type 'Mock<UnknownFunction>' is not assignable to type 'typeof ResizeObserver'"
 window.ResizeObserver = jest.fn().mockImplementation(() => ({
   disconnect: jest.fn(),


### PR DESCRIPTION
### Short Description

Fix yarn test failing wit this error:

```bash
Error: Jest: Failed to parse the TypeScript config file /Users/digitalfabrik/Repos/integreat-app/web/jest.config.ts
  Error: Must use import to load ES Module: /Users/digitalfabrik/Repos/integreat-app/build-configs/dist/integreat-test-cms/index.js
require() of ES modules is not supported.
require() of /Users/digitalfabrik/Repos/integreat-app/build-configs/dist/integreat-test-cms/index.js from /Users/digitalfabrik/Repos/integreat-app/web/jest.config.ts is an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which defines all .js files in that package scope as ES modules.
Instead change the requiring code to use import(), or remove "type": "module" from /Users/digitalfabrik/Repos/integreat-app/build-configs/package.json.

    at readConfigFileAndSetRootDir (/Users/digitalfabrik/Repos/integreat-app/node_modules/@jest/core/node_modules/jest-config/build/index.js:2294:13)
    at async readInitialOptions (/Users/digitalfabrik/Repos/integreat-app/node_modules/@jest/core/node_modules/jest-config/build/index.js:1173:13)
    at async readConfig (/Users/digitalfabrik/Repos/integreat-app/node_modules/@jest/core/node_modules/jest-config/build/index.js:944:7)
    at async readConfigs (/Users/digitalfabrik/Repos/integreat-app/node_modules/@jest/core/node_modules/jest-config/build/index.js:1194:26)
    at async runCLI (/Users/digitalfabrik/Repos/integreat-app/node_modules/@jest/core/build/index.js:1402:7)
    at async Object.run (/Users/digitalfabrik/Repos/integreat-app/node_modules/jest-cli/build/index.js:656:9)
```

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Moved that import out of `jest.config.ts` and into `jest.setup.ts`, setting the global there instead.
- `jest.setup.ts` runs in the test runtime, not under ts-node. The setup file runs before any test in each file, so by the time it reads __BUILD_CONFIG__ it's ready.

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none.

### Testing

- Test `yarn test` at /web .

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2404

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
