### PR TITLE
2404: Fix concurrent upstream jobs persisted the same file(s)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -427,7 +427,7 @@ jobs:
                 path: web/dist/<< parameters.build_config_name >>.tar.gz
             - persist_to_workspace:
                 paths:
-                    - dist
+                    - dist/<<parameters.build_config_name >>
                 root: web
             - notify
     bump_version:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,6 +191,9 @@ commands:
             - run:
                 command: corepack yarn --immutable
                 name: Yarn
+            - run:
+                command: corepack yarn ts:check
+                name: Build files
             - save_cache:
                 key: 11-yarn-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum "package.json" }}-{{ checksum "native/package.json" }}-{{ checksum "web/package.json" }}
                 name: Save Yarn Package Cache
@@ -265,9 +268,6 @@ jobs:
                 command: bundle exec fastlane android keystore
                 name: '[FL] Prepare Android Keystore'
                 working_directory: native/android
-            - run:
-                command: yarn ts:check
-                name: Build files
             - run:
                 command: bundle exec fastlane android build build_config_name:<< parameters.build_config_name >> version_name:${NEW_VERSION_NAME} version_code:${NEW_VERSION_CODE}
                 name: '[FL] << parameters.build_config_name >> Android Build'
@@ -351,9 +351,6 @@ jobs:
                 command: brew install cmake
                 name: Install CMake
             - run:
-                command: yarn ts:check
-                name: Build files
-            - run:
                 command: bundle exec fastlane ios build build_config_name:<< parameters.build_config_name >> version_name:${NEW_VERSION_NAME} version_code:${NEW_VERSION_CODE}
                 name: '[FL] << parameters.build_config_name >> iOS Build'
                 working_directory: native/ios
@@ -413,9 +410,6 @@ jobs:
             - restore_yarn_cache
             - prepare_workspace
             - restore_environment_variables
-            - run:
-                command: yarn ts:check
-                name: Build files
             - run:
                 command: yarn workspace web build:<< parameters.build_config_name >> --env commit_sha=${CIRCLE_SHA1} --env version_name=${NEW_VERSION_NAME}
                 name: << parameters.build_config_name >> build
@@ -492,9 +486,6 @@ jobs:
             - run:
                 command: yarn prettier:check
                 name: Prettier
-            - run:
-                command: yarn ts:check:ci
-                name: TS check
             - run:
                 command: yarn check-circular-dependencies
                 name: Check circular dependencies
@@ -763,9 +754,6 @@ jobs:
             - checkout
             - prepare_workspace
             - restore_yarn_cache
-            - run:
-                command: yarn ts:check
-                name: Build files
             - run:
                 background: true
                 command: yarn workspace web start:integreat-e2e

--- a/.circleci/src/commands/restore_yarn_cache.yml
+++ b/.circleci/src/commands/restore_yarn_cache.yml
@@ -13,6 +13,11 @@ steps:
       # corepack prefix is necessary on macos
       # https://github.com/nodejs/corepack/issues/507
       command: corepack yarn --immutable
+  - run:
+      name: Build files
+      # corepack prefix is necessary on macos
+      # https://github.com/nodejs/corepack/issues/507
+      command: corepack yarn ts:check
   - save_cache:
       name: Save Yarn Package Cache
       key: 11-yarn-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum "package.json" }}-{{ checksum "native/package.json" }}-{{ checksum "web/package.json" }}

--- a/.circleci/src/jobs/build_android.yml
+++ b/.circleci/src/jobs/build_android.yml
@@ -30,9 +30,6 @@ steps:
       command: bundle exec fastlane android keystore
       working_directory: native/android
   - run:
-      name: Build files
-      command: yarn ts:check
-  - run:
       name: '[FL] << parameters.build_config_name >> Android Build'
       command: bundle exec fastlane android build build_config_name:<< parameters.build_config_name >> version_name:${NEW_VERSION_NAME} version_code:${NEW_VERSION_CODE}
       working_directory: native/android

--- a/.circleci/src/jobs/build_ios.yml
+++ b/.circleci/src/jobs/build_ios.yml
@@ -24,9 +24,6 @@ steps:
       name: Install CMake
       command: brew install cmake
   - run:
-      name: Build files
-      command: yarn ts:check
-  - run:
       name: '[FL] << parameters.build_config_name >> iOS Build'
       command: bundle exec fastlane ios build build_config_name:<< parameters.build_config_name >> version_name:${NEW_VERSION_NAME} version_code:${NEW_VERSION_CODE}
       working_directory: native/ios

--- a/.circleci/src/jobs/build_web.yml
+++ b/.circleci/src/jobs/build_web.yml
@@ -15,9 +15,6 @@ steps:
   - prepare_workspace
   - restore_environment_variables
   - run:
-      name: Build files
-      command: yarn ts:check
-  - run:
       name: << parameters.build_config_name >> build
       command: yarn workspace web build:<< parameters.build_config_name >> --env commit_sha=${CIRCLE_SHA1} --env version_name=${NEW_VERSION_NAME}
   - store_artifacts:

--- a/.circleci/src/jobs/build_web.yml
+++ b/.circleci/src/jobs/build_web.yml
@@ -32,5 +32,5 @@ steps:
   - persist_to_workspace:
       root: web
       paths:
-        - dist
+        - dist/<<parameters.build_config_name >>
   - notify

--- a/.circleci/src/jobs/check.yml
+++ b/.circleci/src/jobs/check.yml
@@ -14,9 +14,6 @@ steps:
       name: Prettier
       command: yarn prettier:check
   - run:
-      name: TS check
-      command: yarn ts:check:ci
-  - run:
       name: Check circular dependencies
       command: yarn check-circular-dependencies
   - run:

--- a/.circleci/src/jobs/e2e_web.yml
+++ b/.circleci/src/jobs/e2e_web.yml
@@ -8,9 +8,6 @@ steps:
   - prepare_workspace
   - restore_yarn_cache
   - run:
-      name: Build files
-      command: yarn ts:check
-  - run:
       name: 'Start WebApp'
       command: yarn workspace web start:integreat-e2e
       background: true

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "prettier:write": "prettier --write .",
     "check-circular-dependencies": "./tools/checkCircularDependencies.sh",
     "ts:check": "tsc --build",
-    "ts:check:ci": "yarn node --max-old-space-size=1536 $(yarn bin tsc) --build",
     "postinstall": "yarn workspace native postinstall && yarn workspace web postinstall"
   },
   "resolutions": {


### PR DESCRIPTION
### Short Description

It might fix this error `Concurrent upstream jobs persisted the same file(s)` https://app.circleci.com/pipelines/github/digitalfabrik/integreat-app/16693/workflows/32152574-84c1-461b-b47b-8ad79e055603/jobs/76881  by creating one job `build_files` 

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Create `build_files` job, instead of running it for every build, maybe we could run it once? :thought_balloon: 

### Side Effects

I hope none :see_no_evil: 

### Checklist

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
N/A

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4093 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
