### PR TITLE
4209: Add the chat on native

### DIFF
--- a/native/ios/Podfile.lock
+++ b/native/ios/Podfile.lock
@@ -1684,7 +1684,7 @@ PODS:
     - ReactNativeDependencies
     - Yoga
   - react-native-vector-icons-material-design-icons (13.0.0)
-  - react-native-webview (13.17.1):
+  - react-native-webview (13.17.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2972,7 +2972,7 @@ SPEC CHECKSUMS:
   react-native-netinfo: f6ef8e2319c27b4f48599b85fc827f64b69c5c6d
   react-native-safe-area-context: 90476586077446d5eab1d41ac3e767b016ac41d6
   react-native-vector-icons-material-design-icons: 1955bd08457a8310e6a2d3c87c7f1ebaca159098
-  react-native-webview: 8cb7597ccc815e831d07dacde956fd13fb041d79
+  react-native-webview: aa723c1d2a42fcfd02f22fc9e59f4da885df05d4
   React-NativeModulesApple: 5ba0903927f6b8d335a091700e9fda143980f819
   React-networking: ad2727500e93943a43da70d3b162454af151469c
   React-oscompat: ff26abf0ae3e3fdbe47b44224571e3fc7226a573

--- a/native/package.json
+++ b/native/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@dr.pogodin/react-native-fs": "^2.37.0",
     "@dr.pogodin/react-native-static-server": "^0.26.0",
-    "@dr.pogodin/react-native-webview": "^13.17.1",
+    "@dr.pogodin/react-native-webview": "^13.17.4",
     "@formatjs/intl-displaynames": "^6.8.13",
     "@formatjs/intl-locale": "^4.2.13",
     "@gorhom/bottom-sheet": "^5.2.8",

--- a/native/src/BottomTabNavigator.tsx
+++ b/native/src/BottomTabNavigator.tsx
@@ -2,6 +2,7 @@ import { createBottomTabNavigator } from '@react-navigation/bottom-tabs'
 import { createStackNavigator } from '@react-navigation/stack'
 import React, { ReactElement, useCallback, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
+import { View } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { NavigationProps, RoutesParamsType } from 'src/constants/NavigationTypes'
 import { DefaultTheme, useTheme } from 'styled-components/native'
@@ -20,10 +21,12 @@ import {
 } from 'shared'
 
 import { SignPostIcon } from './assets'
+import ChatFab from './components/ChatFab'
 import { defaultHeader } from './components/DefaultHeader'
 import Icon from './components/base/Icon'
 import Text from './components/base/Text'
 import { TAB_NAVIGATOR_ID } from './constants'
+import buildConfig from './constants/buildConfig'
 import useLoadRegionContent from './hooks/useLoadRegionContent'
 import useNavigate from './hooks/useNavigate'
 import useRegionAppContext from './hooks/useRegionAppContext'
@@ -125,7 +128,8 @@ const BottomTabNavigator = ({ navigation }: BottomTabNavigatorProps): ReactEleme
     return <LoadingErrorHandler loading={loading} error={error} refresh={refresh} />
   }
 
-  const { eventsEnabled, placesEnabled, localNewsEnabled, tuNewsEnabled } = cachedData.region
+  const { eventsEnabled, placesEnabled, localNewsEnabled, tuNewsEnabled, chatEnabled } = cachedData.region
+  const chatVisible = buildConfig().featureFlags.chat && chatEnabled
 
   const Tabs = [
     <Tab.Screen
@@ -175,22 +179,25 @@ const BottomTabNavigator = ({ navigation }: BottomTabNavigatorProps): ReactEleme
   const bottomTabsVisible = Tabs.length > 1
 
   return (
-    <Tab.Navigator
-      id={TAB_NAVIGATOR_ID}
-      backBehavior='history'
-      screenOptions={{
-        headerShown: false,
-        tabBarActiveTintColor: theme.colors.onSurface,
-        tabBarInactiveTintColor: theme.colors.onSurfaceVariant,
-        tabBarStyle: {
-          height: TAB_HEIGHT + insets.bottom,
-          backgroundColor: theme.colors.surfaceVariant,
-          display: bottomTabsVisible ? 'flex' : 'none',
-        },
-        sceneStyle: bottomTabsVisible ? undefined : { paddingBottom: insets.bottom },
-      }}>
-      {Tabs}
-    </Tab.Navigator>
+    <View style={{ flex: 1 }}>
+      <Tab.Navigator
+        id={TAB_NAVIGATOR_ID}
+        backBehavior='history'
+        screenOptions={{
+          headerShown: false,
+          tabBarActiveTintColor: theme.colors.onSurface,
+          tabBarInactiveTintColor: theme.colors.onSurfaceVariant,
+          tabBarStyle: {
+            height: TAB_HEIGHT + insets.bottom,
+            backgroundColor: theme.colors.surfaceVariant,
+            display: bottomTabsVisible ? 'flex' : 'none',
+          },
+          sceneStyle: bottomTabsVisible ? undefined : { paddingBottom: insets.bottom },
+        }}>
+        {Tabs}
+      </Tab.Navigator>
+      {chatVisible && <ChatFab style={{ bottom: TAB_HEIGHT + insets.bottom }} />}
+    </View>
   )
 }
 

--- a/native/src/Navigator.tsx
+++ b/native/src/Navigator.tsx
@@ -23,6 +23,7 @@ import {
   RedirectRouteType,
   SEARCH_ROUTE,
   SETTINGS_ROUTE,
+  CHAT_ROUTE,
 } from 'shared'
 
 import BottomTabNavigator from './BottomTabNavigator'
@@ -36,6 +37,7 @@ import buildConfig from './constants/buildConfig'
 import useLoadRegions from './hooks/useLoadRegions'
 import { useAppContext } from './hooks/useRegionAppContext'
 import useSnackbar from './hooks/useSnackbar'
+import Chat from './routes/Chat'
 import Consent from './routes/Consent'
 import FeedbackModalContainer from './routes/FeedbackModalContainer'
 import ImageViewModal from './routes/ImageViewModal'
@@ -152,6 +154,7 @@ const Navigator = (): ReactElement | null => {
       <Stack.Group screenOptions={{ header: defaultHeader }}>
         <Stack.Screen name={IMPRINT_ROUTE} component={ImprintContainer} />
         <Stack.Screen name={FEEDBACK_MODAL_ROUTE} component={FeedbackModalContainer} />
+        <Stack.Screen name={CHAT_ROUTE} component={Chat} />
         <Stack.Screen name={REGIONS_ROUTE} component={Regions} />
       </Stack.Group>
 

--- a/native/src/components/ChatFab.tsx
+++ b/native/src/components/ChatFab.tsx
@@ -3,12 +3,10 @@ import { ViewStyle } from 'react-native'
 import { FAB, useTheme } from 'react-native-paper'
 import styled from 'styled-components/native'
 
-import { CATEGORIES_ROUTE, getChatName } from 'shared'
+import { CHAT_ROUTE, getChatName } from 'shared'
 
 import buildConfig from '../constants/buildConfig'
-import useRegionAppContext from '../hooks/useRegionAppContext'
-import openExternalUrl from '../utils/openExternalUrl'
-import urlFromRouteInformation from '../utils/url'
+import useNavigate from '../hooks/useNavigate'
 
 const StyledFab = styled(FAB)`
   position: absolute;
@@ -21,24 +19,13 @@ type ChatFabProps = {
 }
 
 const ChatFab = ({ style }: ChatFabProps): ReactElement => {
-  const { regionCode, languageCode } = useRegionAppContext()
+  const { navigation } = useNavigate()
   const theme = useTheme()
 
   return (
     <StyledFab
       icon='forum-outline'
-      onPress={() =>
-        openExternalUrl(
-          urlFromRouteInformation({
-            route: CATEGORIES_ROUTE,
-            regionCode,
-            languageCode,
-            chat: true,
-            regionContentPath: `/${regionCode}/${languageCode}`,
-          }),
-          () => {},
-        )
-      }
+      onPress={() => navigation.navigate(CHAT_ROUTE)}
       accessibilityLabel={getChatName(buildConfig().appName)}
       variant='primary'
       style={{ ...style, backgroundColor: theme.colors.primary }}

--- a/native/src/components/ChatFab.tsx
+++ b/native/src/components/ChatFab.tsx
@@ -1,0 +1,50 @@
+import React, { ReactElement } from 'react'
+import { ViewStyle } from 'react-native'
+import { FAB, useTheme } from 'react-native-paper'
+import styled from 'styled-components/native'
+
+import { CATEGORIES_ROUTE, getChatName } from 'shared'
+
+import buildConfig from '../constants/buildConfig'
+import useRegionAppContext from '../hooks/useRegionAppContext'
+import openExternalUrl from '../utils/openExternalUrl'
+import urlFromRouteInformation from '../utils/url'
+
+const StyledFab = styled(FAB)`
+  position: absolute;
+  right: 0;
+  margin: 16px;
+`
+
+type ChatFabProps = {
+  style?: ViewStyle
+}
+
+const ChatFab = ({ style }: ChatFabProps): ReactElement => {
+  const { regionCode, languageCode } = useRegionAppContext()
+  const theme = useTheme()
+
+  return (
+    <StyledFab
+      icon='forum-outline'
+      onPress={() =>
+        openExternalUrl(
+          urlFromRouteInformation({
+            route: CATEGORIES_ROUTE,
+            regionCode,
+            languageCode,
+            chat: true,
+            regionContentPath: `/${regionCode}/${languageCode}`,
+          }),
+          () => {},
+        )
+      }
+      accessibilityLabel={getChatName(buildConfig().appName)}
+      variant='primary'
+      style={{ ...style, backgroundColor: theme.colors.primary }}
+      size='medium'
+    />
+  )
+}
+
+export default ChatFab

--- a/native/src/components/ChatFab.tsx
+++ b/native/src/components/ChatFab.tsx
@@ -1,17 +1,28 @@
-import React, { ReactElement } from 'react'
+import { useFocusEffect } from '@react-navigation/native'
+import React, { ReactElement, useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
 import { ViewStyle } from 'react-native'
-import { FAB, useTheme } from 'react-native-paper'
+import { Badge, FAB, useTheme } from 'react-native-paper'
 import styled from 'styled-components/native'
 
-import { CHAT_ROUTE, getChatName } from 'shared'
+import { CHAT_DEFAULT_POLLING_INTERVAL, CHAT_ROUTE, getChatName } from 'shared'
+import { createChatMessagesEndpoint, useLoadFromEndpoint } from 'shared/api'
 
 import buildConfig from '../constants/buildConfig'
 import useNavigate from '../hooks/useNavigate'
+import useRegionAppContext from '../hooks/useRegionAppContext'
+import { determineApiUrl } from '../utils/helpers'
 
-const StyledFab = styled(FAB)`
+const Container = styled.View`
   position: absolute;
   right: 0;
   margin: 16px;
+`
+
+const StyledBadge = styled(Badge)`
+  position: absolute;
+  top: -8px;
+  right: -8px;
 `
 
 type ChatFabProps = {
@@ -19,18 +30,46 @@ type ChatFabProps = {
 }
 
 const ChatFab = ({ style }: ChatFabProps): ReactElement => {
+  const { regionCode, languageCode, settings } = useRegionAppContext()
+  const chatSettings = settings.chat[regionCode]
   const { navigation } = useNavigate()
+  const { t } = useTranslation('chat')
   const theme = useTheme()
 
+  const { data, refresh } = useLoadFromEndpoint(createChatMessagesEndpoint, determineApiUrl, {
+    regionCode,
+    languageCode,
+    chatId: chatSettings?.id ?? '',
+  })
+
+  useFocusEffect(
+    useCallback(() => {
+      if (chatSettings) {
+        const interval = setInterval(refresh, CHAT_DEFAULT_POLLING_INTERVAL)
+        return () => clearInterval(interval)
+      }
+      return () => undefined
+    }, [refresh, chatSettings]),
+  )
+
+  const incomingMessageCount = data?.messages.filter(message => !message.userIsAuthor).length ?? 0
+  const unreadMessageCount = incomingMessageCount - (chatSettings?.seenMessages ?? 0)
+
   return (
-    <StyledFab
-      icon='forum-outline'
-      onPress={() => navigation.navigate(CHAT_ROUTE)}
-      accessibilityLabel={getChatName(buildConfig().appName)}
-      variant='primary'
-      style={{ ...style, backgroundColor: theme.colors.primary }}
-      size='medium'
-    />
+    <Container style={style}>
+      <FAB
+        icon='forum-outline'
+        onPress={() => navigation.navigate(CHAT_ROUTE)}
+        accessibilityLabel={getChatName(buildConfig().appName)}
+        variant='primary'
+        style={{ backgroundColor: theme.colors.primary }}
+        size='medium'
+        aria-label={getChatName(buildConfig().appName)}
+      />
+      {unreadMessageCount > 0 && (
+        <StyledBadge aria-label={t('unreadMessages', { count: unreadMessageCount })}>{unreadMessageCount}</StyledBadge>
+      )}
+    </Container>
   )
 }
 

--- a/native/src/components/Page.tsx
+++ b/native/src/components/Page.tsx
@@ -3,7 +3,6 @@ import React, { ReactElement, ReactNode, useCallback, useState } from 'react'
 import styled from 'styled-components/native'
 
 import dimensions from '../constants/dimensions'
-import useNavigateToLink from '../hooks/useNavigateToLink'
 import useTtsPlayer from '../hooks/useTtsPlayer'
 import Caption from './Caption'
 import RemoteContent from './RemoteContent'
@@ -37,8 +36,7 @@ const Page = ({
   lastUpdate,
   padding = true,
 }: PageProps): ReactElement => {
-  const [loading, setLoading] = useState(true)
-  const navigateToLink = useNavigateToLink()
+  const [loading, setLoading] = useState(content.length !== 0)
   const { visible: ttsPlayerVisible } = useTtsPlayer()
 
   const onLoad = useCallback(() => setLoading(false), [setLoading])
@@ -47,13 +45,7 @@ const Page = ({
     <Container $padding={padding}>
       {!loading && title ? <Caption title={title} language={language} /> : null}
       {!loading && beforeContent}
-      <RemoteContent
-        content={content}
-        onLinkPress={navigateToLink}
-        onLoad={onLoad}
-        loading={loading}
-        language={language}
-      />
+      <RemoteContent content={content} onLoad={onLoad} loading={loading} language={language} />
       {!loading && afterContent}
       {!loading && !!content && lastUpdate && <TimeStamp lastUpdate={lastUpdate} />}
       {!loading && footer}

--- a/native/src/components/RemoteContent.tsx
+++ b/native/src/components/RemoteContent.tsx
@@ -1,160 +1,40 @@
-import WebView, { WebViewMessageEvent, WebViewNavigation } from '@dr.pogodin/react-native-webview'
 import { mapValues } from 'lodash'
-import React, { ReactElement, useCallback, useContext, useEffect, useState } from 'react'
+import React, { ReactElement, useContext } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Platform, useWindowDimensions } from 'react-native'
+import { useWindowDimensions } from 'react-native'
 import { useTheme } from 'styled-components/native'
-
-import { CONSENT_ROUTE } from 'shared'
-import { ErrorCode } from 'shared/api'
 
 import buildConfig from '../constants/buildConfig'
 import dimensions from '../constants/dimensions'
-import { userAgent } from '../constants/endpoint'
-import {
-  ALLOW_EXTERNAL_SOURCE_MESSAGE_TYPE,
-  HEIGHT_MESSAGE_TYPE,
-  OPEN_SETTINGS_MESSAGE_TYPE,
-  WARNING_MESSAGE_TYPE,
-} from '../constants/webview'
-import useNavigate from '../hooks/useNavigate'
 import { useAppContext } from '../hooks/useRegionAppContext'
 import useResourceCache from '../hooks/useResourceCache'
 import { getStaticServerFileUrl } from '../utils/helpers'
 import renderHtml from '../utils/renderHtml'
-import { log, captureError } from '../utils/sentry'
-import Failure from './Failure'
 import { StaticServerContext } from './StaticServerProvider'
-import Text from './base/Text'
-
-// Fixes crashing in Android
-// https://github.com/react-native-webview/react-native-webview/issues/811
-const DEFAULT_OPACITY = 0.99
-
-// Fix title being displayed only after content is visible
-const LOADING_OPACITY = 0
-
-const DATA_DETECTOR_TYPES = ['none'] as const
-const ORIGIN_WHITELIST = ['*'] as const
-
-export const renderWebviewError = (
-  errorDomain: string | null | undefined,
-  errorCode: number,
-  errorDesc: string,
-): React.ReactElement => (
-  <Text>
-    ${errorDomain} ${errorCode} ${errorDesc}
-  </Text>
-)
+import WebView from './WebView'
 
 type RemoteContentProps = {
   content: string
   language: string
-  onLinkPress: (url: string) => void
   onLoad: () => void
   loading: boolean
 }
 
 // If the app crashes without an error message while using RemoteContent, consider wrapping it in a ScrollView or setting a manual height
-const RemoteContent = ({
-  onLoad,
-  content,
-  language,
-  onLinkPress,
-  loading,
-}: RemoteContentProps): ReactElement | null => {
-  const [error, setError] = useState<string | null>(null)
-  const [pressedUrl, setPressedUrl] = useState<string | null>(null)
+const RemoteContent = ({ onLoad, content, language, loading }: RemoteContentProps): ReactElement | null => {
   const { data: resourceCache } = useResourceCache()
-  const { settings, updateSettings } = useAppContext()
-  const { navigateTo } = useNavigate()
-  const { externalSourcePermissions } = settings
   const staticServerUrl = useContext(StaticServerContext)
-
-  // https://github.com/react-native-webview/react-native-webview/issues/1069#issuecomment-651699461
-  const defaultWebviewHeight = 1
-  const [webViewHeight, setWebViewHeight] = useState<number>(defaultWebviewHeight)
-  const theme = useTheme()
-  const { t } = useTranslation()
+  const { settings } = useAppContext()
   const { width: deviceWidth } = useWindowDimensions()
+  const { t } = useTranslation()
+  const theme = useTheme()
+
+  const { externalSourcePermissions } = settings
 
   const resourceMap = mapValues(resourceCache, filePath => getStaticServerFileUrl(filePath, staticServerUrl))
 
-  useEffect(() => {
-    // If it takes too long returning false in onShouldStartLoadWithRequest the webview loads the pressed url anyway on android.
-    // Therefore only set it to state and execute onLinkPress in useEffect.
-    if (pressedUrl) {
-      onLinkPress(pressedUrl)
-      setPressedUrl(null)
-    }
-  }, [onLinkPress, pressedUrl])
-
-  useEffect(() => {
-    if (webViewHeight !== defaultWebviewHeight || content.length === 0) {
-      onLoad()
-    }
-  }, [onLoad, webViewHeight, content])
-
-  // messages are triggered in renderHtml.ts
-  const onMessage = useCallback(
-    (event: WebViewMessageEvent) => {
-      const message = JSON.parse(event.nativeEvent.data)
-      if (message.type === HEIGHT_MESSAGE_TYPE && typeof message.height === 'number') {
-        setWebViewHeight(message.height)
-        return
-      }
-
-      if (message.type === OPEN_SETTINGS_MESSAGE_TYPE) {
-        navigateTo({ route: CONSENT_ROUTE })
-        return
-      }
-
-      if (message.type === ALLOW_EXTERNAL_SOURCE_MESSAGE_TYPE && typeof message.source === 'string') {
-        const source = message.source
-        const updatedSources = { ...externalSourcePermissions, [source]: true }
-        updateSettings({ externalSourcePermissions: updatedSources })
-        return
-      }
-
-      if (message.type === WARNING_MESSAGE_TYPE) {
-        log(message.message, { level: 'warning' })
-      } else {
-        const messageText: string | undefined = message.message
-        const error = new Error(messageText ? JSON.stringify(messageText) : 'Unknown message received from webview')
-        captureError(error)
-        setError(error.message)
-      }
-    },
-    [externalSourcePermissions, navigateTo, updateSettings],
-  )
-
-  const onShouldStartLoadWithRequest = useCallback(
-    (event: WebViewNavigation): boolean => {
-      if (buildConfig().supportedIframeSources.some(source => event.url.includes(source) === true)) {
-        return true
-      }
-      if (event.url === new URL(staticServerUrl).href) {
-        // Needed on iOS for the initial load
-        return true
-      }
-      // block non click events on ios that come up with iframes to avoid opening the iframe source directly in browser
-      if (event.navigationType !== 'click' && Platform.OS === 'ios') {
-        return false
-      }
-      // If it takes too long returning false the webview loads the pressed url anyway on android.
-      // Therefore only set it to state and execute onLinkPress in useEffect.
-      setPressedUrl(event.url)
-      return false
-    },
-    [staticServerUrl],
-  )
-
   if (content.length === 0) {
     return null
-  }
-
-  if (error) {
-    return <Failure code={ErrorCode.UnknownError} retry={null} />
   }
 
   return (
@@ -173,25 +53,9 @@ const RemoteContent = ({
           dimensions.pageContainerPaddingHorizontal,
         ),
       }}
-      originWhitelist={ORIGIN_WHITELIST} // Needed by iOS to load the initial html
-      javaScriptEnabled
-      dataDetectorTypes={DATA_DETECTOR_TYPES}
-      userAgent={userAgent}
+      onLoad={onLoad}
+      loading={loading}
       domStorageEnabled={false}
-      allowsFullscreenVideo
-      showsVerticalScrollIndicator={false}
-      showsHorizontalScrollIndicator={false}
-      scrollEnabled={false} // To disable scrolling in iOS
-      onMessage={onMessage}
-      renderError={renderWebviewError}
-      onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
-      // To allow custom handling of link clicks in android
-      // https://github.com/react-native-webview/react-native-webview/issues/1869
-      setSupportMultipleWindows={false}
-      style={{
-        height: webViewHeight,
-        opacity: loading ? LOADING_OPACITY : DEFAULT_OPACITY,
-      }}
     />
   )
 }

--- a/native/src/components/RemoteContent.tsx
+++ b/native/src/components/RemoteContent.tsx
@@ -55,7 +55,6 @@ const RemoteContent = ({ onLoad, content, language, loading }: RemoteContentProp
       }}
       onLoad={onLoad}
       loading={loading}
-      domStorageEnabled={false}
     />
   )
 }

--- a/native/src/components/WebView.tsx
+++ b/native/src/components/WebView.tsx
@@ -49,6 +49,8 @@ const WebView = ({ source, domStorageEnabled, onLoad, loading }: WebViewProps): 
   const navigateToLink = useNavigateToLink()
 
   const webviewUrl = source.uri ?? source.baseUrl
+  const isUriSource = source.uri !== undefined
+  const opacity = loading ? LOADING_OPACITY : DEFAULT_OPACITY
 
   const [webViewHeight, setWebViewHeight] = useState<number>(DEFAULT_WEBVIEW_HEIGHT)
 
@@ -137,18 +139,17 @@ const WebView = ({ source, domStorageEnabled, onLoad, loading }: WebViewProps): 
       allowsFullscreenVideo
       showsVerticalScrollIndicator={false}
       showsHorizontalScrollIndicator={false}
-      // To disable scrolling in iOS
-      scrollEnabled={false}
+      // Disable for HTML (sized via HEIGHT_MESSAGE_TYPE), enabled otherwise to handle iOS keyboard focus
+      scrollEnabled={isUriSource}
+      // Prevent the iOS overscroll with open keyboard from exposing the WKWebView's gray underPageBackground
+      bounces={false}
       onMessage={onMessage}
       renderError={<Failure code={ErrorCode.UnknownError} retry={null} />}
       onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
       // To allow custom handling of link clicks in android
       // https://github.com/react-native-webview/react-native-webview/issues/1869
       setSupportMultipleWindows={false}
-      style={{
-        height: webViewHeight,
-        opacity: loading ? LOADING_OPACITY : DEFAULT_OPACITY,
-      }}
+      style={isUriSource ? { flex: 1, opacity } : { height: webViewHeight, opacity }}
     />
   )
 }

--- a/native/src/components/WebView.tsx
+++ b/native/src/components/WebView.tsx
@@ -34,13 +34,12 @@ const ORIGIN_WHITELIST = ['*'] as const
 
 type WebViewProps = {
   source: { baseUrl: string; html: string; uri?: undefined } | { uri: string; baseUrl?: undefined }
-  domStorageEnabled: boolean
   onLoad?: () => void
   loading?: boolean
 }
 
 // If the app crashes without an error message while using WebView, consider wrapping it in a ScrollView or setting a manual height
-const WebView = ({ source, domStorageEnabled, onLoad, loading }: WebViewProps): ReactElement | null => {
+const WebView = ({ source, onLoad, loading }: WebViewProps): ReactElement | null => {
   const [error, setError] = useState<string | null>(null)
   const [pressedUrl, setPressedUrl] = useState<string | null>(null)
   const { settings, updateSettings } = useAppContext()
@@ -135,7 +134,7 @@ const WebView = ({ source, domStorageEnabled, onLoad, loading }: WebViewProps): 
       javaScriptEnabled
       dataDetectorTypes={DATA_DETECTOR_TYPES}
       userAgent={userAgent}
-      domStorageEnabled={domStorageEnabled}
+      domStorageEnabled={isUriSource}
       allowsFullscreenVideo
       showsVerticalScrollIndicator={false}
       showsHorizontalScrollIndicator={false}

--- a/native/src/components/WebView.tsx
+++ b/native/src/components/WebView.tsx
@@ -1,0 +1,156 @@
+import RNWebView, { WebViewMessageEvent, WebViewNavigation } from '@dr.pogodin/react-native-webview'
+import React, { ReactElement, useCallback, useEffect, useState } from 'react'
+import { Platform } from 'react-native'
+
+import { CONSENT_ROUTE } from 'shared'
+import { ErrorCode } from 'shared/api'
+
+import buildConfig from '../constants/buildConfig'
+import { userAgent } from '../constants/endpoint'
+import {
+  ALLOW_EXTERNAL_SOURCE_MESSAGE_TYPE,
+  HEIGHT_MESSAGE_TYPE,
+  OPEN_SETTINGS_MESSAGE_TYPE,
+  WARNING_MESSAGE_TYPE,
+} from '../constants/webview'
+import useNavigate from '../hooks/useNavigate'
+import useNavigateToLink from '../hooks/useNavigateToLink'
+import { useAppContext } from '../hooks/useRegionAppContext'
+import { log, captureError } from '../utils/sentry'
+import Failure from './Failure'
+
+// Fixes crashing in Android
+// https://github.com/react-native-webview/react-native-webview/issues/811
+const DEFAULT_OPACITY = 0.99
+
+// Fix title being displayed only after content is visible
+const LOADING_OPACITY = 0
+
+// https://github.com/react-native-webview/react-native-webview/issues/1069#issuecomment-651699461
+const DEFAULT_WEBVIEW_HEIGHT = 1
+
+const DATA_DETECTOR_TYPES = ['none'] as const
+const ORIGIN_WHITELIST = ['*'] as const
+
+type WebViewProps = {
+  source: { baseUrl: string; html: string; uri?: undefined } | { uri: string; baseUrl?: undefined }
+  domStorageEnabled: boolean
+  onLoad?: () => void
+  loading?: boolean
+}
+
+// If the app crashes without an error message while using WebView, consider wrapping it in a ScrollView or setting a manual height
+const WebView = ({ source, domStorageEnabled, onLoad, loading }: WebViewProps): ReactElement | null => {
+  const [error, setError] = useState<string | null>(null)
+  const [pressedUrl, setPressedUrl] = useState<string | null>(null)
+  const { settings, updateSettings } = useAppContext()
+  const { navigateTo } = useNavigate()
+  const { externalSourcePermissions } = settings
+  const navigateToLink = useNavigateToLink()
+
+  const webviewUrl = source.uri ?? source.baseUrl
+
+  const [webViewHeight, setWebViewHeight] = useState<number>(DEFAULT_WEBVIEW_HEIGHT)
+
+  useEffect(() => {
+    // If it takes too long returning false in onShouldStartLoadWithRequest the webview loads the pressed url anyway on android.
+    // Therefore, only set it to state and execute onLinkPress in useEffect.
+    if (pressedUrl) {
+      navigateToLink(pressedUrl)
+      setPressedUrl(null)
+    }
+  }, [navigateToLink, pressedUrl])
+
+  useEffect(() => {
+    if (webViewHeight !== DEFAULT_WEBVIEW_HEIGHT) {
+      onLoad?.()
+    }
+  }, [onLoad, webViewHeight])
+
+  // messages are triggered in renderHtml.ts
+  const onMessage = useCallback(
+    (event: WebViewMessageEvent) => {
+      const message = JSON.parse(event.nativeEvent.data)
+      if (message.type === HEIGHT_MESSAGE_TYPE && typeof message.height === 'number') {
+        setWebViewHeight(message.height)
+        return
+      }
+
+      if (message.type === OPEN_SETTINGS_MESSAGE_TYPE) {
+        navigateTo({ route: CONSENT_ROUTE })
+        return
+      }
+
+      if (message.type === ALLOW_EXTERNAL_SOURCE_MESSAGE_TYPE && typeof message.source === 'string') {
+        const source = message.source
+        const updatedSources = { ...externalSourcePermissions, [source]: true }
+        updateSettings({ externalSourcePermissions: updatedSources })
+        return
+      }
+
+      if (message.type === WARNING_MESSAGE_TYPE) {
+        log(message.message, { level: 'warning' })
+      } else {
+        const messageText: string | undefined = message.message
+        const error = new Error(messageText ? JSON.stringify(messageText) : 'Unknown message received from webview')
+        captureError(error)
+        setError(error.message)
+      }
+    },
+    [externalSourcePermissions, navigateTo, updateSettings],
+  )
+
+  const onShouldStartLoadWithRequest = useCallback(
+    (event: WebViewNavigation): boolean => {
+      if (buildConfig().supportedIframeSources.some(source => event.url.includes(source) === true)) {
+        return true
+      }
+      if (event.url === new URL(webviewUrl).href) {
+        // Needed on iOS for the initial load
+        return true
+      }
+      // block non click events on ios that come up with iframes to avoid opening the iframe source directly in browser
+      if (event.navigationType !== 'click' && Platform.OS === 'ios') {
+        return false
+      }
+      // If it takes too long returning false the webview loads the pressed url anyway on android.
+      // Therefore, only set it to state and execute onLinkPress in useEffect.
+      setPressedUrl(event.url)
+      return false
+    },
+    [webviewUrl],
+  )
+
+  if (error) {
+    return <Failure code={ErrorCode.UnknownError} retry={null} />
+  }
+
+  return (
+    <RNWebView
+      source={source}
+      // Needed by iOS to load the initial html
+      originWhitelist={ORIGIN_WHITELIST}
+      javaScriptEnabled
+      dataDetectorTypes={DATA_DETECTOR_TYPES}
+      userAgent={userAgent}
+      domStorageEnabled={domStorageEnabled}
+      allowsFullscreenVideo
+      showsVerticalScrollIndicator={false}
+      showsHorizontalScrollIndicator={false}
+      // To disable scrolling in iOS
+      scrollEnabled={false}
+      onMessage={onMessage}
+      renderError={<Failure code={ErrorCode.UnknownError} retry={null} />}
+      onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
+      // To allow custom handling of link clicks in android
+      // https://github.com/react-native-webview/react-native-webview/issues/1869
+      setSupportMultipleWindows={false}
+      style={{
+        height: webViewHeight,
+        opacity: loading ? LOADING_OPACITY : DEFAULT_OPACITY,
+      }}
+    />
+  )
+}
+
+export default WebView

--- a/native/src/components/__tests__/ChatFab.spec.tsx
+++ b/native/src/components/__tests__/ChatFab.spec.tsx
@@ -1,0 +1,62 @@
+import { fireEvent } from '@testing-library/react-native'
+import { DateTime } from 'luxon'
+import React from 'react'
+
+import { CHAT_ROUTE } from 'shared'
+import { ChatMessageModel } from 'shared/api'
+import { mockUseLoadFromEndpointWithData } from 'shared/api/endpoints/testing/mockUseLoadFromEndpoint'
+
+import useNavigate from '../../hooks/useNavigate'
+import TestingAppContext from '../../testing/TestingAppContext'
+import createNavigationPropMock from '../../testing/createNavigationPropMock'
+import render from '../../testing/render'
+import ChatFab from '../ChatFab'
+
+jest.mock('react-i18next')
+jest.mock('../../hooks/useNavigate')
+
+const buildMessage = (id: number, userIsAuthor: boolean) =>
+  new ChatMessageModel({ id, content: `msg-${id}`, created: DateTime.now(), userIsAuthor, automaticAnswer: false })
+
+const renderChatFab = (chatRegionSettings?: { id: string; seenMessages: number }) =>
+  render(
+    <TestingAppContext settings={{ chat: chatRegionSettings ? { augsburg: chatRegionSettings } : {} }}>
+      <ChatFab />
+    </TestingAppContext>,
+  )
+
+describe('ChatFab', () => {
+  const { mocked } = jest
+  const navigation = createNavigationPropMock()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mocked(useNavigate).mockReturnValue({ navigation, navigateTo: jest.fn() })
+  })
+
+  it('navigates to the chat route when pressed', () => {
+    mockUseLoadFromEndpointWithData({ messages: [] })
+    const { getByTestId } = renderChatFab()
+
+    fireEvent.press(getByTestId('fab'))
+    expect(navigation.navigate).toHaveBeenCalledWith(CHAT_ROUTE)
+  })
+
+  it('shows the number of unseen incoming messages in a badge', () => {
+    mockUseLoadFromEndpointWithData({
+      messages: [buildMessage(1, false), buildMessage(2, true), buildMessage(3, false), buildMessage(4, false)],
+    })
+    const { getByText } = renderChatFab({ id: 'chat-id', seenMessages: 1 })
+
+    expect(getByText('2')).toBeTruthy()
+  })
+
+  it('hides the badge when there are no unseen incoming messages', () => {
+    mockUseLoadFromEndpointWithData({
+      messages: [buildMessage(1, true), buildMessage(2, false)],
+    })
+    const { queryByText } = renderChatFab({ id: 'chat-id', seenMessages: 1 })
+
+    expect(queryByText('0')).toBeNull()
+  })
+})

--- a/native/src/constants/NavigationTypes.ts
+++ b/native/src/constants/NavigationTypes.ts
@@ -49,6 +49,8 @@ import {
   PlacesTabRouteType,
   NEWS_TAB_ROUTE,
   NewsTabRouteType,
+  CHAT_ROUTE,
+  ChatRouteType,
 } from 'shared'
 import { LanguageModel, FeedbackRouteType } from 'shared/api'
 
@@ -73,6 +75,7 @@ export type RootRoutesType =
   | FeedbackModalRouteType
   | LicensesRouteType
   | ConsentRouteType
+  | ChatRouteType
   | BottomTabRouteType
 
 export type RoutesType = RootRoutesType | TabRoutesType | NestedRoutesType
@@ -114,6 +117,7 @@ export type RootRoutesParamsType = {
   [INTRO_ROUTE]: undefined
   [REGIONS_ROUTE]: undefined
   [SUGGEST_TO_REGION_ROUTE]: undefined
+  [CHAT_ROUTE]: undefined
   [IMPRINT_ROUTE]: undefined
   [MAIN_IMPRINT_ROUTE]: undefined
   [CONSENT_ROUTE]: undefined

--- a/native/src/contexts/AppContext.ts
+++ b/native/src/contexts/AppContext.ts
@@ -1,6 +1,6 @@
 import { createContext } from 'react'
 
-import { defaultSettings, SettingsType } from '../utils/AppSettings'
+import { ChatRegionSettings, defaultSettings, SettingsType } from '../utils/AppSettings'
 
 // To change the region or language code, the respective functions should be used
 export type UpdateSettingsType = Partial<Omit<SettingsType, 'selectedCity' | 'contentLanguage'>>
@@ -10,6 +10,7 @@ export type AppContextType = {
   regionCode: string | null
   languageCode: string
   updateSettings: (settings: UpdateSettingsType) => void
+  updateChatSettings: (settings: Partial<ChatRegionSettings>) => void
   changeRegionCode: (regionCode: string | null) => void
   changeLanguageCode: (languageCode: string) => void
 }
@@ -19,6 +20,7 @@ export const AppContext = createContext<AppContextType>({
   regionCode: null,
   languageCode: '',
   updateSettings: () => undefined,
+  updateChatSettings: () => undefined,
   changeRegionCode: () => undefined,
   changeLanguageCode: () => undefined,
 })

--- a/native/src/contexts/AppContextProvider.tsx
+++ b/native/src/contexts/AppContextProvider.tsx
@@ -1,10 +1,10 @@
 import React, { ReactElement, useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { hasProp } from 'shared'
+import { hasProp, uuid } from 'shared'
 
 import buildConfig from '../constants/buildConfig'
-import appSettings, { SettingsType } from '../utils/AppSettings'
+import appSettings, { ChatRegionSettings, SettingsType } from '../utils/AppSettings'
 import dataContainer from '../utils/DefaultDataContainer'
 import { subscribeNews, unsubscribeNews } from '../utils/PushNotificationsManager'
 import { captureError } from '../utils/sentry'
@@ -57,6 +57,17 @@ const AppContextProvider = ({ children }: AppContextProviderProps): ReactElement
     [updateSettings, regionCode, languageCode, allowPushNotifications],
   )
 
+  const updateChatSettings = useCallback(
+    (newChatSettings: Partial<ChatRegionSettings>): void => {
+      if (!settings || !regionCode) {
+        return
+      }
+      const chatRegionSettings = settings.chat[regionCode] ?? { id: uuid(), seenMessages: 0 }
+      updateSettings({ chat: { ...settings.chat, [regionCode]: { ...chatRegionSettings, ...newChatSettings } } })
+    },
+    [updateSettings, regionCode, settings],
+  )
+
   useEffect(() => {
     if (regionCode) {
       dataContainer.storeLastUsage(regionCode).catch(captureError)
@@ -77,8 +88,16 @@ const AppContextProvider = ({ children }: AppContextProviderProps): ReactElement
   }, [settings, changeLanguageCode, languageCode, uiLanguage])
 
   const appContext = useMemo(
-    () => ({ settings, regionCode, languageCode, updateSettings, changeRegionCode, changeLanguageCode }),
-    [settings, regionCode, languageCode, updateSettings, changeRegionCode, changeLanguageCode],
+    () => ({
+      settings,
+      regionCode,
+      languageCode,
+      updateSettings,
+      changeRegionCode,
+      changeLanguageCode,
+      updateChatSettings,
+    }),
+    [settings, regionCode, languageCode, updateSettings, updateChatSettings, changeRegionCode, changeLanguageCode],
   )
 
   return hasProp(appContext, 'settings') && hasProp(appContext, 'languageCode') ? (

--- a/native/src/contexts/__tests__/AppContextProvider.spec.tsx
+++ b/native/src/contexts/__tests__/AppContextProvider.spec.tsx
@@ -96,6 +96,7 @@ describe('AppContextProvider', () => {
       apiUrlOverride: 'https://webnext.integreat.app',
       externalSourcePermissions: { 'https://vimeo.com': true },
       selectedTheme: 'light',
+      chat: {},
     }
     await appSettings.setSettings(settings)
     const { getByText } = renderAppContextProvider({})

--- a/native/src/routes/Chat.tsx
+++ b/native/src/routes/Chat.tsx
@@ -1,0 +1,37 @@
+import React, { ReactElement, useEffect } from 'react'
+
+import { CATEGORIES_ROUTE, regionContentPath } from 'shared'
+
+import ProgressSpinner from '../components/ProgressSpinner'
+import WebView from '../components/WebView'
+import useRegionAppContext from '../hooks/useRegionAppContext'
+import { defaultChatRegionSettings } from '../utils/AppSettings'
+import urlFromRouteInformation from '../utils/url'
+
+const Chat = (): ReactElement => {
+  const { regionCode, languageCode, settings, updateSettings } = useRegionAppContext()
+  const chatSettings = settings.chat[regionCode]
+
+  const chatUrl = urlFromRouteInformation({
+    route: CATEGORIES_ROUTE,
+    regionCode,
+    languageCode,
+    chat: true,
+    chatId: chatSettings?.id,
+    regionContentPath: regionContentPath({ regionCode, languageCode }),
+  })
+
+  useEffect(() => {
+    if (!chatSettings) {
+      updateSettings({ chat: { ...settings.chat, [regionCode]: defaultChatRegionSettings } })
+    }
+  }, [chatSettings, settings, regionCode, updateSettings])
+
+  if (!chatSettings) {
+    return <ProgressSpinner />
+  }
+
+  return <WebView source={{ uri: chatUrl }} domStorageEnabled />
+}
+
+export default Chat

--- a/native/src/routes/Chat.tsx
+++ b/native/src/routes/Chat.tsx
@@ -1,15 +1,18 @@
-import React, { ReactElement, useEffect } from 'react'
+import { useFocusEffect } from '@react-navigation/native'
+import React, { ReactElement, useCallback, useEffect } from 'react'
 
-import { CATEGORIES_ROUTE, regionContentPath } from 'shared'
+import { CATEGORIES_ROUTE, regionContentPath, uuid } from 'shared'
+import { createChatMessagesEndpoint, loadFromEndpoint } from 'shared/api'
 
 import ProgressSpinner from '../components/ProgressSpinner'
 import WebView from '../components/WebView'
 import useRegionAppContext from '../hooks/useRegionAppContext'
-import { defaultChatRegionSettings } from '../utils/AppSettings'
+import { determineApiUrl } from '../utils/helpers'
+import { captureError } from '../utils/sentry'
 import urlFromRouteInformation from '../utils/url'
 
 const Chat = (): ReactElement => {
-  const { regionCode, languageCode, settings, updateSettings } = useRegionAppContext()
+  const { regionCode, languageCode, settings, updateChatSettings } = useRegionAppContext()
   const chatSettings = settings.chat[regionCode]
 
   const chatUrl = urlFromRouteInformation({
@@ -23,9 +26,23 @@ const Chat = (): ReactElement => {
 
   useEffect(() => {
     if (!chatSettings) {
-      updateSettings({ chat: { ...settings.chat, [regionCode]: defaultChatRegionSettings } })
+      updateChatSettings({ seenMessages: 0, id: uuid() })
     }
-  }, [chatSettings, settings, regionCode, updateSettings])
+  }, [chatSettings, updateChatSettings])
+
+  const chatId = chatSettings?.id ?? uuid()
+
+  useFocusEffect(
+    useCallback(
+      () => () =>
+        loadFromEndpoint(createChatMessagesEndpoint, determineApiUrl, { regionCode, languageCode, chatId })
+          .then(({ messages }) =>
+            updateChatSettings({ seenMessages: messages.filter(message => !message.userIsAuthor).length }),
+          )
+          .catch(captureError),
+      [chatId, regionCode, languageCode, updateChatSettings],
+    ),
+  )
 
   if (!chatSettings) {
     return <ProgressSpinner />

--- a/native/src/routes/Chat.tsx
+++ b/native/src/routes/Chat.tsx
@@ -55,7 +55,7 @@ const Chat = (): ReactElement => {
     return <ProgressSpinner />
   }
 
-  return <WebView source={{ uri: chatUrl }} domStorageEnabled />
+  return <WebView source={{ uri: chatUrl }} />
 }
 
 export default Chat

--- a/native/src/routes/Chat.tsx
+++ b/native/src/routes/Chat.tsx
@@ -1,9 +1,11 @@
+import { useNetInfo } from '@react-native-community/netinfo'
 import { useFocusEffect } from '@react-navigation/native'
 import React, { ReactElement, useCallback, useEffect } from 'react'
 
 import { CATEGORIES_ROUTE, regionContentPath, uuid } from 'shared'
-import { createChatMessagesEndpoint, loadFromEndpoint } from 'shared/api'
+import { createChatMessagesEndpoint, ErrorCode, loadFromEndpoint } from 'shared/api'
 
+import Failure from '../components/Failure'
 import ProgressSpinner from '../components/ProgressSpinner'
 import WebView from '../components/WebView'
 import useRegionAppContext from '../hooks/useRegionAppContext'
@@ -12,6 +14,7 @@ import { captureError } from '../utils/sentry'
 import urlFromRouteInformation from '../utils/url'
 
 const Chat = (): ReactElement => {
+  const { isConnected } = useNetInfo()
   const { regionCode, languageCode, settings, updateChatSettings } = useRegionAppContext()
   const chatSettings = settings.chat[regionCode]
 
@@ -43,6 +46,10 @@ const Chat = (): ReactElement => {
       [chatId, regionCode, languageCode, updateChatSettings],
     ),
   )
+
+  if (isConnected === false) {
+    return <Failure code={ErrorCode.NetworkConnectionFailed} retry={null} />
+  }
 
   if (!chatSettings) {
     return <ProgressSpinner />

--- a/native/src/routes/__tests__/Chat.spec.tsx
+++ b/native/src/routes/__tests__/Chat.spec.tsx
@@ -9,6 +9,7 @@ import render from '../../testing/render'
 import Chat from '../Chat'
 
 jest.mock('react-i18next')
+jest.mock('@react-native-community/netinfo', () => ({ useNetInfo: jest.fn(() => ({ isConnected: true })) }))
 jest.mock('../../utils/sentry', () => ({ captureError: jest.fn() }))
 jest.mock('../../utils/helpers', () => ({ determineApiUrl: jest.fn(async () => 'https://api') }))
 
@@ -36,6 +37,8 @@ describe('Chat', () => {
     focusCallback = null
   })
 
+  const { mocked } = jest
+
   it('shows a spinner and seeds default chat settings if none exist for the region', async () => {
     const updateChatSettings = jest.fn()
     const { getByLabelText, queryByTestId } = render(
@@ -62,7 +65,6 @@ describe('Chat', () => {
   })
 
   it('updates seenMessages on blur using the incoming message count', async () => {
-    const { mocked } = jest
     const buildMessage = (id: number, userIsAuthor: boolean) =>
       new ChatMessageModel({ id, content: '', created: DateTime.now(), userIsAuthor, automaticAnswer: false })
     mocked(loadFromEndpoint).mockResolvedValue({

--- a/native/src/routes/__tests__/Chat.spec.tsx
+++ b/native/src/routes/__tests__/Chat.spec.tsx
@@ -1,0 +1,89 @@
+import { waitFor } from '@testing-library/react-native'
+import { DateTime } from 'luxon'
+import React from 'react'
+
+import { ChatMessageModel, loadFromEndpoint } from 'shared/api'
+
+import TestingAppContext from '../../testing/TestingAppContext'
+import render from '../../testing/render'
+import Chat from '../Chat'
+
+jest.mock('react-i18next')
+jest.mock('../../utils/sentry', () => ({ captureError: jest.fn() }))
+jest.mock('../../utils/helpers', () => ({ determineApiUrl: jest.fn(async () => 'https://api') }))
+
+let focusCallback: (() => void | (() => unknown)) | null = null
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useFocusEffect: (callback: () => void | (() => unknown)) => {
+    focusCallback = callback
+  },
+}))
+
+jest.mock('shared/api', () => ({
+  ...jest.requireActual('shared/api'),
+  loadFromEndpoint: jest.fn(),
+}))
+
+jest.mock('../../components/WebView', () => {
+  const { Text } = require('react-native')
+  return ({ source }: { source: { uri: string } }) => <Text testID='webview'>{source.uri}</Text>
+})
+
+describe('Chat', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    focusCallback = null
+  })
+
+  it('shows a spinner and seeds default chat settings if none exist for the region', async () => {
+    const updateChatSettings = jest.fn()
+    const { getByLabelText, queryByTestId } = render(
+      <TestingAppContext settings={{ chat: {} }} updateChatSettings={updateChatSettings}>
+        <Chat />
+      </TestingAppContext>,
+    )
+
+    expect(queryByTestId('webview')).toBeNull()
+    expect(getByLabelText('loading')).toBeTruthy()
+    await waitFor(() => expect(updateChatSettings).toHaveBeenCalledWith({ seenMessages: 0, id: expect.any(String) }))
+  })
+
+  it('renders the chat webview with a URL containing the existing chat id', () => {
+    const { getByTestId } = render(
+      <TestingAppContext settings={{ chat: { augsburg: { id: 'existing-chat-id', seenMessages: 2 } } }}>
+        <Chat />
+      </TestingAppContext>,
+    )
+
+    const uri = getByTestId('webview').props.children
+    expect(uri).toContain('chat=true')
+    expect(uri).toContain('chatId=existing-chat-id')
+  })
+
+  it('updates seenMessages on blur using the incoming message count', async () => {
+    const { mocked } = jest
+    const buildMessage = (id: number, userIsAuthor: boolean) =>
+      new ChatMessageModel({ id, content: '', created: DateTime.now(), userIsAuthor, automaticAnswer: false })
+    mocked(loadFromEndpoint).mockResolvedValue({
+      messages: [buildMessage(1, false), buildMessage(2, true), buildMessage(3, false)],
+    })
+    const updateChatSettings = jest.fn()
+
+    render(
+      <TestingAppContext
+        settings={{ chat: { augsburg: { id: 'existing-chat-id', seenMessages: 0 } } }}
+        updateChatSettings={updateChatSettings}>
+        <Chat />
+      </TestingAppContext>,
+    )
+
+    expect(focusCallback).not.toBeNull()
+    const focusReturn = focusCallback!()
+    if (typeof focusReturn === 'function') {
+      await focusReturn()
+    }
+
+    expect(updateChatSettings).toHaveBeenCalledWith({ seenMessages: 2 })
+  })
+})

--- a/native/src/testing/TestingAppContext.tsx
+++ b/native/src/testing/TestingAppContext.tsx
@@ -12,11 +12,13 @@ export const testingAppContext = ({
   changeRegionCode = jest.fn(),
   changeLanguageCode = jest.fn(),
   updateSettings = jest.fn(),
+  updateChatSettings = jest.fn(),
 }: TestingAppContextParams): AppContextType => ({
   settings: { ...defaultSettings, ...settings },
   regionCode,
   languageCode,
   updateSettings,
+  updateChatSettings,
   changeRegionCode,
   changeLanguageCode,
 })

--- a/native/src/utils/AppSettings.ts
+++ b/native/src/utils/AppSettings.ts
@@ -2,19 +2,17 @@ import LegacyAsyncStorage, { AsyncStorage, createAsyncStorage } from '@react-nat
 import { mapValues } from 'lodash'
 
 import { ThemeKey } from 'build-configs/ThemeKey'
-import { ExternalSourcePermissions, uuid } from 'shared'
+import { ExternalSourcePermissions } from 'shared'
 
 import { log, captureError } from './sentry'
 
 export const ASYNC_STORAGE_VERSION = 2
 
-type ChatRegionSettings = {
+export type ChatRegionSettings = {
   id: string
   seenMessages: number
 }
 type ChatSettings = Record<string, ChatRegionSettings>
-
-export const defaultChatRegionSettings = { id: uuid(), seenMessages: 0 }
 
 export type SettingsType = {
   storageVersion: number | null

--- a/native/src/utils/AppSettings.ts
+++ b/native/src/utils/AppSettings.ts
@@ -2,11 +2,20 @@ import LegacyAsyncStorage, { AsyncStorage, createAsyncStorage } from '@react-nat
 import { mapValues } from 'lodash'
 
 import { ThemeKey } from 'build-configs/ThemeKey'
-import { ExternalSourcePermissions } from 'shared'
+import { ExternalSourcePermissions, uuid } from 'shared'
 
 import { log, captureError } from './sentry'
 
 export const ASYNC_STORAGE_VERSION = 2
+
+type ChatRegionSettings = {
+  id: string
+  seenMessages: number
+}
+type ChatSettings = Record<string, ChatRegionSettings>
+
+export const defaultChatRegionSettings = { id: uuid(), seenMessages: 0 }
+
 export type SettingsType = {
   storageVersion: number | null
   contentLanguage: string | null
@@ -17,7 +26,9 @@ export type SettingsType = {
   apiUrlOverride: string | null
   externalSourcePermissions: ExternalSourcePermissions
   selectedTheme: ThemeKey
+  chat: ChatSettings
 }
+
 export const defaultSettings: SettingsType = {
   storageVersion: null,
   contentLanguage: null,
@@ -28,7 +39,9 @@ export const defaultSettings: SettingsType = {
   apiUrlOverride: null,
   externalSourcePermissions: {},
   selectedTheme: 'light',
+  chat: {},
 }
+
 export const settingsStorage = createAsyncStorage('settings')
 
 const migrateToV2 = async (): Promise<void> => {

--- a/shared/api/endpoints/__tests__/createChatMessagesEndpoint.spec.ts
+++ b/shared/api/endpoints/__tests__/createChatMessagesEndpoint.spec.ts
@@ -8,14 +8,14 @@ describe('createChatMessagesEndpoint', () => {
   const baseUrl = 'https://example.com'
   const params = {
     regionCode: 'augsburg',
-    language: 'fa',
-    deviceId: '23123-dsasd1-2dsa12',
+    languageCode: 'fa',
+    chatId: '23123-dsasd1-2dsa12',
   }
   const endpoint = createChatMessagesEndpoint(baseUrl)
 
   it('should map params to url', () => {
     expect(endpoint.mapParamsToUrl(params)).toBe(
-      `${baseUrl}/api/${API_VERSION}/${params.regionCode}/${params.language}/chat/${params.deviceId}/`,
+      `${baseUrl}/api/${API_VERSION}/${params.regionCode}/${params.languageCode}/chat/${params.chatId}/`,
     )
   })
 

--- a/shared/api/endpoints/__tests__/createSendChatMessageEndpoint.spec.ts
+++ b/shared/api/endpoints/__tests__/createSendChatMessageEndpoint.spec.ts
@@ -5,14 +5,14 @@ describe('createSendChatMessageEndpoint', () => {
   const baseUrl = 'https://example.com'
   const params = {
     regionCode: 'augsburg',
-    language: 'fa',
-    deviceId: '23123-dsasd1-2dsa12',
+    languageCode: 'fa',
+    chatId: '23123-dsasd1-2dsa12',
     message: 'Ich habe eine Frage',
   }
   const endpoint = createSendChatMessageEndpoint(baseUrl)
   it('should map params to url', () => {
     expect(endpoint.mapParamsToUrl(params)).toBe(
-      `${baseUrl}/api/${API_VERSION}/${params.regionCode}/${params.language}/chat/${params.deviceId}/`,
+      `${baseUrl}/api/${API_VERSION}/${params.regionCode}/${params.languageCode}/chat/${params.chatId}/`,
     )
   })
 
@@ -27,8 +27,8 @@ describe('createSendChatMessageEndpoint', () => {
     expect(
       endpoint.mapParamsToBody({
         regionCode: 'augsburg',
-        language: 'fa',
-        deviceId: params.deviceId,
+        languageCode: 'fa',
+        chatId: params.chatId,
         message: params.message,
       }),
     ).toEqual(formData)

--- a/shared/api/endpoints/createChatMessagesEndpoint.ts
+++ b/shared/api/endpoints/createChatMessagesEndpoint.ts
@@ -6,15 +6,15 @@ import { CHAT_ENDPOINT_NAME } from './createSendChatMessageEndpoint.js'
 
 type ParamsType = {
   regionCode: string
-  language: string
-  deviceId: string
+  languageCode: string
+  chatId: string
 }
 
 export default (baseUrl: string): Endpoint<ParamsType, ChatMessagesReturn> =>
   new EndpointBuilder<ParamsType, ChatMessagesReturn>(CHAT_ENDPOINT_NAME)
     .withParamsToUrlMapper(
       (params: ParamsType): string =>
-        `${baseUrl}/api/${API_VERSION}/${params.regionCode}/${params.language}/${CHAT_ENDPOINT_NAME}/${params.deviceId}/`,
+        `${baseUrl}/api/${API_VERSION}/${params.regionCode}/${params.languageCode}/${CHAT_ENDPOINT_NAME}/${params.chatId}/`,
     )
     .withMapper(mapChatMessages)
     .build()

--- a/shared/api/endpoints/createSendChatMessageEndpoint.ts
+++ b/shared/api/endpoints/createSendChatMessageEndpoint.ts
@@ -7,8 +7,8 @@ export const CHAT_ENDPOINT_NAME = 'chat'
 
 type ParamsType = {
   regionCode: string
-  language: string
-  deviceId: string
+  languageCode: string
+  chatId: string
   message: string
 }
 
@@ -16,7 +16,7 @@ export default (baseUrl: string): Endpoint<ParamsType, ChatMessagesReturn> =>
   new EndpointBuilder<ParamsType, ChatMessagesReturn>(CHAT_ENDPOINT_NAME)
     .withParamsToUrlMapper(
       (params: ParamsType): string =>
-        `${baseUrl}/api/${API_VERSION}/${params.regionCode}/${params.language}/${CHAT_ENDPOINT_NAME}/${params.deviceId}/`,
+        `${baseUrl}/api/${API_VERSION}/${params.regionCode}/${params.languageCode}/${CHAT_ENDPOINT_NAME}/${params.chatId}/`,
     )
     .withParamsToBodyMapper((params: ParamsType): FormData => {
       const { message } = params

--- a/shared/constants/index.ts
+++ b/shared/constants/index.ts
@@ -9,7 +9,7 @@ export const APPOINTMENT_BOOKING_OFFER_ALIAS = 'terminbuchung'
 
 export const INTERNAL_OFFERS = [SPRUNGBRETT_OFFER_ALIAS, MALTE_HELP_FORM_OFFER_ALIAS]
 
-export const getChatName = (appName: string): string => `Frag ${appName}`
+export const getChatName = (appName: string): string => `Frag ${appName.replace('TestCms', '')}`
 
 export type Rating = 'positive' | 'negative'
 

--- a/shared/routes/RouteInformationTypes.ts
+++ b/shared/routes/RouteInformationTypes.ts
@@ -18,6 +18,7 @@ type ParamsType = {
   regionCode: string
   languageCode: string
   chat?: boolean
+  chatId?: string
 }
 
 export type RegionsRouteInformationType = {

--- a/shared/routes/__tests__/query.spec.ts
+++ b/shared/routes/__tests__/query.spec.ts
@@ -47,6 +47,10 @@ describe('queryStringFromRouteInformation', () => {
 
     expect(queryStringFromRouteInformation({ ...routeInformation })).toBeUndefined()
     expect(queryStringFromRouteInformation({ ...routeInformation, chat: true })).toBe('?chat=true')
+    expect(queryStringFromRouteInformation({ ...routeInformation, chat: true, chatId: 'abc-123' })).toBe(
+      '?chat=true&chatId=abc-123',
+    )
+    expect(queryStringFromRouteInformation({ ...routeInformation, chatId: 'abc-123' })).toBe('?chatId=abc-123')
   })
 })
 
@@ -69,6 +73,11 @@ describe('parse query params', () => {
   it('should get chat query params', () => {
     expect(parseQueryParams(new URLSearchParams(''))).toEqual({})
     expect(parseQueryParams(new URLSearchParams('?chat=true'))).toEqual({ chat: true })
+    expect(parseQueryParams(new URLSearchParams('?chat=true&chatId=abc-123'))).toEqual({
+      chat: true,
+      chatId: 'abc-123',
+    })
+    expect(parseQueryParams(new URLSearchParams('?chatId=abc-123'))).toEqual({ chatId: 'abc-123' })
   })
 })
 
@@ -93,5 +102,7 @@ describe('toQueryParams', () => {
   it('should get chat query params', () => {
     expect(toQueryParams({ chat: true })).toEqual(new URLSearchParams('?chat=true'))
     expect(toQueryParams({ chat: undefined })).toEqual(new URLSearchParams(''))
+    expect(toQueryParams({ chat: true, chatId: 'abc-123' })).toEqual(new URLSearchParams('?chat=true&chatId=abc-123'))
+    expect(toQueryParams({ chatId: 'abc-123' })).toEqual(new URLSearchParams('?chatId=abc-123'))
   })
 })

--- a/shared/routes/index.ts
+++ b/shared/routes/index.ts
@@ -76,6 +76,9 @@ export const FEEDBACK_MODAL_ROUTE: FeedbackModalRouteType = 'feedback'
 export type ConsentRouteType = 'consent'
 export const CONSENT_ROUTE: ConsentRouteType = 'consent'
 
+export type ChatRouteType = 'chat'
+export const CHAT_ROUTE: ChatRouteType = 'chat'
+
 // Web routes
 export type MainImprintRouteType = 'main-imprint'
 export const MAIN_IMPRINT_ROUTE: MainImprintRouteType = 'main-imprint'

--- a/shared/routes/query.ts
+++ b/shared/routes/query.ts
@@ -6,6 +6,7 @@ import { PLACES_ROUTE, SEARCH_ROUTE } from './index.js'
 export const MULTI_PLACE_QUERY_KEY = 'multiplace'
 export const SEARCH_QUERY_KEY = 'query'
 export const CHAT_QUERY_KEY = 'chat'
+export const CHAT_ID_QUERY_KEY = 'chatId'
 export const FEEDBACK_QUERY_KEY = 'feedback'
 export const PLACE_CATEGORY_QUERY_KEY = 'category'
 export const ZOOM_QUERY_KEY = 'zoom'
@@ -14,8 +15,11 @@ export const queryStringFromRouteInformation = (
   routeInformation: NonNullableRouteInformationType,
 ): string | undefined => {
   const queryParams = []
-  if ('chat' in routeInformation && routeInformation.chat) {
+  if (CHAT_QUERY_KEY in routeInformation && routeInformation.chat) {
     queryParams.push([CHAT_QUERY_KEY, routeInformation.chat.toString()])
+  }
+  if (CHAT_ID_QUERY_KEY in routeInformation && routeInformation.chatId) {
+    queryParams.push([CHAT_ID_QUERY_KEY, routeInformation.chatId])
   }
   if (routeInformation.route === PLACES_ROUTE) {
     const { multiPlace, placeCategoryId, zoom } = routeInformation
@@ -44,6 +48,7 @@ export type VisibilityQueryParams = {
 }
 
 type QueryParams = VisibilityQueryParams & {
+  chatId?: string
   searchText?: string
   multiPlace?: number
   placeCategoryId?: number
@@ -53,12 +58,13 @@ type QueryParams = VisibilityQueryParams & {
 export const parseQueryParams = (queryParams: URLSearchParams): QueryParams => {
   const searchText = queryParams.get(SEARCH_QUERY_KEY) ?? undefined
   const chat = queryParams.get(CHAT_QUERY_KEY) === 'true' || undefined
+  const chatId = queryParams.get(CHAT_ID_QUERY_KEY) ?? undefined
   const feedbackQuery = queryParams.get(FEEDBACK_QUERY_KEY) ?? undefined
   const feedback = feedbackQuery === RATING_POSITIVE || feedbackQuery === RATING_NEGATIVE ? feedbackQuery : undefined
   const multiPlace = safeParseInt(queryParams.get(MULTI_PLACE_QUERY_KEY))
   const placeCategoryId = safeParseInt(queryParams.get(PLACE_CATEGORY_QUERY_KEY))
   const zoom = safeParseInt(queryParams.get(ZOOM_QUERY_KEY))
-  return { searchText, multiPlace, placeCategoryId, zoom, chat, feedback }
+  return { searchText, multiPlace, placeCategoryId, zoom, chat, chatId, feedback }
 }
 
 export const toQueryParams = ({
@@ -67,11 +73,13 @@ export const toQueryParams = ({
   zoom,
   searchText,
   chat,
+  chatId,
   feedback,
 }: QueryParams): URLSearchParams => {
   const queryParams: [string, string | undefined][] = [
     [SEARCH_QUERY_KEY, searchText],
     [CHAT_QUERY_KEY, chat?.toString()],
+    [CHAT_ID_QUERY_KEY, chatId],
     [FEEDBACK_QUERY_KEY, feedback],
     [MULTI_PLACE_QUERY_KEY, multiPlace?.toString()],
     [PLACE_CATEGORY_QUERY_KEY, placeCategoryId?.toString()],

--- a/shared/utils/index.ts
+++ b/shared/utils/index.ts
@@ -1,4 +1,5 @@
 import segment from 'sentencex'
+import { v4 } from 'uuid'
 
 export { formatDateICal } from './date.js'
 
@@ -47,3 +48,5 @@ export const getGenericLanguageCode = (languageCode: string): string => {
 
 export const join = <T, U>(items: T[], separator: (index: number) => U): (T | U)[] =>
   items.flatMap((item, index) => [item, separator(index)]).slice(0, -1)
+
+export const uuid = (): string => v4()

--- a/web/src/RegionContentNavigator.tsx
+++ b/web/src/RegionContentNavigator.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, ReactElement, Suspense } from 'react'
-import { Navigate, Route, Routes, useLocation, useParams } from 'react-router'
+import { Navigate, Route, Routes, useLocation, useParams, useSearchParams } from 'react-router'
 
 import {
   CATEGORIES_ROUTE,
@@ -10,14 +10,17 @@ import {
   normalizePath,
   PLACES_ROUTE,
   SEARCH_ROUTE,
+  parseQueryParams,
 } from 'shared'
 import { NotFoundError, createRegionEndpoint } from 'shared/api'
 
+import ChatContainer from './components/ChatContainer'
 import FailureSwitcherWithHelmet from './components/FailureSwitcherWithHelmet'
 import Footer from './components/Footer'
 import GeneralHeader from './components/GeneralHeader'
 import LanguageFailure from './components/LanguageFailure'
 import Layout from './components/Layout'
+import LoadingSpinner from './components/LoadingSpinner'
 import RegionContentLayout from './components/RegionContentLayout'
 import { cmsApiBaseUrl } from './constants/urls'
 import useQueryFromEndpoint from './hooks/useQueryFromEndpoint'
@@ -45,6 +48,7 @@ type RegionContentNavigatorProps = {
 }
 
 const RegionContentNavigator = ({ languageCode }: RegionContentNavigatorProps): ReactElement => {
+  const externalChatId = parseQueryParams(useSearchParams()[0]).chatId
   // This component is only opened when there is a regionCode in the route
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const regionCode = useParams().regionCode!
@@ -88,6 +92,13 @@ const RegionContentNavigator = ({ languageCode }: RegionContentNavigatorProps): 
         />
       </Layout>
     )
+  }
+
+  if (externalChatId) {
+    if (!region) {
+      return <LoadingSpinner />
+    }
+    return <ChatContainer region={region} languageCode={languageCode} languageChangePaths={[]} />
   }
 
   const regionRouteProps: RegionRouteProps = {

--- a/web/src/RegionContentNavigator.tsx
+++ b/web/src/RegionContentNavigator.tsx
@@ -98,7 +98,11 @@ const RegionContentNavigator = ({ languageCode }: RegionContentNavigatorProps): 
     if (!region) {
       return <LoadingSpinner />
     }
-    return <ChatContainer region={region} languageCode={languageCode} languageChangePaths={[]} />
+    return (
+      <Layout fitScreen>
+        <ChatContainer region={region} languageCode={languageCode} languageChangePaths={[]} />
+      </Layout>
+    )
   }
 
   const regionRouteProps: RegionRouteProps = {

--- a/web/src/components/Chat.tsx
+++ b/web/src/components/Chat.tsx
@@ -100,9 +100,9 @@ const Chat = ({
       () =>
         loadFromEndpoint(createSendChatMessageEndpoint, cmsApiBaseUrl, {
           regionCode: region.code,
-          language: languageCode,
+          languageCode,
+          chatId,
           message,
-          deviceId: chatId,
         }),
       {
         setData: newData => {

--- a/web/src/components/Chat.tsx
+++ b/web/src/components/Chat.tsx
@@ -171,7 +171,7 @@ const Chat = ({
 
   return (
     <Container justifyContent='space-between'>
-      <ChatConversation retrySend={retrySend} messages={messages} isTyping={botTyping} loading={isPending} />
+      <ChatConversation retrySend={retrySend} messages={messages} botTyping={botTyping} loading={isPending} />
       <Stack paddingInline={2} gap={1}>
         {(error || sendingError) && (
           <Alert

--- a/web/src/components/Chat.tsx
+++ b/web/src/components/Chat.tsx
@@ -54,6 +54,7 @@ type ChatProps = {
   chatId: string
   region: RegionModel
   languageCode: string
+  openUrl: ((url: string) => void) | null
 }
 
 const Chat = ({
@@ -63,6 +64,7 @@ const Chat = ({
   chatId,
   region,
   languageCode,
+  openUrl,
 }: ChatProps): ReactElement => {
   const [sendingError, setSendingError] = useState<Error | null>(null)
   const [textInput, setTextInput] = useState<string>('')
@@ -171,7 +173,13 @@ const Chat = ({
 
   return (
     <Container justifyContent='space-between'>
-      <ChatConversation retrySend={retrySend} messages={messages} botTyping={botTyping} loading={isPending} />
+      <ChatConversation
+        retrySend={retrySend}
+        messages={messages}
+        botTyping={botTyping}
+        loading={isPending}
+        openUrl={openUrl}
+      />
       <Stack paddingInline={2} gap={1}>
         {(error || sendingError) && (
           <Alert

--- a/web/src/components/ChatContainer.tsx
+++ b/web/src/components/ChatContainer.tsx
@@ -2,7 +2,7 @@ import { dialogContentClasses } from '@mui/material/DialogContent'
 import { styled } from '@mui/material/styles'
 import React, { ReactElement, useContext, useEffect } from 'react'
 
-import { getChatName, CHAT_QUERY_KEY, CHAT_TYPING_POLLING_INTERVAL, CHAT_DEFAULT_POLLING_INTERVAL } from 'shared'
+import { getChatName, CHAT_QUERY_KEY, CHAT_TYPING_POLLING_INTERVAL, CHAT_DEFAULT_POLLING_INTERVAL, uuid } from 'shared'
 import { createChatMessagesEndpoint, RegionModel, SerializedChatMessage } from 'shared/api'
 
 import buildConfig from '../constants/buildConfig'
@@ -14,7 +14,7 @@ import useLocalStorage, { CHAT_UNSYNCED_MESSAGES_STORAGE_KEY } from '../hooks/us
 import useLockedBody from '../hooks/useLockedBody'
 import useQueryFromEndpoint from '../hooks/useQueryFromEndpoint'
 import useQueryParamVisibility from '../hooks/useQueryParamVisibility'
-import { chatIdKey, chatSeenMessagesKey, generateChatId } from '../utils/chat'
+import { chatIdKey, chatSeenMessagesKey } from '../utils/chat'
 import Chat from './Chat'
 import ChatFab from './ChatFab'
 import ChatMenu from './ChatMenu'
@@ -43,7 +43,7 @@ const ChatContainer = ({ region, languageCode, languageChangePaths }: ChatContai
 
   const [chatId, setChatId] = useLocalStorage<string>({
     key: chatIdKey(region.code),
-    initialValue: generateChatId(),
+    initialValue: uuid(),
   })
 
   const [unsyncedMessages, setUnsyncedMessages] = useLocalStorage<SerializedChatMessage[]>({
@@ -89,7 +89,7 @@ const ChatContainer = ({ region, languageCode, languageChangePaths }: ChatContai
 
   const resetChat = () => {
     setUnsyncedMessages([])
-    setChatId(generateChatId())
+    setChatId(uuid())
     setSeenMessages(0)
   }
 

--- a/web/src/components/ChatContainer.tsx
+++ b/web/src/components/ChatContainer.tsx
@@ -23,6 +23,7 @@ import useLockedBody from '../hooks/useLockedBody'
 import useQueryFromEndpoint from '../hooks/useQueryFromEndpoint'
 import useQueryParamVisibility from '../hooks/useQueryParamVisibility'
 import { chatIdKey, chatSeenMessagesKey } from '../utils/chat'
+import { openUrlInNewTab } from '../utils/openLink'
 import Chat from './Chat'
 import ChatFab from './ChatFab'
 import ChatMenu from './ChatMenu'
@@ -137,6 +138,7 @@ const ChatContainer = ({ region, languageCode, languageChangePaths }: ChatContai
           response={response}
           serializedUnsyncedMessages={unsyncedMessages}
           setUnsyncedMessages={setUnsyncedMessages}
+          openUrl={externalChatId ? openUrlInNewTab : null}
         />
       </StyledDialog>
     )

--- a/web/src/components/ChatContainer.tsx
+++ b/web/src/components/ChatContainer.tsx
@@ -70,8 +70,8 @@ const ChatContainer = ({ region, languageCode, languageChangePaths }: ChatContai
     cmsApiBaseUrl,
     {
       regionCode: region.code,
-      language: languageCode,
-      deviceId: chatId,
+      languageCode,
+      chatId,
     },
     { cached: false },
   )

--- a/web/src/components/ChatContainer.tsx
+++ b/web/src/components/ChatContainer.tsx
@@ -1,8 +1,16 @@
 import { dialogContentClasses } from '@mui/material/DialogContent'
 import { styled } from '@mui/material/styles'
 import React, { ReactElement, useContext, useEffect } from 'react'
+import { useSearchParams } from 'react-router'
 
-import { getChatName, CHAT_QUERY_KEY, CHAT_TYPING_POLLING_INTERVAL, CHAT_DEFAULT_POLLING_INTERVAL, uuid } from 'shared'
+import {
+  getChatName,
+  CHAT_QUERY_KEY,
+  CHAT_TYPING_POLLING_INTERVAL,
+  CHAT_DEFAULT_POLLING_INTERVAL,
+  uuid,
+  parseQueryParams,
+} from 'shared'
 import { createChatMessagesEndpoint, RegionModel, SerializedChatMessage } from 'shared/api'
 
 import buildConfig from '../constants/buildConfig'
@@ -36,15 +44,17 @@ type ChatContainerProps = {
 
 const ChatContainer = ({ region, languageCode, languageChangePaths }: ChatContainerProps): ReactElement | null => {
   const { open, close, openUrl, visible } = useQueryParamVisibility(CHAT_QUERY_KEY)
+  const externalChatId = parseQueryParams(useSearchParams()[0]).chatId
   const { xsmall } = useDimensions()
   const { visible: ttsPlayerVisible } = useContext(TtsContext)
   const isBrowserTabActive = useIsTabActive()
   useLockedBody(visible)
 
-  const [chatId, setChatId] = useLocalStorage<string>({
+  const [storageChatId, setChatId] = useLocalStorage<string>({
     key: chatIdKey(region.code),
     initialValue: uuid(),
   })
+  const chatId = externalChatId ?? storageChatId
 
   const [unsyncedMessages, setUnsyncedMessages] = useLocalStorage<SerializedChatMessage[]>({
     key: CHAT_UNSYNCED_MESSAGES_STORAGE_KEY,

--- a/web/src/components/ChatContainer.tsx
+++ b/web/src/components/ChatContainer.tsx
@@ -117,6 +117,7 @@ const ChatContainer = ({ region, languageCode, languageChangePaths }: ChatContai
       <StyledDialog
         title={chatName}
         close={close}
+        showHeader={!externalChatId}
         actions={[
           ...(languageChangePaths
             ? [

--- a/web/src/components/ChatConversation.tsx
+++ b/web/src/components/ChatConversation.tsx
@@ -24,9 +24,16 @@ type ChatConversationProps = {
   messages: ChatMessageModel[]
   botTyping: boolean
   loading?: boolean
+  openUrl: ((url: string) => void) | null
 }
 
-const ChatConversation = ({ retrySend, messages, botTyping, loading }: ChatConversationProps): ReactElement => {
+const ChatConversation = ({
+  retrySend,
+  messages,
+  botTyping,
+  loading,
+  openUrl,
+}: ChatConversationProps): ReactElement => {
   const [messagesCount, setMessagesCount] = useState(0)
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const { t } = useTranslation('chat')
@@ -73,6 +80,7 @@ const ChatConversation = ({ retrySend, messages, botTyping, loading }: ChatConve
                 message={message}
                 key={message.id}
                 previousMessage={messages[index - 1]}
+                openUrl={openUrl}
               />
             ))}
           </StyledList>

--- a/web/src/components/ChatConversation.tsx
+++ b/web/src/components/ChatConversation.tsx
@@ -22,11 +22,11 @@ const StyledList = styled(List)({
 type ChatConversationProps = {
   retrySend: (message: ChatMessageModel) => void
   messages: ChatMessageModel[]
-  isTyping: boolean
+  botTyping: boolean
   loading?: boolean
 }
 
-const ChatConversation = ({ retrySend, messages, isTyping, loading }: ChatConversationProps): ReactElement => {
+const ChatConversation = ({ retrySend, messages, botTyping, loading }: ChatConversationProps): ReactElement => {
   const [messagesCount, setMessagesCount] = useState(0)
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const { t } = useTranslation('chat')
@@ -43,10 +43,10 @@ const ChatConversation = ({ retrySend, messages, isTyping, loading }: ChatConver
   }, [messages, messagesCount])
 
   useEffect(() => {
-    if (isTyping) {
+    if (botTyping) {
       scrollToBottom()
     }
-  }, [isTyping])
+  }, [botTyping])
 
   const lastMessage = messages[messages.length - 1]
   const lastMessageText = lastMessage ? parseHTML(lastMessage.content, true) : ''
@@ -76,7 +76,7 @@ const ChatConversation = ({ retrySend, messages, isTyping, loading }: ChatConver
               />
             ))}
           </StyledList>
-          <TypingIndicator isVisible={isTyping} />
+          <TypingIndicator isVisible={botTyping} />
           <div ref={messagesEndRef} />
         </>
       )}

--- a/web/src/components/ChatFab.tsx
+++ b/web/src/components/ChatFab.tsx
@@ -32,12 +32,17 @@ type ChatButtonProps = {
 const ChatFab = ({ onClick, unreadMessageCount }: ChatButtonProps): ReactElement => {
   const { desktop, visibleFooterHeight, bottomNavigationHeight } = useDimensions()
   const { t } = useTranslation('chat')
+
   const chatName = getChatName(buildConfig().appName)
+  const unreadMessages = t('unreadMessages', { count: unreadMessageCount })
 
   return (
     <ChatButtonContainer bottom={bottomNavigationHeight ?? visibleFooterHeight}>
-      <LiveAnnouncer message={unreadMessageCount > 0 ? t('unreadMessages', { count: unreadMessageCount }) : ''} />
-      <Badge badgeContent={unreadMessageCount > 0 ? unreadMessageCount : undefined} color='error'>
+      <LiveAnnouncer message={unreadMessageCount > 0 ? unreadMessages : ''} />
+      <Badge
+        badgeContent={unreadMessageCount > 0 ? unreadMessageCount : undefined}
+        color='error'
+        aria-label={unreadMessages}>
         <Fab onClick={onClick} color='primary' aria-label={chatName}>
           <QuestionAnswerOutlinedIcon fontSize='large' />
         </Fab>

--- a/web/src/components/ChatMessage.tsx
+++ b/web/src/components/ChatMessage.tsx
@@ -86,9 +86,10 @@ type ChatMessageProps = {
   retrySend: (message: ChatMessageModel) => void
   message: ChatMessageModel
   previousMessage: ChatMessageModel | undefined
+  openUrl: ((url: string) => void) | null
 }
 
-const ChatMessage = ({ retrySend, message, previousMessage }: ChatMessageProps): ReactElement => {
+const ChatMessage = ({ retrySend, message, previousMessage, openUrl }: ChatMessageProps): ReactElement => {
   const { t } = useTranslation('chat')
 
   const hasAuthorChanged = message.userIsAuthor !== previousMessage?.userIsAuthor
@@ -109,7 +110,7 @@ const ChatMessage = ({ retrySend, message, previousMessage }: ChatMessageProps):
           </Tooltip>
         ) : null
       }>
-      <RemoteContent html={message.content} smallText />
+      <RemoteContent html={message.content} onLinkClick={openUrl ?? undefined} smallText />
     </InnerChatMessage>
   )
 }

--- a/web/src/components/RemoteContent.tsx
+++ b/web/src/components/RemoteContent.tsx
@@ -19,17 +19,23 @@ import {
 import openLink from '../utils/openLink'
 import RemoteContentSandBox from './RemoteContentSandBox'
 
-type RemoteContentProps = {
-  html: string
-  centered?: boolean
-  smallText?: boolean
-}
-
 const DOMPURIFY_TAG_IFRAME = 'iframe'
 const DOMPURIFY_ATTRIBUTE_FULLSCREEN = 'allowfullscreen'
 const DOMPURIFY_ATTRIBUTE_TARGET = 'target'
 
-const RemoteContent = ({ html, centered = false, smallText = false }: RemoteContentProps): ReactElement => {
+type RemoteContentProps = {
+  html: string
+  centered?: boolean
+  smallText?: boolean
+  onLinkClick?: (url: string) => void
+}
+
+const RemoteContent = ({
+  html,
+  centered = false,
+  smallText = false,
+  onLinkClick,
+}: RemoteContentProps): ReactElement => {
   const navigate = useNavigate()
   const sandBoxRef = React.createRef<HTMLDivElement>()
   const [externalSources, setExternalSources] = useLocalStorage<ExternalSourcePermissions>({
@@ -46,9 +52,13 @@ const RemoteContent = ({ html, centered = false, smallText = false }: RemoteCont
     (event: MouseEvent) => {
       event.preventDefault()
       const target = event.currentTarget as HTMLAnchorElement
-      openLink(navigate, target.href)
+      if (onLinkClick) {
+        onLinkClick(target.href)
+      } else {
+        openLink(navigate, target.href)
+      }
     },
-    [navigate],
+    [onLinkClick, navigate],
   )
 
   const addExternalSource = useCallback(

--- a/web/src/components/__tests__/Chat.spec.tsx
+++ b/web/src/components/__tests__/Chat.spec.tsx
@@ -51,6 +51,7 @@ const render = (response = mockResponse(), serializedUnsyncedMessages: Serialize
       languageCode='de'
       serializedUnsyncedMessages={serializedUnsyncedMessages}
       setUnsyncedMessages={mockSetUnsyncedMessages}
+      openUrl={jest.fn()}
     />,
   )
 

--- a/web/src/components/__tests__/ChatContainer.spec.tsx
+++ b/web/src/components/__tests__/ChatContainer.spec.tsx
@@ -1,8 +1,9 @@
 import { fireEvent } from '@testing-library/react'
+import { DateTime } from 'luxon'
 import React from 'react'
 
 import { getChatName } from 'shared'
-import { RegionModelBuilder } from 'shared/api'
+import { ChatMessageModel, RegionModelBuilder } from 'shared/api'
 
 import { CHAT_PRIVACY_POLICIES_STORAGE_KEY } from '../../hooks/useLocalStorage'
 import { mockUseQueryFromEndpointWithData } from '../../testing/mockUseQueryFromEndpoint'
@@ -133,6 +134,69 @@ describe('ChatContainer', () => {
     )
     expect(getAllByText(getChatName('IntegreatTestCms'))).toHaveLength(1)
     expect(router.state.location.search).toBe('?')
+  })
+
+  it('should open chat message links in a new tab when an external chat id is set', () => {
+    const href = 'https://example.com/'
+    mockUseQueryFromEndpointWithData({
+      messages: [
+        new ChatMessageModel({
+          id: 1,
+          content: `<a href="${href}">external link</a>`,
+          created: DateTime.fromISO('2026-03-10T10:28:00.000Z'),
+          userIsAuthor: false,
+          automaticAnswer: false,
+        }),
+      ],
+      botTyping: false,
+    })
+    const windowOpen = jest.spyOn(window, 'open').mockReturnValue(null)
+
+    const { getByRole } = renderRoute(
+      <ChatContainer region={region} languageCode='de' languageChangePaths={languageChangePaths} />,
+      {
+        pathname,
+        routePattern,
+        searchParams: '?chat=true&chatId=external-id',
+      },
+    )
+
+    fireEvent.click(getByRole('link', { name: 'external link' }))
+    expect(windowOpen).toHaveBeenCalledWith(href, '_blank', 'noreferrer')
+
+    windowOpen.mockRestore()
+  })
+
+  it('should follow chat message links via the router when no external chat id is set', () => {
+    const href = 'https://integreat.app/augsburg/en'
+    mockUseQueryFromEndpointWithData({
+      messages: [
+        new ChatMessageModel({
+          id: 1,
+          content: `<a href="${href}">internal link</a>`,
+          created: DateTime.fromISO('2026-03-10T10:28:00.000Z'),
+          userIsAuthor: false,
+          automaticAnswer: false,
+        }),
+      ],
+      botTyping: false,
+    })
+    const windowOpen = jest.spyOn(window, 'open').mockReturnValue(null)
+
+    const { getByRole, router } = renderRoute(
+      <ChatContainer region={region} languageCode='de' languageChangePaths={languageChangePaths} />,
+      {
+        pathname,
+        routePattern: '/:regionCode/:languageCode/*',
+        searchParams: '?chat=true',
+      },
+    )
+
+    fireEvent.click(getByRole('link', { name: 'internal link' }))
+    expect(router.state.location.pathname).toBe('/augsburg/en')
+    expect(windowOpen).not.toHaveBeenCalled()
+
+    windowOpen.mockRestore()
   })
 
   it('should hide the dialog header when an external chat id is set', () => {

--- a/web/src/components/__tests__/ChatContainer.spec.tsx
+++ b/web/src/components/__tests__/ChatContainer.spec.tsx
@@ -135,6 +135,34 @@ describe('ChatContainer', () => {
     expect(router.state.location.search).toBe('?')
   })
 
+  it('should hide the dialog header when an external chat id is set', () => {
+    const { queryByLabelText, queryByText } = renderRoute(
+      <ChatContainer region={region} languageCode='de' languageChangePaths={languageChangePaths} />,
+      {
+        pathname,
+        routePattern,
+        searchParams: '?chat=true&chatId=external-id',
+      },
+    )
+
+    expect(queryByLabelText('layout:common:close')).toBeNull()
+    expect(queryByText(getChatName('IntegreatTestCms'))).toBeNull()
+  })
+
+  it('should show the dialog header when no external chat id is set', () => {
+    const { getByLabelText, getByText } = renderRoute(
+      <ChatContainer region={region} languageCode='de' languageChangePaths={languageChangePaths} />,
+      {
+        pathname,
+        routePattern,
+        searchParams: '?chat=true',
+      },
+    )
+
+    expect(getByLabelText('layout:common:close')).toBeTruthy()
+    expect(getByText(getChatName('IntegreatTestCms'))).toBeTruthy()
+  })
+
   it('should switch the language', () => {
     const { getByText, getByLabelText, router } = renderRoute(
       <ChatContainer region={region} languageCode='de' languageChangePaths={languageChangePaths} />,

--- a/web/src/components/__tests__/ChatConversation.spec.tsx
+++ b/web/src/components/__tests__/ChatConversation.spec.tsx
@@ -14,7 +14,7 @@ jest.useFakeTimers()
 const retrySend = jest.fn()
 
 const render = (messages: ChatMessageModel[], isTyping: boolean) =>
-  renderWithRouterAndTheme(<ChatConversation retrySend={retrySend} messages={messages} isTyping={isTyping} />)
+  renderWithRouterAndTheme(<ChatConversation retrySend={retrySend} messages={messages} botTyping={isTyping} />)
 
 describe('ChatConversation', () => {
   const testMessages: ChatMessageModel[] = [
@@ -124,7 +124,7 @@ describe('ChatConversation', () => {
     })
     const { queryByLabelText, rerender } = render(testMessages, true)
     expect(queryByLabelText('chat:generateAnswer')).toBeTruthy()
-    rerender(<ChatConversation retrySend={retrySend} messages={[...testMessages, botMessage]} isTyping={false} />)
+    rerender(<ChatConversation retrySend={retrySend} messages={[...testMessages, botMessage]} botTyping={false} />)
     expect(queryByLabelText('chat:generateAnswer')).toBeNull()
   })
 

--- a/web/src/components/__tests__/ChatConversation.spec.tsx
+++ b/web/src/components/__tests__/ChatConversation.spec.tsx
@@ -14,7 +14,9 @@ jest.useFakeTimers()
 const retrySend = jest.fn()
 
 const render = (messages: ChatMessageModel[], isTyping: boolean) =>
-  renderWithRouterAndTheme(<ChatConversation retrySend={retrySend} messages={messages} botTyping={isTyping} />)
+  renderWithRouterAndTheme(
+    <ChatConversation retrySend={retrySend} messages={messages} botTyping={isTyping} openUrl={jest.fn()} />,
+  )
 
 describe('ChatConversation', () => {
   const testMessages: ChatMessageModel[] = [
@@ -124,7 +126,14 @@ describe('ChatConversation', () => {
     })
     const { queryByLabelText, rerender } = render(testMessages, true)
     expect(queryByLabelText('chat:generateAnswer')).toBeTruthy()
-    rerender(<ChatConversation retrySend={retrySend} messages={[...testMessages, botMessage]} botTyping={false} />)
+    rerender(
+      <ChatConversation
+        retrySend={retrySend}
+        messages={[...testMessages, botMessage]}
+        botTyping={false}
+        openUrl={jest.fn()}
+      />,
+    )
     expect(queryByLabelText('chat:generateAnswer')).toBeNull()
   })
 

--- a/web/src/components/__tests__/RemoteContent.spec.tsx
+++ b/web/src/components/__tests__/RemoteContent.spec.tsx
@@ -40,6 +40,25 @@ describe('RemoteContent', () => {
     expect(window.open).not.toHaveBeenCalled()
   })
 
+  it('should delegate link clicks to onLinkClick instead of opening them when provided', () => {
+    const onLinkClick = jest.fn()
+    const internalHref = 'https://integreat.app/augsburg/de'
+    const externalHref = 'https://example.com/'
+    const html = `<a href=${internalHref}>Internal</a><a href=${externalHref} class="link-external">External</a>`
+
+    const { getAllByRole } = renderWithTheme(<RemoteContent html={html} onLinkClick={onLinkClick} />)
+    const [internalLink, externalLink] = getAllByRole('link')
+
+    fireEvent.click(internalLink!)
+    fireEvent.click(externalLink!)
+
+    expect(onLinkClick).toHaveBeenCalledTimes(2)
+    expect(onLinkClick).toHaveBeenNthCalledWith(1, internalHref)
+    expect(onLinkClick).toHaveBeenNthCalledWith(2, externalHref)
+    expect(navigate).not.toHaveBeenCalled()
+    expect(window.open).not.toHaveBeenCalled()
+  })
+
   it('should open external links in a new tab', () => {
     const href = 'https://example.com/'
     const html = `<a href=${href} class="link-external">Test Anchor</a>`

--- a/web/src/components/base/Dialog.tsx
+++ b/web/src/components/base/Dialog.tsx
@@ -34,9 +34,10 @@ type DialogProps = {
   close: () => void
   children: ReactElement | ReactElement[]
   className?: string
+  showHeader?: boolean
 }
 
-const Dialog = ({ title, close, children, className, actions }: DialogProps): ReactElement => {
+const Dialog = ({ title, close, children, className, actions, showHeader = true }: DialogProps): ReactElement => {
   const { mobile, desktop } = useDimensions()
   const { t } = useTranslation('layout')
 
@@ -51,20 +52,22 @@ const Dialog = ({ title, close, children, className, actions }: DialogProps): Re
 
   return (
     <StyledMuiDialog onClose={close} container={dialogContainer} fullScreen={mobile} className={className} open>
-      <Stack
-        direction={desktop ? 'row-reverse' : 'row'}
-        alignItems='center'
-        justifyContent={desktop ? 'space-between' : undefined}
-        marginInline={1}>
-        <IconButton aria-label={t('common:close')} onClick={close}>
-          {desktop ? <CloseIcon /> : <DirectionDependentBackIcon />}
-        </IconButton>
-        {desktop && Actions}
-        <StyledDialogTitle component='h2' variant='h4' textOverflow='ellipsis' whiteSpace='nowrap' overflow='hidden'>
-          {title}
-        </StyledDialogTitle>
-        {mobile && Actions}
-      </Stack>
+      {showHeader && (
+        <Stack
+          direction={desktop ? 'row-reverse' : 'row'}
+          alignItems='center'
+          justifyContent={desktop ? 'space-between' : undefined}
+          marginInline={1}>
+          <IconButton aria-label={t('common:close')} onClick={close}>
+            {desktop ? <CloseIcon /> : <DirectionDependentBackIcon />}
+          </IconButton>
+          {desktop && Actions}
+          <StyledDialogTitle component='h2' variant='h4' textOverflow='ellipsis' whiteSpace='nowrap' overflow='hidden'>
+            {title}
+          </StyledDialogTitle>
+          {mobile && Actions}
+        </Stack>
+      )}
       <DialogContent>{children}</DialogContent>
     </StyledMuiDialog>
   )

--- a/web/src/utils/chat.ts
+++ b/web/src/utils/chat.ts
@@ -5,5 +5,3 @@ export const chatIdKey = (regionCode: string): string => `${CHAT_ID_STORAGE_KEY}
 
 export const chatSeenMessagesKey = (regionCode: string): string =>
   `${CHAT_SEEN_MESSAGE_COUNT_STORAGE_KEY}-${regionCode}`
-
-export const generateChatId = (): string => globalThis.crypto.randomUUID()

--- a/web/src/utils/openLink.ts
+++ b/web/src/utils/openLink.ts
@@ -24,6 +24,8 @@ const isRelativeInternalLink = (link: string): boolean => {
 
 export const isInternalLink = (link: string): boolean => isRelativeInternalLink(link) || isInternalUrl(link)
 
+export const openUrlInNewTab = (url: string): Window | null => window.open(url, NEW_TAB, NEW_TAB_FEATURES)
+
 const openLink = (navigate: NavigateFunction, link: string): void => {
   if (isRelativeInternalLink(link)) {
     navigate(link)
@@ -31,7 +33,7 @@ const openLink = (navigate: NavigateFunction, link: string): void => {
     const url = new URL(decodeURIComponent(link))
     navigate(decodeURIComponent(`${url.pathname}${url.search}${url.hash}`))
   } else {
-    window.open(link, NEW_TAB, NEW_TAB_FEATURES)
+    openUrlInNewTab(link)
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2001,16 +2001,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@dr.pogodin/react-native-webview@npm:^13.17.1":
-  version: 13.17.1
-  resolution: "@dr.pogodin/react-native-webview@npm:13.17.1"
+"@dr.pogodin/react-native-webview@npm:^13.17.4":
+  version: 13.17.4
+  resolution: "@dr.pogodin/react-native-webview@npm:13.17.4"
   dependencies:
     escape-string-regexp: "npm:^5.0.0"
     invariant: "npm:2.2.4"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10c0/9fd7aa904d86f36925f3ee3df4d1d9d94fb0585af7ef449813d74ac2fc85d14d2493cb95c2d7a166e0b8860117aad55c9f0a5e4cd1b9f7526cfff3ca59e0b001
+  checksum: 10c0/a45c54bc442fa7f27625a3fe32f303ac008f33b2891fd4559ddc6675c139ae40633f5fa7dd20e3951e1501976bd6f2f8fb403308048a74e76a667598b4a9eab0
   languageName: node
   linkType: hard
 
@@ -18085,7 +18085,7 @@ __metadata:
     "@babel/runtime": "npm:^7.29.2"
     "@dr.pogodin/react-native-fs": "npm:^2.37.0"
     "@dr.pogodin/react-native-static-server": "npm:^0.26.0"
-    "@dr.pogodin/react-native-webview": "npm:^13.17.1"
+    "@dr.pogodin/react-native-webview": "npm:^13.17.4"
     "@formatjs/intl-displaynames": "npm:^6.8.13"
     "@formatjs/intl-locale": "npm:^4.2.13"
     "@gorhom/bottom-sheet": "npm:^5.2.8"


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
<!-- Make sure to correctly set PR labels if necessary: `Native`/`Web` for native/web only PRs and `maintenance` for non-user-facing changes. -->
Add the chat on native by wrapping the web chat in a webview and implementing only the chat id and seen messages logic on native.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Add chat fab with message counter badge on native
- Open a new chat route on native which only renders the chat in a webview
- Allow opening a specific/fixed chat via the `chatId` query param
- Hide the chat dialog header for fixed chats
- Prevent opening of links in the webview for fixed chats
- Make the customized native WebView reusable
- Change chat name while testing from `Frag IntegreatTestCms` to `Frag Integreat`

I had to patch react-native-webview to fix an app crash when closing the chat while waiting for a new answer.
The patch can be removed after https://github.com/birdofpreyru/react-native-webview/pull/21 is merged.

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Checklist

- [x] Followed the [contributing guidelines](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md) and [conventions](https://github.com/digitalfabrik/integreat-app/blob/main/docs/conventions.md)
- [x] Considered accessibility impacts and made the necessary adjustments
- [x] Added or updated unit tests (if applicable)
- [x] Added or updated documentation (if applicable)
- [x] Added a [release note](https://github.com/digitalfabrik/integreat-app/tree/main/release-notes) for native (if [applicable](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes))

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Devs only:
- [Devs only] Start the web dev server
- [Devs only] Replace the [url in L8 of native/src/util/url.ts](https://github.com/digitalfabrik/integreat-app/blob/c2e63c6abd0a29be66c9ca0229b4f6337470cfd8/native/src/utils/url.ts#L8) with the webpack local ip (not localhost), e.g. http://192.168.178.23:9001/
- Click on the chat fab on native
- Close the chat before you get an answer and see the unread messages badge (might still crash, just reopen the app)
- Verify that the chat in web still continues to work as before

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4209, #4210

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
