### PR TITLE
4214: Fix back navigation by separating the condition before redirecting

### DIFF
--- a/native/src/hooks/useNavigate.ts
+++ b/native/src/hooks/useNavigate.ts
@@ -64,15 +64,17 @@ const navigate = <T extends RoutesType>(
   if ((appRegionCode && appRegionCode !== regionCode) || appLanguageCode !== languageCode) {
     // We need to remove or replace the redirect route if only opening the inappbrowser
     // Otherwise this leads to a blank (redirect) screen when navigating back from the inappbrowser
-    if (redirect && navigation.canGoBack()) {
-      navigation.pop()
-    } else {
-      navigation.replace(BOTTOM_TAB_ROUTE, {
-        screen: CATEGORIES_TAB_ROUTE,
-        params: {
-          screen: CATEGORIES_ROUTE,
-        },
-      })
+    if (redirect) {
+      if (navigation.canGoBack()) {
+        navigation.pop()
+      } else {
+        navigation.replace(BOTTOM_TAB_ROUTE, {
+          screen: CATEGORIES_TAB_ROUTE,
+          params: {
+            screen: CATEGORIES_ROUTE,
+          },
+        })
+      }
     }
     openExternalUrl(url, showSnackbar).catch(captureError)
     return

--- a/native/src/hooks/useNavigate.ts
+++ b/native/src/hooks/useNavigate.ts
@@ -64,17 +64,15 @@ const navigate = <T extends RoutesType>(
   if ((appRegionCode && appRegionCode !== regionCode) || appLanguageCode !== languageCode) {
     // We need to remove or replace the redirect route if only opening the inappbrowser
     // Otherwise this leads to a blank (redirect) screen when navigating back from the inappbrowser
-    if (redirect) {
-      if (navigation.canGoBack()) {
-        navigation.pop()
-      } else {
-        navigation.replace(BOTTOM_TAB_ROUTE, {
-          screen: CATEGORIES_TAB_ROUTE,
-          params: {
-            screen: CATEGORIES_ROUTE,
-          },
-        })
-      }
+    if (redirect && navigation.canGoBack()) {
+      navigation.pop()
+    } else if (redirect) {
+      navigation.replace(BOTTOM_TAB_ROUTE, {
+        screen: CATEGORIES_TAB_ROUTE,
+        params: {
+          screen: CATEGORIES_ROUTE,
+        },
+      })
     }
     openExternalUrl(url, showSnackbar).catch(captureError)
     return

--- a/release-notes/unreleased/4214-fix-back-nav-for-inAppBrowser-links.yml
+++ b/release-notes/unreleased/4214-fix-back-nav-for-inAppBrowser-links.yml
@@ -1,0 +1,8 @@
+issue_key: 4214
+show_in_stores: true
+platforms: # relevant platforms, possible values are android and ios
+  - android
+  - ios
+en: Improved the navigation behavior when opening external links in the in-app browser.
+# de is required for notes with show_in_stores set to true
+de: Verbessertes Navigationsverhalten beim Öffnen externer Links im In-App-Browser.


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
<!-- Make sure to correctly set PR labels if necessary: `Native`/`Web` for native/web only PRs and `maintenance` for non-user-facing changes. -->

When I open from a place from a page for example Testumgebung/Social Life, a web/map overlay opens and if I close the the overlay using X button, I am taken back to the Information overview instead of the previous page (e.g Social Life).


### Proposed Changes

<!-- Describe this PR in more detail. -->

- With `(redirect && navigation.canGoBack())` anything that doesn't match falls into the else when `redirect === false` so a click on the location link will reset to the categories root.
- Separated the condition into 2 if statements: one for `redirect` and one for `navigation.canGoBack()`. this way it wont do navigation.replace if it uses externalUrl.


### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Checklist

- [x] Followed the [contributing guidelines](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md) and [conventions](https://github.com/digitalfabrik/integreat-app/blob/main/docs/conventions.md)
- [x] Considered accessibility impacts and made the necessary adjustments
- [x] Added or updated unit tests (if applicable)
- [x] Added or updated documentation (if applicable)
- [x] Added a [release note](https://github.com/digitalfabrik/integreat-app/tree/main/release-notes) for native (if [applicable](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes))

### Testing

1. Go to Testumgebung, EN
2. Select a tile with place content e.g Social Life (switch to cms to see Social Life).
3. Click on the place (link).
4. Close the overlay using "X" button

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4214

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
