### PR TITLE
4228: Fix opening push notifications

### DIFF
--- a/native/src/utils/PushNotificationsManager.ts
+++ b/native/src/utils/PushNotificationsManager.ts
@@ -24,7 +24,7 @@ type UpdateSettingsType = (settings: { allowPushNotifications: boolean }) => voi
 type Message = FirebaseMessagingTypes.RemoteMessage & {
   notification: { title: string }
   data: {
-    region_code: string
+    city_code: string
     language_code: string
     news_id: string
   }
@@ -106,7 +106,7 @@ const displayNotification = async (message: Message): Promise<void> => {
 }
 
 const routeInformationFromMessage = (message: Message): NonNullableRouteInformationType => ({
-  regionCode: message.data.region_code,
+  regionCode: message.data.city_code,
   languageCode: message.data.language_code,
   route: NEWS_ROUTE,
   newsType: LOCAL_NEWS_TYPE,

--- a/native/src/utils/__tests__/PushNotificationsManager.spec.tsx
+++ b/native/src/utils/__tests__/PushNotificationsManager.spec.tsx
@@ -114,7 +114,7 @@ describe('PushNotificationsManager', () => {
     const message: FirebaseMessagingTypes.RemoteMessage = {
       notification: { title: 'Test PN', body: 'Test Body' },
       data: {
-        region_code: 'augsburg',
+        city_code: 'augsburg',
         language_code: 'de',
         news_id: '123',
         group: 'news',
@@ -134,7 +134,7 @@ describe('PushNotificationsManager', () => {
           title: 'Test PN',
           body: 'Test Body',
           data: {
-            region_code: 'augsburg',
+            city_code: 'augsburg',
             language_code: 'de',
             news_id: '123',
             group: 'news',

--- a/release-notes/unreleased/4228-push-notifications.yml
+++ b/release-notes/unreleased/4228-push-notifications.yml
@@ -1,0 +1,7 @@
+issue_key: 4228
+show_in_stores: true
+platforms:
+  - android
+  - ios
+en: Fix opening push notifications
+de: Push Nachrichten werden nun wieder korrekt geöffnet


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
<!-- Make sure to correctly set PR labels if necessary: `Native`/`Web` for native/web only PRs and `maintenance` for non-user-facing changes. -->
Fix opening push notifications.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Fix getting the region code from the message

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Checklist

- [x] Followed the [contributing guidelines](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md) and [conventions](https://github.com/digitalfabrik/integreat-app/blob/main/docs/conventions.md)
- [ ] Considered accessibility impacts and made the necessary adjustments
- [ ] Added or updated unit tests (if applicable)
- [ ] Added or updated documentation (if applicable)
- [x] Added a [release note](https://github.com/digitalfabrik/integreat-app/tree/main/release-notes) for native (if [applicable](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes))

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Send a push notification in the testumgebung and press on it.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4228

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
