### PR TITLE
4225: Fix endless loop in PlaceFiltersModal

### DIFF
--- a/native/src/components/PlaceFiltersModal.tsx
+++ b/native/src/components/PlaceFiltersModal.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import React, { ReactElement, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Button } from 'react-native-paper'
 import { SafeAreaView } from 'react-native-safe-area-context'
@@ -56,30 +56,34 @@ const StyledSvgUri = styled(SvgUri)<{ active: boolean }>`
   }};
 `
 
-type PlaceFiltersModalProps = {
-  modalVisible: boolean
-  closeModal: () => void
-  placeCategories: PlaceCategoryModel[]
-  selectedPlaceCategory: PlaceCategoryModel | undefined
-  setSelectedPlaceCategory: (placeCategory: PlaceCategoryModel | null) => void
+export type PlaceFilters = {
+  placeCategoryFilter: PlaceCategoryModel | undefined
   currentlyOpenFilter: boolean
-  setCurrentlyOpenFilter: (currentlyOpen: boolean) => void
-  placesCount: number
+}
+
+type PlaceFiltersModalProps = PlaceFilters & {
+  closeModal: (filters: PlaceFilters) => void
+  placeCategories: PlaceCategoryModel[]
+  getPlacesCount: (filters: PlaceFilters) => number
 }
 
 const PlaceFiltersModal = ({
-  modalVisible,
   closeModal,
   placeCategories,
-  selectedPlaceCategory,
-  setSelectedPlaceCategory,
+  placeCategoryFilter,
   currentlyOpenFilter,
-  setCurrentlyOpenFilter,
-  placesCount,
+  getPlacesCount,
 }: PlaceFiltersModalProps): ReactElement => {
+  const [tempPlaceCategory, setTempPlaceCategory] = useState(placeCategoryFilter)
+  const [tempCurrentlyOpen, setTempCurrentlyOpen] = useState(currentlyOpenFilter)
   const { t } = useTranslation('places')
+
+  const filters = { placeCategoryFilter: tempPlaceCategory, currentlyOpenFilter: tempCurrentlyOpen }
+  const close = () => closeModal(filters)
+  const placesCount = getPlacesCount(filters)
+
   return (
-    <Modal modalVisible={modalVisible} closeModal={closeModal} headerTitle='' title={t('adjustFilters')}>
+    <Modal closeModal={close} headerTitle='' title={t('adjustFilters')} modalVisible>
       <Container>
         <Section>
           <Row>
@@ -97,11 +101,7 @@ const PlaceFiltersModal = ({
             </Text>
             <FlexEnd>
               {/* key is a workaround for iOS 26 where the Switch animation does not update on first click */}
-              <Switch
-                key={`${currentlyOpenFilter}`}
-                onValueChange={setCurrentlyOpenFilter}
-                value={currentlyOpenFilter}
-              />
+              <Switch key={`${currentlyOpenFilter}`} onValueChange={setTempCurrentlyOpen} value={tempCurrentlyOpen} />
             </FlexEnd>
           </StyledRow>
         </Section>
@@ -122,15 +122,15 @@ const PlaceFiltersModal = ({
               <StyledToggleButton
                 key={it.id}
                 text={it.name}
-                active={it.id === selectedPlaceCategory?.id}
-                onPress={() => setSelectedPlaceCategory(it.id === selectedPlaceCategory?.id ? null : it)}
-                icon={<StyledSvgUri uri={it.icon} active={it.id === selectedPlaceCategory?.id} />}
+                active={it.id === tempPlaceCategory?.id}
+                onPress={() => setTempPlaceCategory(it.id === tempPlaceCategory?.id ? undefined : it)}
+                icon={<StyledSvgUri uri={it.icon} active={it.id === tempPlaceCategory?.id} />}
               />
             ))}
           </TileRow>
         </Section>
         <Section style={{ marginBottom: 8 }}>
-          <Button onPress={closeModal} mode='contained' disabled={placesCount === 0}>
+          <Button onPress={close} mode='contained' disabled={placesCount === 0}>
             {t('showPlaces', { count: placesCount })}
           </Button>
         </Section>

--- a/native/src/components/ThemeContainer.tsx
+++ b/native/src/components/ThemeContainer.tsx
@@ -25,7 +25,7 @@ export const theme = (themeType: 'light' | 'contrast'): DefaultTheme => {
       tertiaryContainer: palette.tertiary.light,
       surface: palette.background.default,
       surfaceVariant: palette.background.accent,
-      surfaceDisabled: palette.background.default,
+      surfaceDisabled: palette.action.disabledBackground,
       background: palette.background.default,
       error: palette.error.main,
       errorContainer: palette.error.light,

--- a/native/src/components/__tests__/PlaceFiltersModal.spec.tsx
+++ b/native/src/components/__tests__/PlaceFiltersModal.spec.tsx
@@ -11,63 +11,94 @@ jest.mock('react-i18next')
 jest.mock('react-native-svg')
 
 describe('PlaceFiltersModal', () => {
-  beforeEach(jest.clearAllMocks)
-
   const placeCategories = new PlaceModelBuilder(2).build().map(it => it.category)
+  const firstCategory = placeCategories[0]!
+  const secondCategory = placeCategories[1]!
 
   const closeModal = jest.fn()
-  const setSelectedPlaceCategory = jest.fn()
-  const setCurrentlyOpenFilter = jest.fn()
+  const getPlacesCount = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    getPlacesCount.mockReturnValue(1)
+  })
 
   const renderPlaceFiltersModal = ({
-    category = undefined,
-    currentlyOpen = false,
-    placesCount = 0,
+    placeCategoryFilter = undefined,
+    currentlyOpenFilter = false,
   }: {
-    category?: PlaceCategoryModel | undefined
-    currentlyOpen?: boolean
-    placesCount?: number
-  }) =>
+    placeCategoryFilter?: PlaceCategoryModel
+    currentlyOpenFilter?: boolean
+  } = {}) =>
     render(
       <PlaceFiltersModal
-        modalVisible
         closeModal={closeModal}
         placeCategories={placeCategories}
-        selectedPlaceCategory={category}
-        setSelectedPlaceCategory={setSelectedPlaceCategory}
-        currentlyOpenFilter={currentlyOpen}
-        setCurrentlyOpenFilter={setCurrentlyOpenFilter}
-        placesCount={placesCount}
+        placeCategoryFilter={placeCategoryFilter}
+        currentlyOpenFilter={currentlyOpenFilter}
+        getPlacesCount={getPlacesCount}
       />,
     )
 
-  it('should set place category on press', () => {
-    const { getByText } = renderPlaceFiltersModal({})
+  it('should not propagate filter changes until the modal is closed', () => {
+    const { getByText } = renderPlaceFiltersModal()
 
-    fireEvent.press(getByText(placeCategories[0]!.name))
-    expect(setSelectedPlaceCategory).toHaveBeenCalledTimes(1)
-    expect(setSelectedPlaceCategory).toHaveBeenCalledWith(placeCategories[0]!)
+    fireEvent.press(getByText(firstCategory.name))
+    fireEvent.press(getByText(secondCategory.name))
+
+    expect(closeModal).not.toHaveBeenCalled()
   })
 
-  it('should deselect place category on selected place category press', () => {
-    const { getByText } = renderPlaceFiltersModal({ category: placeCategories[0]! })
+  it('should close the modal with the selected category', () => {
+    const { getByText } = renderPlaceFiltersModal()
 
-    fireEvent.press(getByText(placeCategories[0]!.name))
-    expect(setSelectedPlaceCategory).toHaveBeenCalledTimes(1)
-    expect(setSelectedPlaceCategory).toHaveBeenCalledWith(null)
-  })
-
-  it('should close modal on button press', () => {
-    const { getByText } = renderPlaceFiltersModal({ placesCount: 1 })
-
+    fireEvent.press(getByText(firstCategory.name))
     fireEvent.press(getByText('showPlaces'))
+
     expect(closeModal).toHaveBeenCalledTimes(1)
+    expect(closeModal).toHaveBeenCalledWith({ placeCategoryFilter: firstCategory, currentlyOpenFilter: false })
   })
 
-  it('should not close modal on button press', () => {
-    const { getByText } = renderPlaceFiltersModal({ placesCount: 0 })
+  it('should deselect the initially selected category', () => {
+    const { getByText } = renderPlaceFiltersModal({ placeCategoryFilter: firstCategory })
+
+    fireEvent.press(getByText(firstCategory.name))
+    fireEvent.press(getByText('showPlaces'))
+
+    expect(closeModal).toHaveBeenCalledWith({ placeCategoryFilter: undefined, currentlyOpenFilter: false })
+  })
+
+  it('should switch to a different category when another one is pressed', () => {
+    const { getByText } = renderPlaceFiltersModal({ placeCategoryFilter: firstCategory })
+
+    fireEvent.press(getByText(secondCategory.name))
+    fireEvent.press(getByText('showPlaces'))
+
+    expect(closeModal).toHaveBeenCalledWith({ placeCategoryFilter: secondCategory, currentlyOpenFilter: false })
+  })
+
+  it('should pass the initial filters back unchanged when nothing is pressed', () => {
+    const { getByText } = renderPlaceFiltersModal({ placeCategoryFilter: firstCategory, currentlyOpenFilter: true })
 
     fireEvent.press(getByText('showPlaces'))
-    expect(closeModal).not.toHaveBeenCalledTimes(1)
+
+    expect(closeModal).toHaveBeenCalledWith({ placeCategoryFilter: firstCategory, currentlyOpenFilter: true })
+  })
+
+  it('should query the places count with the temporary filter selection', () => {
+    const { getByText } = renderPlaceFiltersModal()
+
+    fireEvent.press(getByText(firstCategory.name))
+
+    expect(getPlacesCount).toHaveBeenLastCalledWith({ placeCategoryFilter: firstCategory, currentlyOpenFilter: false })
+  })
+
+  it('should not close the modal when there are no matching places', () => {
+    getPlacesCount.mockReturnValue(0)
+    const { getByText } = renderPlaceFiltersModal()
+
+    fireEvent.press(getByText('showPlaces'))
+
+    expect(closeModal).not.toHaveBeenCalled()
   })
 })

--- a/native/src/routes/Places.tsx
+++ b/native/src/routes/Places.tsx
@@ -10,7 +10,7 @@ import { PlaceCategoryModel, PlaceModel, RegionModel } from 'shared/api'
 
 import { EditLocationIcon } from '../assets'
 import MapView from '../components/MapView'
-import PlaceFiltersModal from '../components/PlaceFiltersModal'
+import PlaceFiltersModal, { PlaceFilters } from '../components/PlaceFiltersModal'
 import PlacesBottomSheet from '../components/PlacesBottomSheet'
 import Icon from '../components/base/Icon'
 import Text from '../components/base/Text'
@@ -73,6 +73,12 @@ const Places = ({ refresh, localHistory, initialZoom, places: allPlaces, regionM
     params: { slug, multiPlace, placeCategoryId, currentlyOpen },
   })
 
+  const getPlacesCount = ({ placeCategoryFilter, currentlyOpenFilter }: PlaceFilters) =>
+    preparePlaces({
+      places: allPlaces,
+      params: { slug, multiPlace, placeCategoryId: placeCategoryFilter?.id, currentlyOpen: currentlyOpenFilter },
+    }).places.length
+
   const handleZoomInRef = useCallback((view: View | null) => {
     setZoomInFocusTarget(findNodeHandle(view) ?? undefined)
   }, [])
@@ -82,10 +88,10 @@ const Places = ({ refresh, localHistory, initialZoom, places: allPlaces, regionM
   const updateShowFilterSelection = (showFilterSelection: boolean) => localHistory.push({ showFilterSelection })
 
   const updatePlaceCategoryFilter = (placeCategory: PlaceCategoryModel | null) =>
-    localHistory.pushReset({ placeCategoryId: placeCategory?.id, currentlyOpen, showFilterSelection })
+    localHistory.pushReset({ placeCategoryId: placeCategory?.id, currentlyOpen })
 
   const updatePlaceCurrentlyOpenFilter = (currentlyOpen: boolean) =>
-    localHistory.pushReset({ placeCategoryId, currentlyOpen, showFilterSelection })
+    localHistory.pushReset({ placeCategoryId, currentlyOpen })
 
   const selectMapFeature = (mapFeature: MapFeature | null) => {
     setBottomSheetSnapPointIndex(1)
@@ -96,6 +102,11 @@ const Places = ({ refresh, localHistory, initialZoom, places: allPlaces, regionM
     } else if (slug || localHistory.current.slug) {
       localHistory.push({ multiPlace: undefined, slug })
     }
+  }
+
+  const closeModal = ({ placeCategoryFilter, currentlyOpenFilter }: PlaceFilters) => {
+    localHistory.pop()
+    localHistory.pushReset({ placeCategoryId: placeCategoryFilter?.id, currentlyOpen: currentlyOpenFilter })
   }
 
   const selectPlace = (place: PlaceModel) => localHistory.push({ slug: place.slug })
@@ -138,16 +149,15 @@ const Places = ({ refresh, localHistory, initialZoom, places: allPlaces, regionM
 
   return (
     <Container>
-      <PlaceFiltersModal
-        modalVisible={showFilterSelection}
-        closeModal={() => updateShowFilterSelection(false)}
-        placeCategories={placeCategories}
-        selectedPlaceCategory={placeCategory}
-        setSelectedPlaceCategory={updatePlaceCategoryFilter}
-        currentlyOpenFilter={currentlyOpen}
-        setCurrentlyOpenFilter={updatePlaceCurrentlyOpenFilter}
-        placesCount={places.length}
-      />
+      {showFilterSelection && (
+        <PlaceFiltersModal
+          closeModal={closeModal}
+          placeCategories={placeCategories}
+          placeCategoryFilter={placeCategory}
+          currentlyOpenFilter={currentlyOpen}
+          getPlacesCount={getPlacesCount}
+        />
+      )}
       <MapView
         selectFeature={selectMapFeature}
         boundingBox={regionModel.boundingBox}

--- a/native/src/routes/__tests__/Places.spec.tsx
+++ b/native/src/routes/__tests__/Places.spec.tsx
@@ -165,23 +165,42 @@ describe('Places', () => {
     expect(localHistory.push).toHaveBeenCalledWith({ showFilterSelection: true })
   })
 
-  it('should call push to hide the filter modal when showPlaces is pressed', () => {
-    const { localHistory, getByText } = renderPlaces({ ...resetHistory, showFilterSelection: true })
-
-    fireEvent.press(getByText('showPlaces'))
-
-    expect(localHistory.push).toHaveBeenCalledWith({ showFilterSelection: false })
-  })
-
-  it('should call pushReset with category id when a category is selected in filter modal', () => {
+  it('should not push to history when a category is selected inside the filter modal', () => {
     const { localHistory, getByRole } = renderPlaces({ ...resetHistory, showFilterSelection: true })
 
     fireEvent.press(getByRole('switch', { name: 'Dienstleistung' }))
 
+    expect(localHistory.push).not.toHaveBeenCalled()
+    expect(localHistory.pushReset).not.toHaveBeenCalled()
+  })
+
+  it('should pop the filter modal entry before pushReset when showPlaces is pressed', () => {
+    const { localHistory, getByText } = renderPlaces({ ...resetHistory, showFilterSelection: true })
+
+    fireEvent.press(getByText('showPlaces'))
+
+    expect(localHistory.pop).toHaveBeenCalledTimes(1)
+    expect(localHistory.pushReset).toHaveBeenCalledTimes(1)
+    expect(localHistory.pushReset).toHaveBeenCalledWith({
+      placeCategoryId: undefined,
+      currentlyOpen: false,
+    })
+    const popOrder = (localHistory.pop as jest.Mock).mock.invocationCallOrder[0]!
+    const pushResetOrder = (localHistory.pushReset as jest.Mock).mock.invocationCallOrder[0]!
+    expect(popOrder).toBeLessThan(pushResetOrder)
+  })
+
+  it('should apply the newly selected category when showPlaces is pressed', () => {
+    const { localHistory, getByRole, getByText } = renderPlaces({ ...resetHistory, showFilterSelection: true })
+
+    fireEvent.press(getByRole('switch', { name: 'Dienstleistung' }))
+    fireEvent.press(getByText('showPlaces'))
+
+    expect(localHistory.pop).toHaveBeenCalledTimes(1)
+    expect(localHistory.pushReset).toHaveBeenCalledTimes(1)
     expect(localHistory.pushReset).toHaveBeenCalledWith({
       placeCategoryId: place1.category.id,
       currentlyOpen: false,
-      showFilterSelection: true,
     })
   })
 
@@ -193,7 +212,65 @@ describe('Places', () => {
     expect(localHistory.pushReset).toHaveBeenCalledWith({
       placeCategoryId: undefined,
       currentlyOpen: false,
-      showFilterSelection: false,
+    })
+  })
+
+  it('should call pushReset to clear currentlyOpen when currentlyOpen chip is pressed', () => {
+    const { localHistory, getByText } = renderPlaces({ ...resetHistory, currentlyOpen: true })
+
+    fireEvent.press(getByText('opened'))
+
+    expect(localHistory.pushReset).toHaveBeenCalledWith({
+      placeCategoryId: undefined,
+      currentlyOpen: false,
+    })
+  })
+
+  it('should open the filter modal with the current filter values after clearing via the chip', () => {
+    const renderAt = (current: PlaceHistory) => {
+      const localHistory = createLocalHistory(current)
+      return {
+        localHistory,
+        element: (
+          <TestingAppContext>
+            <Places
+              refresh={() => undefined}
+              localHistory={localHistory}
+              places={places}
+              regionModel={region}
+              initialZoom={undefined}
+            />
+          </TestingAppContext>
+        ),
+      }
+    }
+
+    const initial = renderAt({ ...resetHistory, showFilterSelection: true })
+    const { getByRole, getByText, getAllByText, rerender } = renderWithTheme(initial.element)
+
+    fireEvent.press(getByRole('switch', { name: 'Gastronomie' }))
+    fireEvent.press(getByText('showPlaces'))
+    expect(initial.localHistory.pushReset).toHaveBeenLastCalledWith({
+      placeCategoryId: place0.category.id,
+      currentlyOpen: false,
+    })
+
+    const filtered = renderAt({ ...resetHistory, placeCategoryId: place0.category.id })
+    rerender(filtered.element)
+
+    fireEvent.press(getAllByText('Gastronomie')[0]!)
+    expect(filtered.localHistory.pushReset).toHaveBeenLastCalledWith({
+      placeCategoryId: undefined,
+      currentlyOpen: false,
+    })
+
+    const reopened = renderAt({ ...resetHistory, showFilterSelection: true })
+    rerender(reopened.element)
+
+    fireEvent.press(getByText('showPlaces'))
+    expect(reopened.localHistory.pushReset).toHaveBeenLastCalledWith({
+      placeCategoryId: undefined,
+      currentlyOpen: false,
     })
   })
 })


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
<!-- Make sure to correctly set PR labels if necessary: `Native`/`Web` for native/web only PRs and `maintenance` for non-user-facing changes. -->
Fix endless loop with navigating back after opening the place filter modal.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Add temporary state for the filter modal and only update the filters when the modal is closed
- Use the correct disabled background color

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Checklist

- [x] Followed the [contributing guidelines](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md) and [conventions](https://github.com/digitalfabrik/integreat-app/blob/main/docs/conventions.md)
- [ ] Considered accessibility impacts and made the necessary adjustments
- [x] Added or updated unit tests (if applicable)
- [ ] Added or updated documentation (if applicable)
- [ ] Added a [release note](https://github.com/digitalfabrik/integreat-app/tree/main/release-notes) for native (if [applicable](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes))

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
See issue.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4225

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
