### PR TITLE
Prevent commit and commit_main workflows for api triggers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -949,9 +949,16 @@ workflows:
         jobs:
             - check
         unless:
-            equal:
-                - main
-                - << pipeline.git.branch >>
+            or:
+                - equal:
+                    - << pipeline.git.branch >>
+                    - main
+                - equal:
+                    - << pipeline.trigger.type >>
+                    - api
+                - equal:
+                    - << pipeline.trigger.type >>
+                    - schedule
     commit_main:
         jobs:
             - bump_version:
@@ -971,9 +978,18 @@ workflows:
                 requires:
                     - build_web
         when:
-            equal:
-                - main
-                - << pipeline.git.branch >>
+            and:
+                - equal:
+                    - << pipeline.git.branch >>
+                    - main
+                - not:
+                    or:
+                        - equal:
+                            - << pipeline.trigger.type >>
+                            - api
+                        - equal:
+                            - << pipeline.trigger.type >>
+                            - schedule
     delivery:
         jobs:
             - bump_version:

--- a/.circleci/src/workflows/commit.yml
+++ b/.circleci/src/workflows/commit.yml
@@ -1,4 +1,7 @@
 unless:
-  equal: [main, << pipeline.git.branch >>]
+  or:
+    - equal: [<< pipeline.git.branch >>, main]
+    - equal: [<< pipeline.trigger.type >>, api]
+    - equal: [<< pipeline.trigger.type >>, schedule]
 jobs:
   - check

--- a/.circleci/src/workflows/commit_main.yml
+++ b/.circleci/src/workflows/commit_main.yml
@@ -1,5 +1,10 @@
 when:
-  equal: [main, << pipeline.git.branch >>]
+  and:
+    - equal: [<< pipeline.git.branch >>, main]
+    - not:
+        or:
+          - equal: [<< pipeline.trigger.type >>, api]
+          - equal: [<< pipeline.trigger.type >>, schedule]
 jobs:
   - bump_version:
       prepare_delivery: false


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
<!-- Make sure to correctly set PR labels if necessary: `Native`/`Web` for native/web only PRs and `maintenance` for non-user-facing changes. -->
When triggering a workflow from the CI (e.g. `delivery`, `promotion` or `e2e_tests`), the `commit` or `commit_main` (depending on the branch) workflows are always run as well. Disable that by checking for `schedule` or `api` on `pipeline.trigger.type` ([docs](https://circleci.com/docs/guides/orchestrate/pipeline-variables/#trigger-and-event-information)).

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Disable `commit` and `commit_main` pipelines for `api` and `schedule` triggers

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Checklist

- [x] Followed the [contributing guidelines](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md) and [conventions](https://github.com/digitalfabrik/integreat-app/blob/main/docs/conventions.md)
- [ ] Considered accessibility impacts and made the necessary adjustments
- [ ] Added or updated unit tests (if applicable)
- [ ] Added or updated documentation (if applicable)
- [ ] Added a [release note](https://github.com/digitalfabrik/integreat-app/tree/main/release-notes) for native (if [applicable](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes))

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
N/A

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: N/A

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
