### PR TITLE
4234: [iOS] Use onSurfaceVariant for the iOS switch off-track so on/off is distinguishable

### DIFF
--- a/native/src/components/base/Switch.tsx
+++ b/native/src/components/base/Switch.tsx
@@ -4,8 +4,9 @@ import { useTheme } from 'styled-components/native'
 
 const Switch = (props: SwitchProps): ReactElement => {
   const theme = useTheme()
-  // The ios_backgroundColor prop is used to set the background under the handle to improve contrast on iOS.
-  return <RNSwitch ios_backgroundColor={theme.colors.outline} {...props} />
+  // ios_backgroundColor sets the OFF-state track color on iOS. outline rendered too subtle to tell
+  // an off switch from an on one, so use onSurfaceVariant, a clearly visible gray.
+  return <RNSwitch ios_backgroundColor={theme.colors.onSurfaceVariant} {...props} />
 }
 
 export default Switch

--- a/native/src/components/base/Switch.tsx
+++ b/native/src/components/base/Switch.tsx
@@ -4,8 +4,6 @@ import { useTheme } from 'styled-components/native'
 
 const Switch = (props: SwitchProps): ReactElement => {
   const theme = useTheme()
-  // ios_backgroundColor sets the OFF-state track color on iOS. outline rendered too subtle to tell
-  // an off switch from an on one, so use onSurfaceVariant, a clearly visible gray.
   return <RNSwitch ios_backgroundColor={theme.colors.onSurfaceVariant} {...props} />
 }
 


### PR DESCRIPTION
### Short Description

On iOS a toggle switch in its OFF state was hard to tell apart from an ON one. This swaps the OFF-track color for a clearly visible gray. (Native, accessibility.)

### Proposed Changes

- The iOS switch used `theme.colors.outline` for `ios_backgroundColor` (the OFF-state track), which rendered too subtle to distinguish an off switch from an on one (see the screenshot in #4234).
- Use `theme.colors.onSurfaceVariant`, a clearly visible gray, for the OFF-state track instead. It is a one-line change, and the exact MD3 role is easy to adjust in review if you prefer a different shade.

### Side Effects

Only the iOS `Switch` OFF-state track color changes. Android and the ON state are untouched.

### Checklist

- [ ] Followed the [contributing guidelines](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md) and [conventions](https://github.com/digitalfabrik/integreat-app/blob/main/docs/conventions.md)
- [x] Considered accessibility impacts and made the necessary adjustments
- [ ] Added or updated unit tests (if applicable)
- [ ] Added or updated documentation (if applicable)
- [ ] Added a [release note](https://github.com/digitalfabrik/integreat-app/tree/main/release-notes) for native (if applicable)

### Testing

- On iOS, open a screen with a toggle (for example Settings) and confirm an OFF switch is now clearly distinguishable from an ON one.

### Resolved Issues

Fixes: #4234
