### PR TITLE
4232: Prevent web-only releases from being set as latest release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -782,7 +782,11 @@ jobs:
             - restore_yarn_tools_cache
             - run:
                 command: |
-                    RELEASE=$(npx --no app-toolbelt v0 release promote --platform << parameters.platform >> --private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME})
+                    NO_SET_LATEST=""
+                    if [ "<< parameters.platform >>" = "web" ]; then
+                      NO_SET_LATEST="--no-set-latest"
+                    fi
+                    RELEASE=$(npx --no app-toolbelt v0 release promote --platform << parameters.platform >> --private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME} ${NO_SET_LATEST})
                     echo "export RELEASE='${RELEASE}'" >> $BASH_ENV
                 name: Remove prerelease flag from github release
                 working_directory: tools
@@ -813,7 +817,11 @@ jobs:
             - generate_sbom
             - run:
                 command: |
-                    RELEASE=$(npx --no app-toolbelt v0 release create << parameters.platform >> ${NEW_VERSION_NAME} ${NEW_VERSION_CODE} --private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME} <<# parameters.production_delivery >>--production-release<</ parameters.production_delivery >>)
+                    NO_SET_LATEST=""
+                    if [ "<< parameters.platform >>" = "web" ]; then
+                      NO_SET_LATEST="--no-set-latest"
+                    fi
+                    RELEASE=$(npx --no app-toolbelt v0 release create << parameters.platform >> ${NEW_VERSION_NAME} ${NEW_VERSION_CODE} --private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME} <<# parameters.production_delivery >>--production-release ${NO_SET_LATEST}<</ parameters.production_delivery >>)
                     echo "export RELEASE_ID=$(echo ${RELEASE} | jq .id)" >> ${BASH_ENV}
                     echo "export RELEASE_NOTES=$(echo ${RELEASE} | jq .releaseNotes)" >> ${BASH_ENV}
                 name: Create github release

--- a/.circleci/src/jobs/notify_promotion.yml
+++ b/.circleci/src/jobs/notify_promotion.yml
@@ -12,7 +12,11 @@ steps:
   - run:
       name: Remove prerelease flag from github release
       command: |
-        RELEASE=$(npx --no app-toolbelt v0 release promote --platform << parameters.platform >> --private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME})
+        NO_SET_LATEST=""
+        if [ "<< parameters.platform >>" = "web" ]; then
+          NO_SET_LATEST="--no-set-latest"
+        fi
+        RELEASE=$(npx --no app-toolbelt v0 release promote --platform << parameters.platform >> --private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME} ${NO_SET_LATEST})
         echo "export RELEASE='${RELEASE}'" >> $BASH_ENV
       working_directory: tools
   - notify:

--- a/.circleci/src/jobs/notify_release.yml
+++ b/.circleci/src/jobs/notify_release.yml
@@ -18,7 +18,11 @@ steps:
   - run:
       name: Create github release
       command: |
-        RELEASE=$(npx --no app-toolbelt v0 release create << parameters.platform >> ${NEW_VERSION_NAME} ${NEW_VERSION_CODE} --private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME} <<# parameters.production_delivery >>--production-release<</ parameters.production_delivery >>)
+        NO_SET_LATEST=""
+        if [ "<< parameters.platform >>" = "web" ]; then
+          NO_SET_LATEST="--no-set-latest"
+        fi
+        RELEASE=$(npx --no app-toolbelt v0 release create << parameters.platform >> ${NEW_VERSION_NAME} ${NEW_VERSION_CODE} --private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME} <<# parameters.production_delivery >>--production-release ${NO_SET_LATEST}<</ parameters.production_delivery >>)
         echo "export RELEASE_ID=$(echo ${RELEASE} | jq .id)" >> ${BASH_ENV}
         echo "export RELEASE_NOTES=$(echo ${RELEASE} | jq .releaseNotes)" >> ${BASH_ENV}
       working_directory: tools

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,7 +2,7 @@ approvedGitRepositories:
   - '**'
 
 catalog:
-  app-toolbelt: 'github:digitalfabrik/app-toolbelt#semver:1.1.0'
+  app-toolbelt: 'github:digitalfabrik/app-toolbelt#semver:1.2.0'
 
 enableScripts: true
 

--- a/tools/yarn.lock
+++ b/tools/yarn.lock
@@ -592,9 +592,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"app-toolbelt@github:digitalfabrik/app-toolbelt#semver:1.1.0":
-  version: 0.10.0
-  resolution: "app-toolbelt@https://github.com/digitalfabrik/app-toolbelt.git#commit=5f187615098119059206f36508b2944e66ba838a"
+"app-toolbelt@github:digitalfabrik/app-toolbelt#semver:1.2.0":
+  version: 1.2.0
+  resolution: "app-toolbelt@https://github.com/digitalfabrik/app-toolbelt.git#commit=2c09f8ff01b7ef1ef5739e904f822899190dc3c7"
   dependencies:
     "@expo/plist": "npm:^0.5.2"
     "@octokit/auth-app": "npm:^8.2.0"
@@ -614,7 +614,7 @@ __metadata:
     typescript: "npm:^6.0.3"
   bin:
     app-toolbelt: bin/app-toolbelt
-  checksum: 10c0/8b7af4dd0bbf35ee594d9baf01b026d1989d6ad8646361d20b5214f73cfcef68ad09111b3ecd063a90a017a539cc70b772639649f9a670bb54383e3f41d15c39
+  checksum: 10c0/fc5c56fefa1f48b834be65d47f3b4a60342f5a352aead19e0d947ba8f6c0a7ef6f090576645fa9986512bd10e21db3035d2117d863dad0adfbe28cd96a6f6b2a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8491,9 +8491,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"app-toolbelt@github:digitalfabrik/app-toolbelt#semver:1.1.0":
-  version: 0.10.0
-  resolution: "app-toolbelt@https://github.com/digitalfabrik/app-toolbelt.git#commit=5f187615098119059206f36508b2944e66ba838a"
+"app-toolbelt@github:digitalfabrik/app-toolbelt#semver:1.2.0":
+  version: 1.2.0
+  resolution: "app-toolbelt@https://github.com/digitalfabrik/app-toolbelt.git#commit=2c09f8ff01b7ef1ef5739e904f822899190dc3c7"
   dependencies:
     "@expo/plist": "npm:^0.5.2"
     "@octokit/auth-app": "npm:^8.2.0"
@@ -8513,7 +8513,7 @@ __metadata:
     typescript: "npm:^6.0.3"
   bin:
     app-toolbelt: bin/app-toolbelt
-  checksum: 10c0/8b7af4dd0bbf35ee594d9baf01b026d1989d6ad8646361d20b5214f73cfcef68ad09111b3ecd063a90a017a539cc70b772639649f9a670bb54383e3f41d15c39
+  checksum: 10c0/fc5c56fefa1f48b834be65d47f3b4a60342f5a352aead19e0d947ba8f6c0a7ef6f090576645fa9986512bd10e21db3035d2117d863dad0adfbe28cd96a6f6b2a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
<!-- Make sure to correctly set PR labels if necessary: `Native`/`Web` for native/web only PRs and `maintenance` for non-user-facing changes. -->
Prevent web-only releases from being set as latest release to keep the direct download link working.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Bump app-toolbelt to [v1.2.0](https://github.com/digitalfabrik/app-toolbelt/releases/tag/1.2.0)
- Set `--no-set-latest` flag for web only releases and promotions

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Checklist

- [x] Followed the [contributing guidelines](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md) and [conventions](https://github.com/digitalfabrik/integreat-app/blob/main/docs/conventions.md)
- [ ] Considered accessibility impacts and made the necessary adjustments
- [ ] Added or updated unit tests (if applicable)
- [ ] Added or updated documentation (if applicable)
- [ ] Added a [release note](https://github.com/digitalfabrik/integreat-app/tree/main/release-notes) for native (if [applicable](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes))

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
N/A

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4232

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
