### PR TITLE
4252: Fix nullable chat ids

### DIFF
--- a/web/src/components/ChatContainer.tsx
+++ b/web/src/components/ChatContainer.tsx
@@ -1,6 +1,6 @@
 import { dialogContentClasses } from '@mui/material/DialogContent'
 import { styled } from '@mui/material/styles'
-import React, { ReactElement, useContext, useEffect } from 'react'
+import React, { ReactElement, useContext, useEffect, useState } from 'react'
 import { useSearchParams } from 'react-router'
 
 import {
@@ -51,11 +51,20 @@ const ChatContainer = ({ region, languageCode, languageChangePaths }: ChatContai
   const isBrowserTabActive = useIsTabActive()
   useLockedBody(visible)
 
-  const [storageChatId, setChatId] = useLocalStorage<string>({
+  const [initialChatId] = useState<string>(uuid)
+  const [storageChatId, setChatId] = useLocalStorage<string | null>({
     key: chatIdKey(region.code),
-    initialValue: uuid(),
+    initialValue: initialChatId,
   })
-  const chatId = externalChatId ?? storageChatId
+
+  // We previously saved null as chat id for unstarted chats
+  // Therefore reinitialize with a correct chat id
+  useEffect(() => {
+    if (storageChatId === null) {
+      setChatId(initialChatId)
+    }
+  }, [storageChatId, setChatId, initialChatId])
+  const chatId = externalChatId ?? storageChatId ?? initialChatId
 
   const [unsyncedMessages, setUnsyncedMessages] = useLocalStorage<SerializedChatMessage[]>({
     key: CHAT_UNSYNCED_MESSAGES_STORAGE_KEY,

--- a/web/src/components/__tests__/ChatContainer.spec.tsx
+++ b/web/src/components/__tests__/ChatContainer.spec.tsx
@@ -8,7 +8,7 @@ import { ChatMessageModel, RegionModelBuilder } from 'shared/api'
 import { CHAT_PRIVACY_POLICIES_STORAGE_KEY } from '../../hooks/useLocalStorage'
 import { mockUseQueryFromEndpointWithData } from '../../testing/mockUseQueryFromEndpoint'
 import { renderRoute } from '../../testing/render'
-import { chatSeenMessagesKey } from '../../utils/chat'
+import { chatIdKey, chatSeenMessagesKey } from '../../utils/chat'
 import ChatContainer from '../ChatContainer'
 
 jest.mock('react-i18next', () => ({
@@ -17,6 +17,10 @@ jest.mock('react-i18next', () => ({
     t: (key: string) => (namespace ? `${namespace}:${key}` : key),
   }),
   Trans: ({ i18nKey }: { i18nKey: string }) => i18nKey,
+}))
+jest.mock('shared', () => ({
+  ...jest.requireActual('shared'),
+  uuid: jest.fn(() => '11111111-2222-3333-4444-555555555555'),
 }))
 jest.mock('../../hooks/useQueryFromEndpoint')
 
@@ -225,6 +229,17 @@ describe('ChatContainer', () => {
 
     expect(getByLabelText('layout:common:close')).toBeTruthy()
     expect(getByText(getChatName('IntegreatTestCms'))).toBeTruthy()
+  })
+
+  it('should reinitialize a null chat id previously written to local storage', () => {
+    localStorage.setItem(chatIdKey(region.code), 'null')
+
+    renderRoute(<ChatContainer region={region} languageCode='de' languageChangePaths={languageChangePaths} />, {
+      pathname,
+      routePattern,
+    })
+
+    expect(localStorage.getItem(chatIdKey(region.code))).toBe(JSON.stringify('11111111-2222-3333-4444-555555555555'))
   })
 
   it('should switch the language', () => {


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
<!-- Make sure to correctly set PR labels if necessary: `Native`/`Web` for native/web only PRs and `maintenance` for non-user-facing changes. -->
Reinitialize `null` chat ids to fix unrelated chats being displayed.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Update `null` chat ids with a new uuid

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Checklist

- [x] Followed the [contributing guidelines](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md) and [conventions](https://github.com/digitalfabrik/integreat-app/blob/main/docs/conventions.md)
- [ ] Considered accessibility impacts and made the necessary adjustments
- [ ] Added or updated unit tests (if applicable)
- [ ] Added or updated documentation (if applicable)
- [ ] Added a [release note](https://github.com/digitalfabrik/integreat-app/tree/main/release-notes) for native (if [applicable](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes))

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
See issue.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4252

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
