### PR TITLE
4266: Fix chat web view zoom in on ios

### DIFF
--- a/native/src/components/WebView.tsx
+++ b/native/src/components/WebView.tsx
@@ -136,6 +136,8 @@ const WebView = ({ source, onLoad, loading }: WebViewProps): ReactElement | null
       javaScriptEnabled
       dataDetectorTypes={DATA_DETECTOR_TYPES}
       userAgent={userAgent}
+      // Disable pinch to zoom-in in android
+      setBuiltInZoomControls={false}
       domStorageEnabled={isUriSource}
       allowsFullscreenVideo
       showsVerticalScrollIndicator={false}

--- a/native/src/utils/renderHtml.ts
+++ b/native/src/utils/renderHtml.ts
@@ -247,7 +247,7 @@ const renderHtml = (
   <html lang='${language}'>
   <head>
     <!-- disables zooming https://stackoverflow.com/questions/44625680/disable-zoom-on-web-view-react-native -->
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no' />
     <style>
       @font-face {
         font-family: 'Inter';

--- a/native/src/utils/renderHtml.ts
+++ b/native/src/utils/renderHtml.ts
@@ -247,7 +247,7 @@ const renderHtml = (
   <html lang='${language}'>
   <head>
     <!-- disables zooming https://stackoverflow.com/questions/44625680/disable-zoom-on-web-view-react-native -->
-    <meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no' />
+    <meta name='viewport' content='initial-scale=1.0, maximum-scale=1.0'>
     <style>
       @font-face {
         font-family: 'Inter';

--- a/native/src/utils/renderHtml.ts
+++ b/native/src/utils/renderHtml.ts
@@ -247,7 +247,7 @@ const renderHtml = (
   <html lang='${language}'>
   <head>
     <!-- disables zooming https://stackoverflow.com/questions/44625680/disable-zoom-on-web-view-react-native -->
-    <meta name='viewport' content='initial-scale=1.0, maximum-scale=1.0'>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <style>
       @font-face {
         font-family: 'Inter';

--- a/web/src/components/ChatInput.tsx
+++ b/web/src/components/ChatInput.tsx
@@ -21,7 +21,7 @@ import Link from './base/Link'
 const StyledTextField = styled(TextField, { shouldForwardProp: prop => prop !== 'expanded' })<{ expanded: boolean }>(
   ({ theme, expanded }) => ({
     [`& .${outlinedInputClasses.root}`]: {
-      ...theme.typography.body1,
+      ...theme.typography.body1, // should be set to 16px or above to avoid webview zoom-in in native ios
       borderRadius: 12,
       minHeight: 56,
       alignItems: 'flex-start',

--- a/web/src/components/ChatInput.tsx
+++ b/web/src/components/ChatInput.tsx
@@ -21,7 +21,7 @@ import Link from './base/Link'
 const StyledTextField = styled(TextField, { shouldForwardProp: prop => prop !== 'expanded' })<{ expanded: boolean }>(
   ({ theme, expanded }) => ({
     [`& .${outlinedInputClasses.root}`]: {
-      ...theme.typography.body2,
+      ...theme.typography.body1,
       borderRadius: 12,
       minHeight: 56,
       alignItems: 'flex-start',

--- a/web/src/components/ChatInput.tsx
+++ b/web/src/components/ChatInput.tsx
@@ -21,7 +21,10 @@ import Link from './base/Link'
 const StyledTextField = styled(TextField, { shouldForwardProp: prop => prop !== 'expanded' })<{ expanded: boolean }>(
   ({ theme, expanded }) => ({
     [`& .${outlinedInputClasses.root}`]: {
-      ...theme.typography.body1, // should be set to 16px or above to avoid webview zoom-in in native ios
+      // Has to be set to 16px or above to avoid webview zoom-in in native ios on input focus
+      // https://github.com/digitalfabrik/integreat-app/issues/4266
+      // https://github.com/react-native-webview/react-native-webview/issues/3437
+      ...theme.typography.body1,
       borderRadius: 12,
       minHeight: 56,
       alignItems: 'flex-start',


### PR DESCRIPTION
### Short Description

This PR fixes zoom in of the web view when pressed on field input. Seems like iOS automatically zooms in on input field if the font size less than 16px. See the blog topic on this issue https://blog.stackademic.com/preventing-auto-zoom-on-ios-input-fields-best-practices-for-textarea-and-inputs-80bb4440febe

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Set the input field font size into 16px
- Disable pinch to zoom-in for ios by adjusing meta viewport and disable on android by adding prop

### Side Effects

Font size now a bit larger and it is not possible to pinch to zoom-in in webview

### Checklist

- [ ] Followed the [contributing guidelines](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md) and [conventions](https://github.com/digitalfabrik/integreat-app/blob/main/docs/conventions.md)
- [ ] Considered accessibility impacts and made the necessary adjustments
- [ ] Added or updated unit tests (if applicable)
- [ ] Added or updated documentation (if applicable)
- [ ] Added a [release note](https://github.com/digitalfabrik/integreat-app/tree/main/release-notes) for native (if [applicable](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes))

### Testing

- Start web and native on iOS 
- Set url in url.ts to your local network, for ex. `http://192.168.0.131:9001/`
- Go to Testumgebung
- Open the chat
- Press input field, also check the whole view by sending a question

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4266 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
