### PR TITLE
4272: Fix Chat's badge

### DIFF
--- a/native/src/components/ChatFab.tsx
+++ b/native/src/components/ChatFab.tsx
@@ -23,8 +23,8 @@ const Container = styled.View`
 
 const StyledBadge = styled(Badge)`
   position: absolute;
-  top: -8px;
   right: -8px;
+  bottom: 44px;
 `
 
 type ChatFabProps = {


### PR DESCRIPTION
### Short Description

The chat's number of messages badge is above the highlight popup on native.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Used bottom instead of top for `StyledBadge`.

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Checklist

- [X] Followed the [contributing guidelines](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md) and [conventions](https://github.com/digitalfabrik/integreat-app/blob/main/docs/conventions.md)
- [X] Considered accessibility impacts and made the necessary adjustments
- [X] Added or updated unit tests (if applicable)
- [X] Added or updated documentation (if applicable)
- [X] Added a [release note](https://github.com/digitalfabrik/integreat-app/tree/main/release-notes) for native (if [applicable](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes))

### Testing

- Launch integreat and go to Testumgebung on native.
- Don't close the highlight popup that is above the chat.
- open the chat and type anything and close the chat.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4272

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
