### PR TITLE
Fix chat popup dismissed naming

### DIFF
--- a/native/src/components/ChatHighlightPopup.tsx
+++ b/native/src/components/ChatHighlightPopup.tsx
@@ -63,7 +63,7 @@ const ChatHighlightPopup = ({ chatName }: ChatHighlightPopupProps): ReactElement
   const { t } = useTranslation('chat')
   const { settings, updateSettings } = useRegionAppContext()
 
-  if (settings.chatHighlightPopupVisible) {
+  if (settings.chatHighlightPopupDismissed) {
     return null
   }
 
@@ -77,7 +77,7 @@ const ChatHighlightPopup = ({ chatName }: ChatHighlightPopupProps): ReactElement
         <IconButton
           icon='close'
           size={16}
-          onPress={() => updateSettings({ chatHighlightPopupVisible: true })}
+          onPress={() => updateSettings({ chatHighlightPopupDismissed: true })}
           accessibilityLabel={t('common:close')}
         />
       </Header>

--- a/native/src/components/__tests__/ChatHighlightPopup.spec.tsx
+++ b/native/src/components/__tests__/ChatHighlightPopup.spec.tsx
@@ -23,7 +23,7 @@ describe('ChatHighlightPopup', () => {
 
   it('should not render popup when previously dismissed', () => {
     const { queryByText } = render(
-      <TestingAppContext settings={{ chatHighlightPopupVisible: true }}>
+      <TestingAppContext settings={{ chatHighlightPopupDismissed: true }}>
         <ChatHighlightPopup chatName={chatName} />
       </TestingAppContext>,
     )
@@ -42,6 +42,6 @@ describe('ChatHighlightPopup', () => {
 
     fireEvent.press(getByLabelText('common:close'))
 
-    expect(updateSettings).toHaveBeenCalledWith({ chatHighlightPopupVisible: true })
+    expect(updateSettings).toHaveBeenCalledWith({ chatHighlightPopupDismissed: true })
   })
 })

--- a/native/src/contexts/__tests__/AppContextProvider.spec.tsx
+++ b/native/src/contexts/__tests__/AppContextProvider.spec.tsx
@@ -97,7 +97,7 @@ describe('AppContextProvider', () => {
       externalSourcePermissions: { 'https://vimeo.com': true },
       selectedTheme: 'light',
       chat: {},
-      chatHighlightPopupVisible: false,
+      chatHighlightPopupDismissed: false,
     }
     await appSettings.setSettings(settings)
     const { getByText } = renderAppContextProvider({})

--- a/native/src/utils/AppSettings.ts
+++ b/native/src/utils/AppSettings.ts
@@ -24,7 +24,7 @@ export type SettingsType = {
   externalSourcePermissions: ExternalSourcePermissions
   selectedTheme: ThemeType
   chat: ChatSettings
-  chatHighlightPopupVisible: boolean
+  chatHighlightPopupDismissed: boolean
 }
 
 export const defaultSettings: SettingsType = {
@@ -38,7 +38,7 @@ export const defaultSettings: SettingsType = {
   externalSourcePermissions: {},
   selectedTheme: 'light',
   chat: {},
-  chatHighlightPopupVisible: false,
+  chatHighlightPopupDismissed: false,
 }
 
 export const settingsStorage = createAsyncStorage('settings')


### PR DESCRIPTION
### Short Description

Currently the naming for the chatHighlightPopup setting at `AppSettings.ts` is called `chatHighlightPopupVisible` and is semantically wrong because the default is set to false.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Just changed the naming for `chatHighlightPopupVisible` to `chatHighlightPopupDismissed`.

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Checklist

- [X] Followed the [contributing guidelines](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md) and [conventions](https://github.com/digitalfabrik/integreat-app/blob/main/docs/conventions.md)
- [X] Considered accessibility impacts and made the necessary adjustments
- [X] Added or updated unit tests (if applicable)
- [X] Added or updated documentation (if applicable)
- [X] Added a [release note](https://github.com/digitalfabrik/integreat-app/tree/main/release-notes) for native (if [applicable](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes))

### Testing

Test that the ChatHighlightPopup is working correctly on native.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
