### PR TITLE
4298: Keep filter chips visible on focus

### DIFF
--- a/web/src/components/ThemeContainer.tsx
+++ b/web/src/components/ThemeContainer.tsx
@@ -79,6 +79,9 @@ const createTheme = (themeType: ThemeType, contentDirection: UiDirectionType): O
                 ':hover': {
                   backgroundColor: theme.palette.background.default,
                 },
+                [`&.${chipClasses.focusVisible}`]: {
+                  backgroundColor: theme.palette.background.default,
+                },
               },
             },
           },

--- a/web/src/components/__tests__/ThemeContainer.spec.tsx
+++ b/web/src/components/__tests__/ThemeContainer.spec.tsx
@@ -1,3 +1,4 @@
+import Chip, { chipClasses } from '@mui/material/Chip'
 import { useTheme } from '@mui/material/styles'
 import { render } from '@testing-library/react'
 import React from 'react'
@@ -40,5 +41,18 @@ describe('ThemeContainer', () => {
     const { getByText } = renderThemeContainer()
 
     expect(getByText('contrast')).toBeInTheDocument()
+  })
+
+  it('should keep outlined chips visible on keyboard focus', () => {
+    const { getByRole } = render(
+      <ThemeContainer contentDirection='ltr'>
+        <Chip label='Filter locations' variant='outlined' clickable />
+      </ThemeContainer>,
+    )
+    const chip = getByRole('button', { name: 'Filter locations' })
+
+    chip.classList.add(chipClasses.focusVisible)
+
+    expect(getComputedStyle(chip).backgroundColor).toBe('rgb(255, 255, 255)')
   })
 })


### PR DESCRIPTION
### Short Description

Keep outlined location filter chips opaque when they receive keyboard focus.

### Proposed Changes

- Match the clickable chip focus-visible background to its hover background.
- Add a regression test for the computed outlined-chip focus style.

### Side Effects

All clickable outlined chips using the shared web theme receive the same visible focus background. The focus indicator and keyboard behavior remain unchanged.

### Checklist

- [x] Followed the contributing guidelines and conventions
- [x] Considered accessibility impacts and made the necessary adjustments
- [x] Added or updated unit tests
- [x] Documentation update is not applicable
- [x] Release note is not applicable because this is web-only

### Testing

Manual review:

1. Launch the Integreat web app and open the map/places view.
2. Optionally filter the places list so the location filter chips are reached with fewer Tab presses.
3. Use the keyboard to Tab to an outlined location filter chip.
4. Verify the focused chip keeps an opaque background matching its hover state instead of becoming transparent.
5. Verify the existing keyboard focus indicator remains visible and keyboard interaction still works.

Automated checks:

- `yarn prettier:check`
- `yarn lint --quiet`
- `yarn ts:check`
- `yarn test --runInBand`

### Resolved Issues

Fixes: #4298