### PR TITLE
4284: Adjust Chat Input Colors

### DIFF
--- a/build-configs/src/ThemeType.ts
+++ b/build-configs/src/ThemeType.ts
@@ -54,6 +54,8 @@ export type TypeChat = {
   answerMessageBackground: string
   userMessageBackground: string
   messageBorderColor: string
+  grayNeutral38: string
+  grayNeutral60: string
 }
 
 export type CommonColorPalette = CommonColors & {

--- a/build-configs/src/ThemeType.ts
+++ b/build-configs/src/ThemeType.ts
@@ -55,8 +55,8 @@ export type TypeChat = {
   answerMessageBackground: string
   userMessageBackground: string
   messageBorderColor: string
-  grayNeutral38: string
-  grayNeutral60: string
+  chatInputOutlineColor: string
+  chatInputPlaceholderColor: string
 }
 
 export type CommonColorPalette = CommonColors & {

--- a/build-configs/src/ThemeType.ts
+++ b/build-configs/src/ThemeType.ts
@@ -54,8 +54,8 @@ export type TypeChat = {
   answerMessageBackground: string
   userMessageBackground: string
   messageBorderColor: string
-  grayNeutral38: string
-  grayNeutral60: string
+  chatInputOutlineColor: string
+  chatInputPlaceholderColor: string
 }
 
 export type CommonColorPalette = CommonColors & {

--- a/build-configs/src/ThemeType.ts
+++ b/build-configs/src/ThemeType.ts
@@ -55,6 +55,8 @@ export type TypeChat = {
   answerMessageBackground: string
   userMessageBackground: string
   messageBorderColor: string
+  grayNeutral38: string
+  grayNeutral60: string
 }
 
 export type CommonColorPalette = CommonColors & {

--- a/build-configs/src/common/theme/colors.ts
+++ b/build-configs/src/common/theme/colors.ts
@@ -61,6 +61,8 @@ export const commonLightColors: CommonColorPalette = {
     answerMessageBackground: '#EAEEF9',
     userMessageBackground: '#F5F5F5',
     messageBorderColor: 'transparent',
+    grayNeutral38: 'rgba(0, 0, 0, 0.38)',
+    grayNeutral60: 'rgba(0, 0, 0, 0.6)',
   },
 }
 
@@ -104,5 +106,7 @@ export const commonDarkColors: CommonColorPalette = {
     answerMessageBackground: '#181818',
     userMessageBackground: '#20293A',
     messageBorderColor: '#C9C9C9',
+    grayNeutral38: 'rgba(255, 255, 255, 0.38)',
+    grayNeutral60: 'rgba(255, 255, 255, 0.6)',
   },
 }

--- a/build-configs/src/common/theme/colors.ts
+++ b/build-configs/src/common/theme/colors.ts
@@ -64,8 +64,8 @@ export const commonLightColors: CommonColorPalette = {
     answerMessageBackground: '#EAEEF9',
     userMessageBackground: '#F5F5F5',
     messageBorderColor: 'transparent',
-    grayNeutral38: 'rgba(0, 0, 0, 0.38)',
-    grayNeutral60: 'rgba(0, 0, 0, 0.6)',
+    chatInputOutlineColor: 'rgba(0, 0, 0, 0.38)',
+    chatInputPlaceholderColor: 'rgba(0, 0, 0, 0.6)',
   },
 }
 
@@ -109,7 +109,7 @@ export const commonDarkColors: CommonColorPalette = {
     answerMessageBackground: '#181818',
     userMessageBackground: '#20293A',
     messageBorderColor: '#C9C9C9',
-    grayNeutral38: 'rgba(255, 255, 255, 0.38)',
-    grayNeutral60: 'rgba(255, 255, 255, 0.6)',
+    chatInputOutlineColor: 'rgba(255, 255, 255, 0.38)',
+    chatInputPlaceholderColor: 'rgba(255, 255, 255, 0.6)',
   },
 }

--- a/build-configs/src/common/theme/colors.ts
+++ b/build-configs/src/common/theme/colors.ts
@@ -61,8 +61,8 @@ export const commonLightColors: CommonColorPalette = {
     answerMessageBackground: '#EAEEF9',
     userMessageBackground: '#F5F5F5',
     messageBorderColor: 'transparent',
-    grayNeutral38: 'rgba(0, 0, 0, 0.38)',
-    grayNeutral60: 'rgba(0, 0, 0, 0.6)',
+    chatInputOutlineColor: 'rgba(0, 0, 0, 0.38)',
+    chatInputPlaceholderColor: 'rgba(0, 0, 0, 0.6)',
   },
 }
 
@@ -106,7 +106,7 @@ export const commonDarkColors: CommonColorPalette = {
     answerMessageBackground: '#181818',
     userMessageBackground: '#20293A',
     messageBorderColor: '#C9C9C9',
-    grayNeutral38: 'rgba(255, 255, 255, 0.38)',
-    grayNeutral60: 'rgba(255, 255, 255, 0.6)',
+    chatInputOutlineColor: 'rgba(255, 255, 255, 0.38)',
+    chatInputPlaceholderColor: 'rgba(255, 255, 255, 0.6)',
   },
 }

--- a/build-configs/src/common/theme/colors.ts
+++ b/build-configs/src/common/theme/colors.ts
@@ -64,6 +64,8 @@ export const commonLightColors: CommonColorPalette = {
     answerMessageBackground: '#EAEEF9',
     userMessageBackground: '#F5F5F5',
     messageBorderColor: 'transparent',
+    grayNeutral38: 'rgba(0, 0, 0, 0.38)',
+    grayNeutral60: 'rgba(0, 0, 0, 0.6)',
   },
 }
 
@@ -107,5 +109,7 @@ export const commonDarkColors: CommonColorPalette = {
     answerMessageBackground: '#181818',
     userMessageBackground: '#20293A',
     messageBorderColor: '#C9C9C9',
+    grayNeutral38: 'rgba(255, 255, 255, 0.38)',
+    grayNeutral60: 'rgba(255, 255, 255, 0.6)',
   },
 }

--- a/build-configs/src/common/theme/colors.ts
+++ b/build-configs/src/common/theme/colors.ts
@@ -61,8 +61,8 @@ export const commonLightColors: CommonColorPalette = {
     answerMessageBackground: '#EAEEF9',
     userMessageBackground: '#F5F5F5',
     messageBorderColor: 'transparent',
-    chatInputOutlineColor: 'rgba(0, 0, 0, 0.38)',
-    chatInputPlaceholderColor: 'rgba(0, 0, 0, 0.6)',
+    chatInputOutlineColor: '#9E9E9E',
+    chatInputPlaceholderColor: '#666666',
   },
 }
 
@@ -106,7 +106,7 @@ export const commonDarkColors: CommonColorPalette = {
     answerMessageBackground: '#181818',
     userMessageBackground: '#20293A',
     messageBorderColor: '#C9C9C9',
-    chatInputOutlineColor: 'rgba(255, 255, 255, 0.38)',
-    chatInputPlaceholderColor: 'rgba(255, 255, 255, 0.6)',
+    chatInputOutlineColor: '#B6B6B6',
+    chatInputPlaceholderColor: '#8B8B8B',
   },
 }

--- a/build-configs/src/common/theme/colors.ts
+++ b/build-configs/src/common/theme/colors.ts
@@ -58,8 +58,8 @@ export const commonLightColors: CommonColorPalette = {
   chat: {
     background: '#FFFFFF',
     headerBackground: '#EAEEF9',
-    answerMessageBackground: '#EAEEF9',
-    userMessageBackground: '#F5F5F5',
+    answerMessageBackground: '#F5F5F5',
+    userMessageBackground: '#EAEEF9',
     messageBorderColor: 'transparent',
     chatInputOutlineColor: '#9E9E9E',
     chatInputPlaceholderColor: '#666666',
@@ -103,8 +103,8 @@ export const commonDarkColors: CommonColorPalette = {
   chat: {
     background: '#1E1E1E',
     headerBackground: '#1E1E1E',
-    answerMessageBackground: '#181818',
-    userMessageBackground: '#20293A',
+    answerMessageBackground: '#2B2B2B',
+    userMessageBackground: '#242D3B',
     messageBorderColor: '#C9C9C9',
     chatInputOutlineColor: '#B6B6B6',
     chatInputPlaceholderColor: '#8B8B8B',

--- a/build-configs/src/common/theme/colors.ts
+++ b/build-configs/src/common/theme/colors.ts
@@ -61,8 +61,8 @@ export const commonLightColors: CommonColorPalette = {
   chat: {
     background: '#FFFFFF',
     headerBackground: '#EAEEF9',
-    answerMessageBackground: '#EAEEF9',
-    userMessageBackground: '#F5F5F5',
+    answerMessageBackground: '#F5F5F5',
+    userMessageBackground: '#EAEEF9',
     messageBorderColor: 'transparent',
     chatInputOutlineColor: '#9E9E9E',
     chatInputPlaceholderColor: '#666666',
@@ -106,8 +106,8 @@ export const commonDarkColors: CommonColorPalette = {
   chat: {
     background: '#1E1E1E',
     headerBackground: '#1E1E1E',
-    answerMessageBackground: '#181818',
-    userMessageBackground: '#20293A',
+    answerMessageBackground: '#2B2B2B',
+    userMessageBackground: '#242D3B',
     messageBorderColor: '#C9C9C9',
     chatInputOutlineColor: '#B6B6B6',
     chatInputPlaceholderColor: '#8B8B8B',

--- a/build-configs/src/common/theme/colors.ts
+++ b/build-configs/src/common/theme/colors.ts
@@ -64,8 +64,8 @@ export const commonLightColors: CommonColorPalette = {
     answerMessageBackground: '#EAEEF9',
     userMessageBackground: '#F5F5F5',
     messageBorderColor: 'transparent',
-    chatInputOutlineColor: 'rgba(0, 0, 0, 0.38)',
-    chatInputPlaceholderColor: 'rgba(0, 0, 0, 0.6)',
+    chatInputOutlineColor: '#9E9E9E',
+    chatInputPlaceholderColor: '#666666',
   },
 }
 
@@ -109,7 +109,7 @@ export const commonDarkColors: CommonColorPalette = {
     answerMessageBackground: '#181818',
     userMessageBackground: '#20293A',
     messageBorderColor: '#C9C9C9',
-    chatInputOutlineColor: 'rgba(255, 255, 255, 0.38)',
-    chatInputPlaceholderColor: 'rgba(255, 255, 255, 0.6)',
+    chatInputOutlineColor: '#B6B6B6',
+    chatInputPlaceholderColor: '#8B8B8B',
   },
 }

--- a/native/src/components/HeaderActionItem.tsx
+++ b/native/src/components/HeaderActionItem.tsx
@@ -35,6 +35,7 @@ const HeaderActionItem = ({
   const theme = useTheme()
   const { t } = useTranslation('layout')
   const icon = iconName === 'search' ? 'magnify' : 'translate'
+  const color = theme.dark ? theme.colors.primaryContainer : theme.colors.primary
 
   if (innerText) {
     return (
@@ -44,8 +45,8 @@ const HeaderActionItem = ({
         icon={icon}
         onPress={onPress}
         accessibilityLabel={t(title)}
-        textColor={theme.colors.primary}
-        style={[styles.button, { borderColor: theme.colors.primary }]}>
+        textColor={color}
+        style={[styles.button, { borderColor: color }]}>
         {innerText}
       </Button>
     )
@@ -56,9 +57,9 @@ const HeaderActionItem = ({
       disabled={!visible}
       icon={icon}
       onPress={visible ? onPress : () => undefined}
-      color={theme.colors.primary}
+      color={color}
       accessibilityLabel={t(title)}
-      style={[styles.appbarAction, { borderColor: theme.colors.primary, display: visible ? 'flex' : 'none' }]}
+      style={[styles.appbarAction, { borderColor: color, display: visible ? 'flex' : 'none' }]}
     />
   )
 }

--- a/native/src/components/Link.tsx
+++ b/native/src/components/Link.tsx
@@ -22,7 +22,7 @@ const Link = ({ url, onPress, children, style }: LinkProps): ReactElement => {
       paddingVertical: 28,
       alignSelf: 'center',
       textDecorationLine: 'underline',
-      color: theme.colors.primary,
+      color: theme.dark ? theme.colors.primaryContainer : theme.colors.primary,
     },
   })
 

--- a/native/src/utils/renderHtml.ts
+++ b/native/src/utils/renderHtml.ts
@@ -371,17 +371,19 @@ const renderHtml = (
       }
       
       a {
-        color: ${theme.colors.primary};
+        color: ${theme.dark ? theme.colors.primaryContainer : theme.colors.primary};
       }
 
       .link-external::after {
         /* ExternalIcon, WebView can't handle imported svg as background */
-        content: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18'><path d='M16 15.9996l-14 0l0 -14l7 0l0 -2l-7 0a2 2 0 0 0 -2 2l0 14a2 2 0 0 0 2 2l14 0c1.1 0 2 -0.9 2 -2l0 -7l-2 0l0 7zm-5 -16l0 2l3.59 0l-9.83 9.83 1.41 1.41 9.83 -9.83l0 3.59l2 0l0 -7l-7 0z' fill='rgb(11, 87, 208)'/></svg>");
+        content: '';
+        mask-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18'><path d='M16 15.9996l-14 0l0 -14l7 0l0 -2l-7 0a2 2 0 0 0 -2 2l0 14a2 2 0 0 0 2 2l14 0c1.1 0 2 -0.9 2 -2l0 -7l-2 0l0 7zm-5 -16l0 2l3.59 0l-9.83 9.83 1.41 1.41 9.83 -9.83l0 3.59l2 0l0 -7l-7 0z'/></svg>");
         display: inline-block;
         width: ${buildConfig().fonts.contentFontSize};
         height: ${buildConfig().fonts.contentFontSize};
-        background-size: contain;
-        background-repeat: no-repeat;
+        background-color: currentcolor;
+        mask-size: contain;
+        mask-repeat: no-repeat;
         vertical-align: -2px;
         margin: 0 4px;
       }

--- a/web/src/@types/mui-theme.d.ts
+++ b/web/src/@types/mui-theme.d.ts
@@ -41,6 +41,8 @@ declare module '@mui/material/styles' {
       answerMessageBackground: string
       userMessageBackground: string
       messageBorderColor: string
+      grayNeutral38: string
+      grayNeutral60: string
     }
   }
 
@@ -56,6 +58,8 @@ declare module '@mui/material/styles' {
       answerMessageBackground: string
       userMessageBackground: string
       messageBorderColor: string
+      grayNeutral38: string
+      grayNeutral60: string
     }
   }
 }

--- a/web/src/@types/mui-theme.d.ts
+++ b/web/src/@types/mui-theme.d.ts
@@ -42,8 +42,8 @@ declare module '@mui/material/styles' {
       answerMessageBackground: string
       userMessageBackground: string
       messageBorderColor: string
-      grayNeutral38: string
-      grayNeutral60: string
+      chatInputOutlineColor: string
+      chatInputPlaceholderColor: string
     }
   }
 
@@ -60,8 +60,8 @@ declare module '@mui/material/styles' {
       answerMessageBackground: string
       userMessageBackground: string
       messageBorderColor: string
-      grayNeutral38: string
-      grayNeutral60: string
+      chatInputOutlineColor: string
+      chatInputPlaceholderColor: string
     }
   }
 }

--- a/web/src/@types/mui-theme.d.ts
+++ b/web/src/@types/mui-theme.d.ts
@@ -42,6 +42,8 @@ declare module '@mui/material/styles' {
       answerMessageBackground: string
       userMessageBackground: string
       messageBorderColor: string
+      grayNeutral38: string
+      grayNeutral60: string
     }
   }
 
@@ -58,6 +60,8 @@ declare module '@mui/material/styles' {
       answerMessageBackground: string
       userMessageBackground: string
       messageBorderColor: string
+      grayNeutral38: string
+      grayNeutral60: string
     }
   }
 }

--- a/web/src/@types/mui-theme.d.ts
+++ b/web/src/@types/mui-theme.d.ts
@@ -41,8 +41,8 @@ declare module '@mui/material/styles' {
       answerMessageBackground: string
       userMessageBackground: string
       messageBorderColor: string
-      grayNeutral38: string
-      grayNeutral60: string
+      chatInputOutlineColor: string
+      chatInputPlaceholderColor: string
     }
   }
 
@@ -58,8 +58,8 @@ declare module '@mui/material/styles' {
       answerMessageBackground: string
       userMessageBackground: string
       messageBorderColor: string
-      grayNeutral38: string
-      grayNeutral60: string
+      chatInputOutlineColor: string
+      chatInputPlaceholderColor: string
     }
   }
 }

--- a/web/src/components/ChatAvatar.tsx
+++ b/web/src/components/ChatAvatar.tsx
@@ -44,20 +44,15 @@ export const ChatLogoAvatar = ({ size = DEFAULT_AVATAR_SIZE, visible }: ChatLogo
 }
 
 type MessageAvatarProps = {
-  userIsAuthor: boolean
   isAutomaticAnswer: boolean
   visible: boolean
 }
 
-export const MessageAvatar = ({ userIsAuthor, isAutomaticAnswer, visible }: MessageAvatarProps): ReactElement => {
+export const MessageAvatar = ({ isAutomaticAnswer, visible }: MessageAvatarProps): ReactElement => {
   const { t } = useTranslation('chat')
   const theme = useTheme()
   const label = t(isAutomaticAnswer ? 'bot' : 'consultant')
   const appLogo = buildConfig().icons.appLogoInverted
-
-  if (userIsAuthor) {
-    return <ChatAvatar visible={visible} aria-label={t('user')} />
-  }
 
   return (
     <Tooltip title={label} disableHoverListener={!visible}>

--- a/web/src/components/ChatInput.tsx
+++ b/web/src/components/ChatInput.tsx
@@ -33,12 +33,27 @@ const StyledTextField = styled(TextField, { shouldForwardProp: prop => prop !== 
       [theme.breakpoints.up('md')]: {
         flexDirection: 'row',
       },
+      // MUI hovers to text.primary, excluding the focused state
+      [`&:hover:not(.${outlinedInputClasses.focused}) .${outlinedInputClasses.notchedOutline}`]: {
+        borderColor: theme.palette.chat.grayNeutral60,
+      },
+    },
+
+    [`& .${outlinedInputClasses.notchedOutline}`]: {
+      borderColor: theme.palette.chat.grayNeutral38,
+      borderWidth: 2,
+    },
+
+    [`& .${outlinedInputClasses.input}::placeholder`]: {
+      color: theme.palette.chat.grayNeutral60,
+      // The global placeholder opacity must not dim the color any further
+      opacity: 1,
     },
   }),
 )
 
 const ChatIconButton = styled(IconButton)(({ theme }) => ({
-  color: theme.palette.text.secondary,
+  color: theme.palette.chat.grayNeutral60,
   [`&.${buttonBaseClasses.focusVisible}`]: { color: theme.palette.text.primary },
 })) as typeof IconButton
 
@@ -51,7 +66,9 @@ const SendButton = styled(IconButton)(({ theme }) => ({
   '&:hover': {
     backgroundColor: theme.palette.primary.dark,
   },
-
+  [`&.${buttonBaseClasses.disabled}`]: {
+    color: theme.palette.chat.grayNeutral38,
+  },
   [theme.breakpoints.up('md')]: {
     borderRadius: 12,
   },

--- a/web/src/components/ChatInput.tsx
+++ b/web/src/components/ChatInput.tsx
@@ -79,12 +79,13 @@ const ButtonStack = styled(Stack, { shouldForwardProp })<{ expanded: boolean }>(
   flexDirection: expanded ? 'row-reverse' : 'row',
   justifyContent: expanded ? 'space-between' : 'flex-end',
   alignSelf: expanded ? 'stretch' : 'flex-end',
+  marginTop: expanded ? theme.spacing(1) : 0,
+  paddingInlineStart: theme.spacing(1),
 
   [theme.breakpoints.up('md')]: {
     flexDirection: expanded ? 'column' : 'row',
     justifyContent: 'flex-end',
     alignSelf: 'flex-end',
-    paddingLeft: 8,
   },
 }))
 

--- a/web/src/components/ChatInput.tsx
+++ b/web/src/components/ChatInput.tsx
@@ -35,17 +35,17 @@ const StyledTextField = styled(TextField, { shouldForwardProp: prop => prop !== 
       },
       // MUI hovers to text.primary, excluding the focused state
       [`&:hover:not(.${outlinedInputClasses.focused}) .${outlinedInputClasses.notchedOutline}`]: {
-        borderColor: theme.palette.chat.grayNeutral60,
+        borderColor: theme.palette.chat.chatInputPlaceholderColor,
       },
     },
 
     [`& .${outlinedInputClasses.notchedOutline}`]: {
-      borderColor: theme.palette.chat.grayNeutral38,
+      borderColor: theme.palette.chat.chatInputOutlineColor,
       borderWidth: 2,
     },
 
     [`& .${outlinedInputClasses.input}::placeholder`]: {
-      color: theme.palette.chat.grayNeutral60,
+      color: theme.palette.chat.chatInputPlaceholderColor,
       // The global placeholder opacity must not dim the color any further
       opacity: 1,
     },
@@ -53,7 +53,7 @@ const StyledTextField = styled(TextField, { shouldForwardProp: prop => prop !== 
 )
 
 const ChatIconButton = styled(IconButton)(({ theme }) => ({
-  color: theme.palette.chat.grayNeutral60,
+  color: theme.palette.chat.chatInputPlaceholderColor,
   [`&.${buttonBaseClasses.focusVisible}`]: { color: theme.palette.text.primary },
 })) as typeof IconButton
 
@@ -67,7 +67,7 @@ const SendButton = styled(IconButton)(({ theme }) => ({
     backgroundColor: theme.palette.primary.dark,
   },
   [`&.${buttonBaseClasses.disabled}`]: {
-    color: theme.palette.chat.grayNeutral38,
+    color: theme.palette.chat.chatInputOutlineColor,
   },
   [theme.breakpoints.up('md')]: {
     borderRadius: 12,

--- a/web/src/components/ChatMessage.tsx
+++ b/web/src/components/ChatMessage.tsx
@@ -20,7 +20,11 @@ export const Message = styled('div', { shouldForwardProp })<{ userIsAuthor: bool
   borderRadius: 8,
   wordBreak: 'break-word',
   backgroundColor: userIsAuthor ? theme.palette.chat.userMessageBackground : theme.palette.chat.answerMessageBackground,
-  border: `1px solid ${theme.palette.chat.messageBorderColor}`,
+  border: `1px solid ${
+    userIsAuthor && theme.isContrastTheme ? theme.palette.primary.light : theme.palette.chat.messageBorderColor
+  }`,
+  '& p:first-of-type': { marginTop: 0 },
+  '& p:last-of-type': { marginBottom: 0 },
 }))
 
 const RetryButton = styled(IconButton)({
@@ -44,7 +48,7 @@ export const InnerChatMessage = ({
   hint,
 }: InnerChatMessageProps): ReactElement => (
   <Stack direction={userIsAuthor ? 'row-reverse' : 'row'} gap={1}>
-    <MessageAvatar userIsAuthor={userIsAuthor} isAutomaticAnswer={isAutomaticAnswer} visible={showAvatar} />
+    {!userIsAuthor && <MessageAvatar isAutomaticAnswer={isAutomaticAnswer} visible={showAvatar} />}
     <Message userIsAuthor={userIsAuthor}>
       <Typography variant='body2' component='div'>
         {children}

--- a/web/src/components/ChatMessage.tsx
+++ b/web/src/components/ChatMessage.tsx
@@ -20,7 +20,11 @@ export const Message = styled('div', { shouldForwardProp })<{ userIsAuthor: bool
   borderRadius: 8,
   wordBreak: 'break-word',
   backgroundColor: userIsAuthor ? theme.palette.chat.userMessageBackground : theme.palette.chat.answerMessageBackground,
-  border: `1px solid ${theme.palette.chat.messageBorderColor}`,
+  border: `1px solid ${
+    userIsAuthor && theme.isContrastTheme ? theme.palette.primary.light : theme.palette.chat.messageBorderColor
+  }`,
+  '& p:first-of-type': { marginTop: 0 },
+  '& p:last-of-type': { marginBottom: 0 },
 }))
 
 const RetryButton = styled(IconButton)({
@@ -44,7 +48,7 @@ export const InnerChatMessage = ({
   hint,
 }: InnerChatMessageProps): ReactElement => (
   <Stack direction={userIsAuthor ? 'row-reverse' : 'row'} sx={{ gap: 1 }}>
-    <MessageAvatar userIsAuthor={userIsAuthor} isAutomaticAnswer={isAutomaticAnswer} visible={showAvatar} />
+    {!userIsAuthor && <MessageAvatar isAutomaticAnswer={isAutomaticAnswer} visible={showAvatar} />}
     <Message userIsAuthor={userIsAuthor}>
       <Typography variant='body2' component='div'>
         {children}

--- a/web/src/components/HeaderActionItem.tsx
+++ b/web/src/components/HeaderActionItem.tsx
@@ -9,11 +9,15 @@ import Link from './base/Link'
 const StyledButton = styled(MuiButton)`
   padding: 2px 12px;
   border: 1px solid;
+  color: ${props =>
+    props.theme.isContrastTheme ? props.theme.palette.primary.light : props.theme.palette.primary.main};
   background-color: ${props => (props.theme.isContrastTheme ? 'transparent' : props.theme.palette.background.default)};
 ` as typeof MuiButton
 
 const StyledIconButton = styled(IconButton)`
   border: 1px solid;
+  color: ${props =>
+    props.theme.isContrastTheme ? props.theme.palette.primary.light : props.theme.palette.primary.main};
   background-color: ${props => (props.theme.isContrastTheme ? 'transparent' : props.theme.palette.background.default)};
 ` as typeof IconButton
 

--- a/web/src/components/RemoteContentSandBox.ts
+++ b/web/src/components/RemoteContentSandBox.ts
@@ -68,7 +68,8 @@ const RemoteContentSandBox = styled('div')<{ centered: boolean; smallText: boole
 
   a {
     overflow-wrap: break-word;
-    color: ${props => props.theme.palette.primary.main};
+    color: ${props =>
+      props.theme.isContrastTheme ? props.theme.palette.primary.light : props.theme.palette.primary.main};
   }
 
   details > * {
@@ -92,12 +93,12 @@ const RemoteContentSandBox = styled('div')<{ centered: boolean; smallText: boole
     display: inline-block;
 
     /* prettier-ignore */
-    background-image: url("${ExternalLinkIcon}"); /* use double quotes otherwise it won't be rendered, see https://vite.dev/guide/assets about inlining SVGs through url()  */
+    mask-image: url("${ExternalLinkIcon}"); /* use double quotes otherwise it won't be rendered, see https://vite.dev/guide/assets about inlining SVGs through url()  */
     width: 16px;
     height: 16px;
-    color: ${props => props.theme.palette.primary.main};
-    background-size: contain;
-    background-repeat: no-repeat;
+    background-color: currentcolor;
+    mask-size: contain;
+    mask-repeat: no-repeat;
     vertical-align: middle;
     margin: 0 4px;
   }

--- a/web/src/components/__tests__/ChatConversation.spec.tsx
+++ b/web/src/components/__tests__/ChatConversation.spec.tsx
@@ -141,7 +141,6 @@ describe('ChatConversation', () => {
     const expectedResults = [
       { label: 'chat:consultant', text: 'Consultant Message 1', opacity: '1' },
       { label: 'chat:bot', text: 'Bot Message 1', opacity: '1' },
-      { label: 'chat:user', text: 'User Message 1', opacity: '1' },
       { label: 'chat:consultant', text: 'Consultant Message 2', opacity: '1' },
       { label: 'chat:consultant', text: 'Consultant Message 3', opacity: '0' },
       { label: 'chat:bot', text: 'Bot Message 2', opacity: '1' },
@@ -151,7 +150,7 @@ describe('ChatConversation', () => {
     const { getAllByLabelText } = render(testMessages2, false)
     const avatars = getAllByLabelText(/chat:.*/)
 
-    expect(avatars).toHaveLength(7)
+    expect(avatars).toHaveLength(6)
 
     avatars.forEach((avatar, index) => {
       const expected = expectedResults[index]!


### PR DESCRIPTION
### Short Description

Adjust the neutral colors of the input composer to create a clearer visual hierarchy:

Use Neutral 38% for:

- Input field outline
- Inactive send button

Use Neutral 60% for:

- Placeholder text
- Datenschutz icon



### Proposed Changes

<!-- Describe this PR in more detail. -->

- Added `grayNeutral38` and `grayNeutral60` to `TypeChat` at `ThemeType.ts`.
- at `colors.ts` added `grayNeutral38` and `grayNeutral60`as rgba colors to match the actual color.

Used `grayNeutral38` for:
   - Added a `notchedOutline` rule to `StyledTextField` that sets the input outline to `grayNeutral38` and `borderWidth: 2`.
   - The inactive send button.


Used `grayNeutral60` for:
   -  The placeholder color.
   - The privacy policy icon in `ChatIconButton`.
   - The hover outline color.

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Checklist

- [X] Followed the [contributing guidelines](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md) and [conventions](https://github.com/digitalfabrik/integreat-app/blob/main/docs/conventions.md)
- [ ] Considered accessibility impacts and made the necessary adjustments
- [ ] Added or updated unit tests (if applicable)
- [ ] Added or updated documentation (if applicable)
- [ ] Added a [release note](https://github.com/digitalfabrik/integreat-app/tree/main/release-notes) for native (if [applicable](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes))

### Testing

- Go to Testumgebung and open the chat.
- Check the input's place holder color, icon colors, the hovering and contrast more.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4284

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
