### PR TITLE
4310: Improve region search results for dashes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1477,4 +1477,3 @@ workflows:
             equal:
                 - << pipeline.parameters.workflow_type >>
                 - web_promotion
-

--- a/native/src/components/Highlighter.tsx
+++ b/native/src/components/Highlighter.tsx
@@ -17,7 +17,7 @@ const Highlighter = ({ search, text, style, wordStartOnly = false }: Highlighter
   const theme = useTheme()
   const chunks = findAllMatches({
     textToHighlight: text,
-    searchWords: search.split(MATCH_WHITESPACE_AND_DASHES),
+    searchWords: wordStartOnly ? search.split(MATCH_WHITESPACE_AND_DASHES) : [search],
     sanitize: normalizeString,
     autoEscape: true,
     findChunks: (props: FindChunks) => findNormalizedMatches(props, { wordStartOnly }),

--- a/native/src/components/Highlighter.tsx
+++ b/native/src/components/Highlighter.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement } from 'react'
 import { StyleProp, TextStyle } from 'react-native'
 import { useTheme } from 'styled-components/native'
 
-import { findAllMatches, findNormalizedMatches, normalizeString, FindChunks } from 'shared'
+import { findAllMatches, findNormalizedMatches, normalizeString, MATCH_WHITESPACE_AND_DASHES, FindChunks } from 'shared'
 
 import Text from './base/Text'
 
@@ -17,7 +17,7 @@ const Highlighter = ({ search, text, style, wordStartOnly = false }: Highlighter
   const theme = useTheme()
   const chunks = findAllMatches({
     textToHighlight: text,
-    searchWords: [search],
+    searchWords: search.split(MATCH_WHITESPACE_AND_DASHES),
     sanitize: normalizeString,
     autoEscape: true,
     findChunks: (props: FindChunks) => findNormalizedMatches(props, { wordStartOnly }),

--- a/release-notes/unreleased/4310-improve-region-search-results-for-dashes.yml
+++ b/release-notes/unreleased/4310-improve-region-search-results-for-dashes.yml
@@ -1,0 +1,7 @@
+issue_key: 4310
+show_in_stores: true
+platforms:
+  - android
+  - ios
+en: Region search now finds names that contain dashes.
+de: Die Regionssuche findet nun auch Namen mit Bindestrichen.

--- a/shared/package.json
+++ b/shared/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "test": "yarn run -T jest",
     "test:changed": "yarn run test -o",
     "test:watch": "yarn run test --watchAll",
     "check-circular-dependencies": "yarn run -T check-circular-dependencies",

--- a/shared/src/utils/__tests__/search.spec.ts
+++ b/shared/src/utils/__tests__/search.spec.ts
@@ -126,6 +126,19 @@ describe('search', () => {
       ]
       expect(filterSortRegions(regions, 'ba')).toEqual([])
     })
+
+    it('should match regions with dashes in their name', () => {
+      const regions = [
+        region({ sortingName: 'Rems-Murr-Kreis', prefix: '' }),
+        region({ sortingName: 'Alzey-Worms', prefix: 'Landkreis' }),
+        region({ sortingName: 'Breisgau-Hochschwarzwald', prefix: 'Landkreis' }),
+      ]
+      expect(filterSortRegions(regions, 'Rems-Murr-Kreis')).toEqual([regions[0]])
+      expect(filterSortRegions(regions, 'rems-murr')).toEqual([regions[0]])
+      expect(filterSortRegions(regions, 'Alzey-Worms')).toEqual([regions[1]])
+      expect(filterSortRegions(regions, 'alzey')).toEqual([regions[1]])
+      expect(filterSortRegions(regions, 'Landkreis Breisgau-Hochschwarzwald')).toEqual([regions[2]])
+    })
   })
 })
 

--- a/shared/src/utils/search.ts
+++ b/shared/src/utils/search.ts
@@ -4,10 +4,13 @@ import { normalizeString } from './normalizeString.ts'
 export const MATCH_WHITESPACE_AND_DASHES = /[\s-]+/
 
 // Matches with all three string start cases, for ex. Landkreis Breisgau-Hochschwarzwald
-const matchesWordStart = (text: string, normalizedFilter: string): boolean =>
-  normalizeString(text)
-    .split(MATCH_WHITESPACE_AND_DASHES)
-    .some(word => word.startsWith(normalizedFilter))
+const matchesWordStart = (text: string, normalizedFilter: string): boolean => {
+  const normalizedSearchWords = normalizedFilter.split(MATCH_WHITESPACE_AND_DASHES)
+  const normalizedTextWords = normalizeString(text).split(MATCH_WHITESPACE_AND_DASHES)
+  return normalizedSearchWords.every(searchWord =>
+    normalizedTextWords.some(textWord => textWord.startsWith(searchWord)),
+  )
+}
 
 const regionFilter =
   (filterText: string, developerFriendly: boolean) =>

--- a/web/src/components/Highlighter.tsx
+++ b/web/src/components/Highlighter.tsx
@@ -2,7 +2,7 @@ import { useTheme } from '@mui/material/styles'
 import React, { ReactElement } from 'react'
 import ReactHighlighter from 'react-highlight-words'
 
-import { findNormalizedMatches, normalizeString, FindChunks } from 'shared'
+import { findNormalizedMatches, normalizeString, MATCH_WHITESPACE_AND_DASHES, FindChunks } from 'shared'
 import { UiDirectionType } from 'translations'
 
 type HighlighterProps = {
@@ -19,7 +19,7 @@ const Highlighter = ({ search, text, className, dir, wordStartOnly = false }: Hi
     <ReactHighlighter
       className={className}
       textToHighlight={text}
-      searchWords={[search]}
+      searchWords={search.split(MATCH_WHITESPACE_AND_DASHES)}
       sanitize={normalizeString}
       findChunks={(props: FindChunks) => findNormalizedMatches(props, { wordStartOnly })}
       highlightStyle={{

--- a/web/src/components/Highlighter.tsx
+++ b/web/src/components/Highlighter.tsx
@@ -19,7 +19,7 @@ const Highlighter = ({ search, text, className, dir, wordStartOnly = false }: Hi
     <ReactHighlighter
       className={className}
       textToHighlight={text}
-      searchWords={search.split(MATCH_WHITESPACE_AND_DASHES)}
+      searchWords={wordStartOnly ? search.split(MATCH_WHITESPACE_AND_DASHES) : [search]}
       sanitize={normalizeString}
       findChunks={(props: FindChunks) => findNormalizedMatches(props, { wordStartOnly })}
       highlightStyle={{


### PR DESCRIPTION
### Short Description

If a user writes a region which has a dash in between the region name then nothing returns, it returns only the word before the dash, without including dash and after dash word. For ex, Rems-Murr-Kreis, Landkreis Alzey-Worms.
It should return all the occurrences including the regions which have dashes in-between the region name


### Proposed Changes

<!-- Describe this PR in more detail. -->

- Split `normalizedFilter` into `normalizedSearchWords` on `MATCH_WHITESPACE_AND_DASHES`, so a search containing dashes is no longer compared as a single string against single words.
- Updated `matchesWordStart` to split the query on whitespace/dashes as well, then use `every`/`some` so each search word must be a prefix of some text word. This allows matches for names like `Rems-Murr-Kreis` and `Landkreis Alzey-Worms` while still rejecting mid-word hits.
- For the Highlighter's (web and native) `search` prop I changed the typing to `string | string[]` letting each caller decide between highlighting a string or highlighting an array.
- Changed the native `Highlighter` to split `search` with `MATCH_WHITESPACE_AND_DASHES` before passing `searchWords` to `findAllMatches`
- Switched `searchWords` in native and web `Highlighter` from `[search]` to `search.split(MATCH_WHITESPACE_AND_DASHES)` so both platforms split the query the same way.
- Replaced the `test` script's `NODE_OPTIONS=--experimental-vm-modules jest` with `yarn run -T jest`, matching `web` and `native`.

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- This could affect the search and Highlighting at the searchPage.

### Checklist

- [X] Followed the [contributing guidelines](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md) and [conventions](https://github.com/digitalfabrik/integreat-app/blob/main/docs/conventions.md)
- [ ] Considered accessibility impacts and made the necessary adjustments
- [X] Added or updated unit tests (if applicable)
- [X] Added or updated documentation (if applicable)
- [X] Added a [release note](https://github.com/digitalfabrik/integreat-app/tree/main/release-notes) for native (if [applicable](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes))

### Testing

- Launch integreat and test the regions page.
- Type `rems-murr-kreis` for example also `murr` or `murr-kreis`.
- Test web and native.
- Highlighting should work as expected.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4310

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
