### PR TITLE
4317: Fix delayed loading of an event page detail

### DIFF
--- a/native/src/components/EventList.tsx
+++ b/native/src/components/EventList.tsx
@@ -1,10 +1,10 @@
-import React, { ReactElement } from 'react'
+import React, { ReactElement, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { SectionList } from 'react-native'
 import { Divider, List as PaperList } from 'react-native-paper'
 import styled, { useTheme } from 'styled-components/native'
 
-import { eventGroupTitle, EVENTS_ROUTE, groupEventsByDate, RouteInformationType, useDateFilter } from 'shared'
+import { eventGroupTitle, groupEventsByDate, RouteInformationType, useDateFilter } from 'shared'
 import { RegionModel, EventModel } from 'shared/api'
 
 import Caption from '../components/Caption'
@@ -36,32 +36,27 @@ const EventList = ({ events, regionModel, language, navigateTo, refresh }: Event
   const { t } = useTranslation('events', { lng: language })
   const { startDate, setStartDate, endDate, setEndDate, filteredEvents, startDateError } = useDateFilter(events)
 
-  let sections: EventSection[]
-  if (startDate || endDate) {
-    sections = filteredEvents.length > 0 ? [{ title: null, data: filteredEvents }] : []
-  } else {
-    sections = groupEventsByDate(events).map(([key, events]) => ({ title: t(...eventGroupTitle(key)), data: events }))
-  }
+  const sections = useMemo<EventSection[]>(() => {
+    if (startDate || endDate) {
+      return filteredEvents.length ? [{ title: null, data: filteredEvents }] : []
+    }
 
-  const renderEventListItem = ({ item }: { item: EventModel }) => {
-    const navigateToEvent = () =>
-      navigateTo({
-        route: EVENTS_ROUTE,
-        regionCode: regionModel.code,
-        languageCode: language,
-        slug: item.slug,
-      })
+    return groupEventsByDate(events).map(([key, data]) => ({
+      title: t(...eventGroupTitle(key)),
+      data,
+    }))
+  }, [events, filteredEvents, startDate, endDate, t])
 
-    return (
-      <EventListItem
-        event={item}
-        language={language}
-        navigateToEvent={navigateToEvent}
-        filterStartDate={startDate}
-        filterEndDate={endDate}
-      />
-    )
-  }
+  const renderEventListItem = ({ item }: { item: EventModel }) => (
+    <EventListItem
+      event={item}
+      language={language}
+      navigateTo={navigateTo}
+      regionCode={regionModel.code}
+      filterStartDate={startDate}
+      filterEndDate={endDate}
+    />
+  )
 
   const renderSectionHeader = ({ section }: { section: EventSection }) =>
     section.title ? (
@@ -74,6 +69,7 @@ const EventList = ({ events, regionModel, language, navigateTo, refresh }: Event
     <ListContainer>
       <SectionList
         sections={sections}
+        keyExtractor={item => item.slug}
         renderItem={renderEventListItem}
         renderSectionHeader={renderSectionHeader}
         stickySectionHeadersEnabled

--- a/native/src/components/EventListItem.tsx
+++ b/native/src/components/EventListItem.tsx
@@ -5,7 +5,7 @@ import { StyleSheet, View } from 'react-native'
 import { List as PaperList } from 'react-native-paper'
 import styled from 'styled-components/native'
 
-import { parseHTML, getDisplayDate } from 'shared'
+import { parseHTML, getDisplayDate, RouteInformationType, EVENTS_ROUTE } from 'shared'
 import { EventModel } from 'shared/api'
 
 import { EventThumbnailPlaceholder1, EventThumbnailPlaceholder2, EventThumbnailPlaceholder3 } from '../assets'
@@ -35,7 +35,8 @@ const placeholderThumbnails = [EventThumbnailPlaceholder1, EventThumbnailPlaceho
 type EventListItemProps = {
   event: EventModel
   language: string
-  navigateToEvent: () => void
+  navigateTo: (route: RouteInformationType) => void
+  regionCode: string
   filterStartDate?: DateTime | null
   filterEndDate?: DateTime | null
 }
@@ -43,7 +44,8 @@ type EventListItemProps = {
 const EventListItem = ({
   language,
   event,
-  navigateToEvent,
+  regionCode,
+  navigateTo,
   filterStartDate = null,
   filterEndDate = null,
 }: EventListItemProps): ReactElement => {
@@ -66,6 +68,15 @@ const EventListItem = ({
   )
 
   const renderThumbnail = useCallback(() => <SimpleImage style={styles.thumbnail} source={thumbnail} />, [thumbnail])
+
+  const handlePress = useCallback(() => {
+    navigateTo({
+      route: EVENTS_ROUTE,
+      regionCode,
+      languageCode: language,
+      slug: event.slug,
+    })
+  }, [navigateTo, regionCode, language, event.slug])
 
   return (
     <PaperList.Item
@@ -101,7 +112,7 @@ const EventListItem = ({
       }
       left={isRtl ? DateIcon : renderThumbnail}
       right={isRtl ? renderThumbnail : DateIcon}
-      onPress={navigateToEvent}
+      onPress={handlePress}
     />
   )
 }

--- a/native/src/components/__tests__/EventListItem.spec.tsx
+++ b/native/src/components/__tests__/EventListItem.spec.tsx
@@ -12,12 +12,15 @@ jest.mock('react-i18next')
 jest.useFakeTimers({ now: new Date('2023-10-02T05:23:57.443+02:00') })
 describe('EventListItem', () => {
   const language = 'de'
+  const regionCode = 'augsburg'
 
   const event = new EventModelBuilder('seed', 1, 'augsburg', language).build()[0]!
   const navigateToEvent = jest.fn()
 
   it('should show event list item with specific thumbnail', () => {
-    const { getByText } = render(<EventListItem event={event} language={language} navigateToEvent={navigateToEvent} />)
+    const { getByText } = render(
+      <EventListItem event={event} language={language} regionCode={regionCode} navigateTo={navigateToEvent} />,
+    )
 
     expect(getByText(event.title)).toBeTruthy()
     expect(getByText(event.date.formatEventDateInOneLine(language, jest.fn()))).toBeTruthy()
@@ -39,7 +42,7 @@ describe('EventListItem', () => {
       const event = createEvent()
 
       const { queryByLabelText } = render(
-        <EventListItem event={event} language={language} navigateToEvent={navigateToEvent} />,
+        <EventListItem event={event} language={language} regionCode={regionCode} navigateTo={navigateToEvent} />,
       )
 
       expect(queryByLabelText('recurring')).toBeFalsy()
@@ -49,7 +52,7 @@ describe('EventListItem', () => {
       const event = createEvent('DTSTART:20230414T050000\nRRULE:FREQ=WEEKLY;BYDAY=MO;UNTIL=20231029T050000')
 
       const { queryByLabelText } = render(
-        <EventListItem event={event} language={language} navigateToEvent={navigateToEvent} />,
+        <EventListItem event={event} language={language} regionCode={regionCode} navigateTo={navigateToEvent} />,
       )
 
       expect(queryByLabelText('recurring')).toBeTruthy()


### PR DESCRIPTION
### Short Description

This PR fixes delay of selected event item navigation.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Use `useMemo()` hook to memoize the sections calculation
- Create `handlePress()` navigation handler inside the memoized `EventListItem.tsx` component which prevents a new callback from being passed to every row whenever the parent renders.
- Add `keyExtractor` to optimize the section list

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Checklist

- [x] Followed the [contributing guidelines](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md) and [conventions](https://github.com/digitalfabrik/integreat-app/blob/main/docs/conventions.md)
- [ ] Considered accessibility impacts and made the necessary adjustments
- [x] Added or updated unit tests (if applicable)
- [ ] Added or updated documentation (if applicable)
- [ ] Added a [release note](https://github.com/digitalfabrik/integreat-app/tree/main/release-notes) for native (if [applicable](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes))

### Testing

1. Go to Stadt Augsburg  / Landeshauptstadt München
2. Go to Events
3. Tap on any event list item and see that it is not delaying in opening event detail page

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4317 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
