### PR TITLE
2537: Fix news ids

### DIFF
--- a/native/src/components/News.tsx
+++ b/native/src/components/News.tsx
@@ -47,7 +47,7 @@ const ListHeaderContainer = styled(View)`
 
 type NewsProps = {
   news: NewsModel[]
-  id: number | null
+  id: string | null
   region: RegionModel
   languageCode: string
   refresh: () => void

--- a/native/src/components/__tests__/News.spec.tsx
+++ b/native/src/components/__tests__/News.spec.tsx
@@ -20,21 +20,21 @@ jest.mock('../../utils/openExternalUrl')
 
 const defaultNews: [NewsModel, NewsModel] = [
   new NewsModel({
-    id: 1,
+    id: 'local-1',
     title: 'Tick bite - What to do?',
     lastUpdate: DateTime.fromISO('2020-01-20T00:00:00.000Z'),
     content:
       'In summer there are often ticks in forest and meadows with high grass. These are very small animals. They feed on the blood of people or animals they sting, like mosquitoes. But they stay in the skin longer and can transmit dangerous diseases. If you have been in high grass, you should search your body very thoroughly for ticks. They like to sit in the knees, armpits or in the groin area. If you discover a tick in your skin, you should carefully pull it out with tweezers without crushing it. If the sting inflames, you must see a doctor. https://example.com',
-    availableLanguages: { de: 1234 },
+    availableLanguages: { de: 'local-1234' },
     externalUrl: 'https://example.com',
     source: 'tunews',
   }),
   new NewsModel({
-    id: 2,
+    id: 'local-2',
     title: 'Test Local',
     lastUpdate: DateTime.fromISO('2020-01-21T00:00:00.000Z'),
     content: 'Test local news content. https://example.com',
-    availableLanguages: { de: 123 },
+    availableLanguages: { de: 'local-123' },
     externalUrl: 'https://example.com',
     source: 'local',
   }),
@@ -57,7 +57,7 @@ describe('News', () => {
     externalNewsEnabled = true,
     localNewsEnabled = true,
   }: {
-    id?: number | null
+    id?: string | null
     news?: NewsModel[]
     externalNewsEnabled?: boolean
     localNewsEnabled?: boolean
@@ -96,7 +96,7 @@ describe('News', () => {
   }
 
   it('should show not found error if news with id not found', () => {
-    const { getByText } = renderNews({ id: 32498732984824 })
+    const { getByText } = renderNews({ id: 'local-32498732984824' })
     expect(getByText('pageNotFound')).toBeTruthy()
   })
 
@@ -117,7 +117,12 @@ describe('News', () => {
     expect(getByText(defaultNews[1].content)).toBeTruthy()
 
     fireEvent.press(getByText(defaultNews[1].title))
-    expect(navigateTo).toHaveBeenCalledWith({ id: 2, languageCode: 'de', regionCode: 'augsburg', route: 'news' })
+    expect(navigateTo).toHaveBeenCalledWith({
+      id: 'local-2',
+      languageCode: 'de',
+      regionCode: 'augsburg',
+      route: 'news',
+    })
   })
 
   it('should show currently no news', () => {

--- a/native/src/components/__tests__/NewsListItem.spec.tsx
+++ b/native/src/components/__tests__/NewsListItem.spec.tsx
@@ -11,12 +11,12 @@ jest.mock('react-i18next')
 
 const buildNews = (source: NewsSource = LOCAL_NEWS_SOURCE) =>
   new NewsModel({
-    id: 217,
+    id: 'local-217',
     title: 'Tick bite - What to do?',
     lastUpdate: DateTime.fromISO('2020-01-20T00:00:00.000Z'),
     content:
       'In summer there are often ticks in forest and meadows with high grass. These are very small animals. They feed on the blood of people or animals they sting, like mosquitoes. But they stay in the skin longer and can transmit dangerous diseases. If you have been in high grass, you should search your body very thoroughly for ticks. They like to sit in the knees, armpits or in the groin area. If you discover a tick in your skin, you should carefully pull it out with tweezers without crushing it. If the sting inflames, you must see a doctor.',
-    availableLanguages: { de: 123, it: 234 },
+    availableLanguages: { de: 'local-123', it: 'local-234' },
     externalUrl: 'https://example.com',
     source,
   })

--- a/native/src/constants/NavigationTypes.ts
+++ b/native/src/constants/NavigationTypes.ts
@@ -98,7 +98,7 @@ export type NestedRoutesParamsType = {
     slug?: string
   }
   [NEWS_ROUTE]: RouteTitle & {
-    id: number | null
+    id: string | null
   }
 }
 

--- a/native/src/hooks/__tests__/useNavigate.spec.tsx
+++ b/native/src/hooks/__tests__/useNavigate.spec.tsx
@@ -187,9 +187,9 @@ describe('useNavigate', () => {
   })
 
   it('should navigate to news route', () => {
-    renderMockComponent({ route: NEWS_ROUTE, ...params, id: 1234 })
+    renderMockComponent({ route: NEWS_ROUTE, ...params, id: 'local-1234' })
     expect(navigation.push).not.toHaveBeenCalled()
-    expect(navigateNested).toHaveBeenCalledWith(navigation, NEWS_ROUTE, { id: 1234 }, false)
+    expect(navigateNested).toHaveBeenCalledWith(navigation, NEWS_ROUTE, { id: 'local-1234' }, false)
     expect(navigateNested).toHaveBeenCalledTimes(1)
   })
 

--- a/native/src/utils/DatabaseConnector.ts
+++ b/native/src/utils/DatabaseConnector.ts
@@ -178,12 +178,12 @@ type ContentPlaceJsonType = {
 }
 
 type ContentNewsJsonType = {
-  id: number
+  id: string
   lastUpdate: string
   title: string
   content: string
   source: NewsSource
-  availableLanguages: Record<string, number> | null
+  availableLanguages: Record<string, string> | null
   externalUrl: string
 }
 

--- a/native/src/utils/PushNotificationsManager.ts
+++ b/native/src/utils/PushNotificationsManager.ts
@@ -13,6 +13,7 @@ import { useEffect } from 'react'
 import { checkNotifications, requestNotifications, RESULTS } from 'react-native-permissions'
 
 import { NEWS_ROUTE, NonNullableRouteInformationType, RouteInformationType } from 'shared'
+import { LOCAL_NEWS_SOURCE } from 'shared/api'
 
 import buildConfig from '../constants/buildConfig'
 import { AppContextType } from '../contexts/AppContext'
@@ -109,7 +110,7 @@ const routeInformationFromMessage = (message: Message): NonNullableRouteInformat
   regionCode: message.data.city_code,
   languageCode: message.data.language_code,
   route: NEWS_ROUTE,
-  id: parseInt(message.data.news_id, 10),
+  id: `${LOCAL_NEWS_SOURCE}-${message.data.news_id}`,
 })
 
 const openMessage = (message: Message, navigate: (routeInformation: RouteInformationType) => void): void => {

--- a/native/src/utils/__tests__/PushNotificationsManager.spec.tsx
+++ b/native/src/utils/__tests__/PushNotificationsManager.spec.tsx
@@ -157,7 +157,7 @@ describe('PushNotificationsManager', () => {
       expect(navigate).toHaveBeenCalledWith({
         regionCode: 'augsburg',
         languageCode: 'de',
-        id: 123,
+        id: 'local-123',
         route: 'news',
       })
     })
@@ -169,7 +169,7 @@ describe('PushNotificationsManager', () => {
       expect(navigate).toHaveBeenCalledWith({
         regionCode: 'augsburg',
         languageCode: 'de',
-        id: 123,
+        id: 'local-123',
         route: 'news',
       })
     })

--- a/native/src/utils/__tests__/navigation.spec.ts
+++ b/native/src/utils/__tests__/navigation.spec.ts
@@ -53,7 +53,7 @@ describe('navigateNested', () => {
   const categoriesParams = { path: '/augsburg/de/category' }
   const eventsParams = { slug: 'some-event' }
   const placesParams = { slug: 'some-place' }
-  const newsParams = { id: 1 }
+  const newsParams = { id: 'local-1' }
 
   describe('root navigator', () => {
     it('pushes bottom tab route with correct tab and screen', () => {

--- a/shared/src/api/endpoints/__tests__/createNewsElementEndpoint.spec.ts
+++ b/shared/src/api/endpoints/__tests__/createNewsElementEndpoint.spec.ts
@@ -10,12 +10,12 @@ describe('createNewsElementEndpoint', () => {
   const newsElement = createNewsElementEndpoint(baseUrl)
 
   const createNewsItem = (date: string): JsonNewsType => ({
-    id: 1,
+    id: 'local-1',
     title: 'Tick bite - What to do?',
     display_date: date,
     content:
       'In summer there are often ticks in forest and meadows with high grass. These are very small animals. They feed on the blood of people or animals they sting, like mosquitoes. But they stay in the skin longer and can transmit dangerous diseases. If you have been in high grass, you should search your body very thoroughly for ticks. They like to sit in the knees, armpits or in the groin area. If you discover a tick in your skin, you should carefully pull it out with tweezers without crushing it. If the sting inflames, you must see a doctor.',
-    available_languages: { de: { id: 1234 } },
+    available_languages: { de: { id: 'local-1234' } },
     source: 'local',
     externalUrl: 'https://example.com',
   })
@@ -24,12 +24,12 @@ describe('createNewsElementEndpoint', () => {
 
   const createNewsItemModel = (date: DateTime): NewsModel =>
     new NewsModel({
-      id: 1,
+      id: 'local-1',
       title: 'Tick bite - What to do?',
       lastUpdate: date,
       content:
         'In summer there are often ticks in forest and meadows with high grass. These are very small animals. They feed on the blood of people or animals they sting, like mosquitoes. But they stay in the skin longer and can transmit dangerous diseases. If you have been in high grass, you should search your body very thoroughly for ticks. They like to sit in the knees, armpits or in the groin area. If you discover a tick in your skin, you should carefully pull it out with tweezers without crushing it. If the sting inflames, you must see a doctor.',
-      availableLanguages: { de: 1234 },
+      availableLanguages: { de: 'local-1234' },
       externalUrl: 'https://example.com',
       source: 'local',
     })
@@ -38,7 +38,7 @@ describe('createNewsElementEndpoint', () => {
   const params = {
     region: 'testumgebung',
     language: 'en',
-    id: '1',
+    id: 'local-1',
   }
 
   it('should map params to url', () => {

--- a/shared/src/api/endpoints/__tests__/createNewsEndpoint.spec.ts
+++ b/shared/src/api/endpoints/__tests__/createNewsEndpoint.spec.ts
@@ -10,12 +10,12 @@ describe('createNewsEndpoint', () => {
   const news = createNewsEndpoint(baseUrl)
 
   const createNewsItem = (date: string): JsonNewsType => ({
-    id: 217,
+    id: 'local-217',
     title: 'Tick bite - What to do?',
     display_date: date,
     content:
       'In summer there are often ticks in forest and meadows with high grass. These are very small animals. They feed on the blood of people or animals they sting, like mosquitoes. But they stay in the skin longer and can transmit dangerous diseases. If you have been in high grass, you should search your body very thoroughly for ticks. They like to sit in the knees, armpits or in the groin area. If you discover a tick in your skin, you should carefully pull it out with tweezers without crushing it. If the sting inflames, you must see a doctor.',
-    available_languages: { de: { id: 123 }, it: { id: 234 } },
+    available_languages: { de: { id: 'local-123' }, it: { id: 'local-234' } },
     source: 'local',
     externalUrl: 'https://example.com',
   })
@@ -26,12 +26,12 @@ describe('createNewsEndpoint', () => {
 
   const createNewsItemModel = (date: DateTime): NewsModel =>
     new NewsModel({
-      id: 217,
+      id: 'local-217',
       title: 'Tick bite - What to do?',
       lastUpdate: date,
       content:
         'In summer there are often ticks in forest and meadows with high grass. These are very small animals. They feed on the blood of people or animals they sting, like mosquitoes. But they stay in the skin longer and can transmit dangerous diseases. If you have been in high grass, you should search your body very thoroughly for ticks. They like to sit in the knees, armpits or in the groin area. If you discover a tick in your skin, you should carefully pull it out with tweezers without crushing it. If the sting inflames, you must see a doctor.',
-      availableLanguages: { de: 123, it: 234 },
+      availableLanguages: { de: 'local-123', it: 'local-234' },
       externalUrl: 'https://example.com',
       source: 'local',
     })

--- a/shared/src/api/endpoints/testing/LanguageModelBuilder.ts
+++ b/shared/src/api/endpoints/testing/LanguageModelBuilder.ts
@@ -4,6 +4,7 @@ const languages = [
   new LanguageModel('en', 'English'),
   new LanguageModel('de', 'Deutsch'),
   new LanguageModel('ar', 'اَللُّغَةُ اَلْعَرَبِيَّة'),
+  new LanguageModel('es', 'Español'),
 ]
 
 class LanguageModelBuilder {

--- a/shared/src/api/endpoints/testing/NewsModelBuilder.ts
+++ b/shared/src/api/endpoints/testing/NewsModelBuilder.ts
@@ -33,7 +33,7 @@ class NewsModelBuilder {
       () => ({
         path: null,
         newsItem: new NewsModel({
-          id: 12,
+          id: 'local-12',
           title: 'first news item',
           lastUpdate: DateTime.fromISO('2017-11-18T19:30:00.000Z'),
           content: 'This is a sample news',

--- a/shared/src/api/endpoints/testing/RegionModelBuilder.ts
+++ b/shared/src/api/endpoints/testing/RegionModelBuilder.ts
@@ -1,7 +1,7 @@
 import RegionModel from '../../models/RegionModel.ts'
 import LanguageModelBuilder from './LanguageModelBuilder.ts'
 
-const languages = new LanguageModelBuilder(3).build()
+const languages = new LanguageModelBuilder(4).build()
 
 const regions = [
   new RegionModel({

--- a/shared/src/api/mapping/__tests__/mapNewsJson.spec.ts
+++ b/shared/src/api/mapping/__tests__/mapNewsJson.spec.ts
@@ -6,13 +6,13 @@ import mapNewsJson from '../mapNewsJson.ts'
 
 describe('mapNewsJson', () => {
   const buildJson = (overrides: Partial<JsonNewsType> = {}): JsonNewsType => ({
-    id: 1,
+    id: 'local-1',
     title: 'News title',
     content: '<p>News body</p>',
     display_date: '2020-03-20T17:50:00+02:00',
     source: 'local',
     externalUrl: 'https://example.com',
-    available_languages: { de: { id: 1 }, en: { id: 42 } },
+    available_languages: { de: { id: 'local-1' }, en: { id: 'local-42' } },
     ...overrides,
   })
 
@@ -20,12 +20,12 @@ describe('mapNewsJson', () => {
     const news = mapNewsJson(buildJson())
     expect(news).toEqual(
       new NewsModel({
-        id: 1,
+        id: 'local-1',
         title: 'News title',
         content: '<p>News body</p>',
         source: 'local',
         lastUpdate: DateTime.fromISO('2020-03-20T17:50:00+02:00'),
-        availableLanguages: { de: 1, en: 42 },
+        availableLanguages: { de: 'local-1', en: 'local-42' },
         externalUrl: 'https://example.com',
       }),
     )

--- a/shared/src/api/mapping/mapNewsJson.ts
+++ b/shared/src/api/mapping/mapNewsJson.ts
@@ -3,7 +3,7 @@ import { DateTime } from 'luxon'
 import NewsModel from '../models/NewsModel.ts'
 import { JsonNewsType } from '../types.ts'
 
-const mapNewsAvailableLanguages = (json: Record<string, { id: number }> | null): Record<string, number> | null =>
+const mapNewsAvailableLanguages = (json: Record<string, { id: string }> | null): Record<string, string> | null =>
   json
     ? Object.entries(json).reduce(
         (availableLanguages, [code, value]) => ({ ...availableLanguages, [code]: value.id }),

--- a/shared/src/api/models/NewsModel.ts
+++ b/shared/src/api/models/NewsModel.ts
@@ -4,19 +4,19 @@ import { DateTime } from 'luxon'
 import { NewsSource } from '../constants/index.ts'
 
 class NewsModel {
-  _id: number
   _title: string
   _content: string
   _source: NewsSource
   _lastUpdate: DateTime
-  _availableLanguages: Record<string, number> | null
+  _externalUrl: string
+
   constructor(params: {
-    id: number
+    id: string
     title: string
     content: string
     lastUpdate: DateTime
     source: NewsSource
-    availableLanguages: Record<string, number> | null
+    availableLanguages: Record<string, string> | null
     externalUrl: string
   }) {
     this._id = params.id
@@ -28,11 +28,13 @@ class NewsModel {
     this._externalUrl = params.externalUrl
   }
 
-  _externalUrl: string
+  _id: string
 
-  get id(): number {
+  get id(): string {
     return this._id
   }
+
+  _availableLanguages: Record<string, string> | null
 
   get title(): string {
     return this._title
@@ -50,7 +52,7 @@ class NewsModel {
     return this._lastUpdate
   }
 
-  get availableLanguages(): Record<string, number> | null {
+  get availableLanguages(): Record<string, string> | null {
     return this._availableLanguages
   }
 

--- a/shared/src/api/types.ts
+++ b/shared/src/api/types.ts
@@ -150,13 +150,13 @@ export type JsonEventType = {
 }
 
 export type JsonNewsType = {
-  id: number
+  id: string
   title: string
   content: string
   display_date: string
   source: NewsSource
   externalUrl: string
-  available_languages: Record<string, { id: number }> | null
+  available_languages: Record<string, { id: string }> | null
 }
 
 export type JsonOfferPostType = {

--- a/shared/src/routes/InternalPathnameParser.ts
+++ b/shared/src/routes/InternalPathnameParser.ts
@@ -154,7 +154,7 @@ class InternalPathnameParser {
       route: NEWS_ROUTE,
       regionCode: this._parts[0]!,
       languageCode: this._parts[1]!,
-      id: id ? parseInt(id, 10) : undefined,
+      id,
     }
   }
 

--- a/shared/src/routes/RouteInformationTypes.ts
+++ b/shared/src/routes/RouteInformationTypes.ts
@@ -50,7 +50,7 @@ export type CategoriesRouteInformationType = ParamsType & {
 
 export type NewsRouteInformationType = ParamsType & {
   route: NewsRouteType
-  id?: number
+  id?: string
 }
 
 export type SimpleRegionContentFeatureType = ParamsType & {

--- a/shared/src/routes/__tests__/InternalPathnameParser.spec.ts
+++ b/shared/src/routes/__tests__/InternalPathnameParser.spec.ts
@@ -210,11 +210,11 @@ describe('InternalPathnameParser', () => {
   })
 
   it('should match local news detail route', () => {
-    const pathname = `/${regionCode}/${languageCode}/${NEWS_ROUTE}/1234`
+    const pathname = `/${regionCode}/${languageCode}/${NEWS_ROUTE}/local-1234`
     const parser = new InternalPathnameParser(pathname, languageCode, null)
     expect(parser.route()).toEqual({
       route: NEWS_ROUTE,
-      id: 1234,
+      id: 'local-1234',
       languageCode,
       regionCode,
     })
@@ -395,11 +395,11 @@ describe('InternalPathnameParser', () => {
     })
 
     it('should match local news detail route', () => {
-      const pathname = `/${fixedRegion}/${languageCode}/${NEWS_ROUTE}/1234`
+      const pathname = `/${fixedRegion}/${languageCode}/${NEWS_ROUTE}/local-1234`
       const parser = new InternalPathnameParser(pathname, languageCode, fixedRegion)
       expect(parser.route()).toEqual({
         route: NEWS_ROUTE,
-        id: 1234,
+        id: 'local-1234',
         languageCode,
         regionCode: fixedRegion,
       })

--- a/shared/src/routes/__tests__/pathname.spec.ts
+++ b/shared/src/routes/__tests__/pathname.spec.ts
@@ -152,11 +152,11 @@ describe('pathname', () => {
       expect(
         pathnameFromRouteInformation({
           route: NEWS_ROUTE,
-          id: 1234,
+          id: 'local-1234',
           languageCode,
           regionCode,
         }),
-      ).toBe(`/${regionCode}/${languageCode}/${NEWS_ROUTE}/1234`)
+      ).toBe(`/${regionCode}/${languageCode}/${NEWS_ROUTE}/local-1234`)
     })
 
     it('should match categories route', () => {

--- a/web/src/components/__tests__/NewsListItem.spec.tsx
+++ b/web/src/components/__tests__/NewsListItem.spec.tsx
@@ -22,12 +22,12 @@ describe('NewsListItem', () => {
   const lastUpdate = DateTime.fromISO('2020-03-20T17:50:00.000Z')
   const buildNews = (source: NewsSource) =>
     new NewsModel({
-      id: 217,
+      id: 'local-217',
       title: 'Tick bite - What to do?',
       lastUpdate,
       content:
         'In summer there are often ticks in forest and meadows with high grass. These are very small animals. They feed on the blood of people or animals they sting, like mosquitoes. But they stay in the skin longer and can transmit dangerous diseases. If you have been in high grass, you should search your body very thoroughly for ticks. They like to sit in the knees, armpits or in the groin area. If you discover a tick in your skin, you should carefully pull it out with tweezers without crushing it. If the sting inflames, you must see a doctor.',
-      availableLanguages: { de: 123, it: 234 },
+      availableLanguages: { de: 'local-123', it: 'local-234' },
       externalUrl: 'https://example.com',
       source,
     })
@@ -55,7 +55,7 @@ describe('NewsListItem', () => {
 
   it('should link to the news detail page', () => {
     const { getByRole } = renderWithRouterAndTheme(<NewsListItem news={news} languageCode='de' regionCode='augsburg' />)
-    expect(getByRole('link')).toHaveProperty('href', 'http://localhost/augsburg/de/news/217')
+    expect(getByRole('link')).toHaveProperty('href', 'http://localhost/augsburg/de/news/local-217')
   })
 
   it.each([

--- a/web/src/routes/CategoriesPage.tsx
+++ b/web/src/routes/CategoriesPage.tsx
@@ -144,7 +144,7 @@ const CategoriesPage = ({ region, pathname, regionCode, languageCode }: RegionRo
     const isCurrentLanguage = code === languageCode
     const path = category?.isRoot()
       ? regionContentPath({ regionCode, languageCode: code })
-      : category?.availableLanguages[code] || null
+      : (category?.availableLanguages[code] ?? null)
 
     return {
       path: isCurrentLanguage ? pathname : path,

--- a/web/src/routes/EventsPage.tsx
+++ b/web/src/routes/EventsPage.tsx
@@ -59,13 +59,13 @@ const EventsPage = ({ region, pathname, languageCode, regionCode }: RegionRouteP
 
   const languageChangePaths = region.languages.map(({ code, name }) => {
     const isCurrentLanguage = code === languageCode
-    const path =
-      event?.availableLanguages[code] ??
-      pathnameFromRouteInformation({
-        route: EVENTS_ROUTE,
-        regionCode,
-        languageCode: code,
-      })
+    const path = event
+      ? (event.availableLanguages[code] ?? null)
+      : pathnameFromRouteInformation({
+          route: EVENTS_ROUTE,
+          regionCode,
+          languageCode: code,
+        })
     return {
       path: isCurrentLanguage ? pathname : path,
       name,

--- a/web/src/routes/NewsDetailPage.tsx
+++ b/web/src/routes/NewsDetailPage.tsx
@@ -37,19 +37,15 @@ const NewsDetailPage = ({ region, pathname, regionCode, languageCode }: RegionRo
 
   const pageTitle = `${news?.title ?? t('news')} - ${region.name}`
 
-  const languageChangePaths = region.languages.map(({ code, name }) => ({
-    path:
-      code === languageCode
-        ? pathname
-        : pathnameFromRouteInformation({
-            route: NEWS_ROUTE,
-            regionCode,
-            languageCode: code,
-            id: news?.availableLanguages?.[code],
-          }),
-    name,
-    code,
-  }))
+  const languageChangePaths = region.languages.map(({ code, name }) => {
+    const id = news?.availableLanguages?.[code]
+    const path = id ? pathnameFromRouteInformation({ route: NEWS_ROUTE, regionCode, languageCode: code, id }) : null
+    return {
+      path: code === languageCode ? pathname : path,
+      name,
+      code,
+    }
+  })
 
   const locationLayoutParams: Omit<RegionContentLayoutProps, 'isLoading'> = {
     region,

--- a/web/src/routes/PlacesPage.tsx
+++ b/web/src/routes/PlacesPage.tsx
@@ -34,13 +34,13 @@ const PlacesPage = ({ regionCode, languageCode, region, pathname }: RegionRouteP
 
   const languageChangePaths = region.languages.map(({ code, name }) => {
     const isCurrentLanguage = code === languageCode
-    const path =
-      place?.availableLanguages[code] ??
-      pathnameFromRouteInformation({
-        route: PLACES_ROUTE,
-        regionCode,
-        languageCode: code,
-      })
+    const path = place
+      ? (place.availableLanguages[code] ?? null)
+      : pathnameFromRouteInformation({
+          route: PLACES_ROUTE,
+          regionCode,
+          languageCode: code,
+        })
     return {
       path: isCurrentLanguage ? pathname : path,
       name,

--- a/web/src/routes/__tests__/EventsPage.spec.tsx
+++ b/web/src/routes/__tests__/EventsPage.spec.tsx
@@ -1,0 +1,86 @@
+import { fireEvent } from '@testing-library/react'
+import React from 'react'
+
+import { EVENTS_ROUTE, pathnameFromRouteInformation } from 'shared'
+import { EventModelBuilder, RegionModelBuilder } from 'shared/api'
+
+import {
+  mockUseQueryFromEndpointWithData,
+  mockUseQueryFromEndpointWithError,
+} from '../../testing/mockUseQueryFromEndpoint'
+import { renderRoute } from '../../testing/render'
+import EventsPage from '../EventsPage'
+import { RoutePatterns } from '../index'
+
+jest.mock('react-i18next')
+jest.mock('../../hooks/useQueryFromEndpoint')
+jest.mock('../../hooks/useTtsPlayer', () => jest.fn())
+jest.mock('../../hooks/useJsonLd', () => jest.fn())
+jest.mock('../../components/EventList', () => () => null)
+jest.mock('../../components/RegionContentToolbar', () => () => null)
+
+describe('EventsPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  const region = new RegionModelBuilder(1).build()[0]!
+  const languageCode = 'de'
+  const arabicName = 'اَللُّغَةُ اَلْعَرَبِيَّة'
+  const events = new EventModelBuilder('seed', 2, region.code, languageCode).build()
+  const eventsPathname = pathnameFromRouteInformation({ route: EVENTS_ROUTE, regionCode: region.code, languageCode })
+  const routePattern = `/:regionCode/:languageCode/${RoutePatterns[EVENTS_ROUTE]}`
+  const detailRoutePattern = `${routePattern}/:eventId`
+
+  const renderOverview = () =>
+    renderRoute(
+      <EventsPage region={region} pathname={eventsPathname} regionCode={region.code} languageCode={languageCode} />,
+      { pathname: eventsPathname, routePattern },
+    )
+
+  const renderDetail = (pathname: string) =>
+    renderRoute(
+      <EventsPage region={region} pathname={pathname} regionCode={region.code} languageCode={languageCode} />,
+      { pathname, routePattern: detailRoutePattern },
+    )
+
+  it('should render failure switcher on error', () => {
+    mockUseQueryFromEndpointWithError('something went wrong')
+    const { getByText } = renderOverview()
+
+    expect(getByText('error:unknownError')).toBeTruthy()
+  })
+
+  it('should render nothing when region is missing', () => {
+    mockUseQueryFromEndpointWithData(events)
+    const { container } = renderRoute(
+      <EventsPage region={null} pathname={eventsPathname} regionCode={region.code} languageCode={languageCode} />,
+      { pathname: eventsPathname, routePattern },
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('should link to all languages if no event is selected', () => {
+    mockUseQueryFromEndpointWithData(events)
+    const { getAllByText, getByRole } = renderOverview()
+    fireEvent.click(getByRole('button', { name: 'layout:changeLanguage' }))
+
+    expect(getAllByText('English')[0]?.closest('a')).toHaveAttribute('href', `/${region.code}/en/${EVENTS_ROUTE}`)
+    expect(getAllByText(arabicName)[0]?.closest('a')).toHaveAttribute('href', `/${region.code}/ar/${EVENTS_ROUTE}`)
+    expect(getAllByText('Español')[0]?.closest('a')).toHaveAttribute('href', `/${region.code}/es/${EVENTS_ROUTE}`)
+    expect(getAllByText('Deutsch')[1]?.closest('a')).toHaveAttribute('href', eventsPathname)
+  })
+
+  it('should link only to languages with available translations', () => {
+    mockUseQueryFromEndpointWithData(events)
+    const event = events[0]!
+    const { getAllByText, getByRole } = renderDetail(event.path)
+    fireEvent.click(getByRole('button', { name: 'layout:changeLanguage' }))
+
+    expect(getAllByText('English')[0]?.closest('a')).toHaveAttribute('href', event.availableLanguages.en!)
+    expect(getAllByText(arabicName)[0]?.closest('a')).toHaveAttribute('href', event.availableLanguages.ar!)
+    expect(getAllByText('Español')[0]?.closest('a')).toBeNull()
+    expect(getAllByText('Deutsch')[1]?.closest('a')).toHaveAttribute('href', event.path)
+  })
+})

--- a/web/src/routes/__tests__/NewsDetailPage.spec.tsx
+++ b/web/src/routes/__tests__/NewsDetailPage.spec.tsx
@@ -31,7 +31,7 @@ describe('NewsDetailPage', () => {
 
   const region = new RegionModelBuilder(1).build()[0]!
   const languageCode = 'de'
-  const newsId = 217
+  const newsId = 'local-217'
 
   const buildNews = (source: NewsSource) =>
     new NewsModel({
@@ -40,7 +40,7 @@ describe('NewsDetailPage', () => {
       content: '<p>News body</p>',
       source,
       lastUpdate: DateTime.fromISO('2023-03-20T17:50:00.000Z'),
-      availableLanguages: { de: newsId, en: 42 },
+      availableLanguages: { de: newsId, en: 'local-42' },
       externalUrl: 'https://external.example.com',
     })
 

--- a/web/src/routes/__tests__/NewsDetailPage.spec.tsx
+++ b/web/src/routes/__tests__/NewsDetailPage.spec.tsx
@@ -1,3 +1,4 @@
+import { fireEvent } from '@testing-library/react'
 import { DateTime } from 'luxon'
 import React from 'react'
 
@@ -22,7 +23,6 @@ import { NEWS_DETAIL_ROUTE, RoutePatterns } from '../index'
 jest.mock('react-i18next')
 jest.mock('../../hooks/useQueryFromEndpoint')
 jest.mock('../../hooks/useTtsPlayer', () => jest.fn())
-jest.mock('../../components/RegionContentHeader', () => () => null)
 
 describe('NewsDetailPage', () => {
   beforeEach(() => {
@@ -32,6 +32,7 @@ describe('NewsDetailPage', () => {
   const region = new RegionModelBuilder(1).build()[0]!
   const languageCode = 'de'
   const newsId = 'local-217'
+  const arabicName = 'اَللُّغَةُ اَلْعَرَبِيَّة'
 
   const buildNews = (source: NewsSource) =>
     new NewsModel({
@@ -103,5 +104,26 @@ describe('NewsDetailPage', () => {
       { pathname, routePattern },
     )
     expect(container).toBeEmptyDOMElement()
+  })
+
+  it('should link only to languages with available translations', () => {
+    mockUseQueryFromEndpointWithData(buildNews(LOCAL_NEWS_SOURCE))
+    const { getAllByText, getByRole } = renderDetail()
+    fireEvent.click(getByRole('button', { name: 'layout:changeLanguage' }))
+
+    expect(getAllByText('English')[0]?.closest('a')).toHaveAttribute(
+      'href',
+      `/${region.code}/en/${NEWS_ROUTE}/local-42`,
+    )
+    expect(getAllByText(arabicName)[0]?.closest('a')).toBeNull()
+  })
+
+  it('should not link to other languages while news is loading', () => {
+    mockUseQueryFromEndpointWithData(undefined)
+    const { getAllByText, getByRole } = renderDetail()
+    fireEvent.click(getByRole('button', { name: 'layout:changeLanguage' }))
+
+    expect(getAllByText('English')[0]?.closest('a')).toBeNull()
+    expect(getAllByText(arabicName)[0]?.closest('a')).toBeNull()
   })
 })

--- a/web/src/routes/__tests__/NewsPage.spec.tsx
+++ b/web/src/routes/__tests__/NewsPage.spec.tsx
@@ -21,11 +21,11 @@ jest.mock('../../hooks/useQueryFromEndpoint')
 
 const news = [
   new NewsModel({
-    id: 42,
+    id: 'local-42',
     title: 'sample news title',
     content: 'sample news content',
     lastUpdate: DateTime.fromISO('2023-01-01T00:00:00.000Z'),
-    availableLanguages: { de: 43 },
+    availableLanguages: { de: 'local-43' },
     externalUrl: 'https://example.com',
     source: 'local',
   }),

--- a/web/src/routes/__tests__/PlacesPage.spec.tsx
+++ b/web/src/routes/__tests__/PlacesPage.spec.tsx
@@ -35,7 +35,7 @@ describe('PlacesPage', () => {
 
   const pathname = regionContentPath({ route: PLACES_ROUTE, regionCode: region.code, languageCode })
 
-  const renderPlaces = (path?: string) =>
+  const renderPlaces = (path?: string, currentLanguageCode: string = languageCode) =>
     renderWithRouterAndTheme(
       <Routes>
         <Route
@@ -44,7 +44,7 @@ describe('PlacesPage', () => {
             <PlacesPage
               region={region}
               pathname={path ?? pathname}
-              languageCode={languageCode}
+              languageCode={currentLanguageCode}
               regionCode={region.code}
             />
           }>
@@ -83,5 +83,26 @@ describe('PlacesPage', () => {
 
     expect(getAllByText('English')[0]?.closest('a')).toHaveAttribute('href', place0.availableLanguages.en)
     expect(getAllByText('Deutsch')[0]?.closest('a')).toHaveAttribute('href', place0.availableLanguages.de)
+  })
+
+  it('should link only to languages with available translations if a place is selected', () => {
+    mockUseQueryFromEndpointWithData(places)
+    const { getAllByText, getByRole } = renderPlaces('/places/test', 'de')
+    fireEvent.click(getByRole('button', { name: 'layout:changeLanguage' }))
+
+    const arabicLanguageName = 'اَللُّغَةُ اَلْعَرَبِيَّة'
+    expect(getAllByText(arabicLanguageName)[0]?.closest('a')).toBeNull()
+  })
+
+  it('should link to all languages if no place is selected', () => {
+    mockUseQueryFromEndpointWithData(places)
+    const { getAllByText, getByRole } = renderPlaces('/places', 'de')
+    fireEvent.click(getByRole('button', { name: 'layout:changeLanguage' }))
+
+    const arabicLanguageName = 'اَللُّغَةُ اَلْعَرَبِيَّة'
+    expect(getAllByText(arabicLanguageName)[0]?.closest('a')).toHaveAttribute(
+      'href',
+      `/${region.code}/ar/${PLACES_ROUTE}`,
+    )
   })
 })


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
<!-- Make sure to correctly set PR labels if necessary: `Native`/`Web` for native/web only PRs and `maintenance` for non-user-facing changes. -->
We forgot to change the news ids from number to string and assemble the correct path for push notifications in #4260 and #4262. This PR fixes that.
On top, this PR prevents falsely showing languages as available and linking to the news list.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Adjust types and tests for string-based news ids
- Fix id/path for push notifications
- Fix falsely showing languages as available for news (and events and places)

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Checklist

- [x] Followed the [contributing guidelines](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md) and [conventions](https://github.com/digitalfabrik/integreat-app/blob/main/docs/conventions.md)
- [ ] Considered accessibility impacts and made the necessary adjustments
- [x] Added or updated unit tests (if applicable)
- [ ] Added or updated documentation (if applicable)
- [ ] Added a [release note](https://github.com/digitalfabrik/integreat-app/tree/main/release-notes) for native (if [applicable](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes))

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Go to http://localhost:9001/testumgebung/de/news/tunews-74316 and try to change the language (web).
Send a push notification and click on it and get to the news detail (native).

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2537

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
