### PR TITLE
2004: Support versioned category URLs

### DIFF
--- a/native/src/components/__tests__/EmbeddedOffers.spec.tsx
+++ b/native/src/components/__tests__/EmbeddedOffers.spec.tsx
@@ -31,6 +31,7 @@ describe('EmbeddedOffers', () => {
       lastUpdate: DateTime.fromISO('2024-08-15T10:47:34+02:00'),
       organization: null,
       embeddedOffers: [offer],
+      slugHistory: [],
     })
 
   const renderEmbeddedOffers = (category: CategoryModel) =>

--- a/native/src/constants/database.ts
+++ b/native/src/constants/database.ts
@@ -1,6 +1,6 @@
 import BlobUtil from 'react-native-blob-util'
 
-export const CONTENT_VERSION = 'v13'
+export const CONTENT_VERSION = 'v14'
 export const RESOURCE_CACHE_VERSION = 'v4'
 
 // Our pdf view can only load from DocumentDir. Therefore we need to use that

--- a/native/src/routes/CategoriesContainer.tsx
+++ b/native/src/routes/CategoriesContainer.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useCallback, useMemo } from 'react'
 
-import { CATEGORIES_ROUTE, CategoriesRouteType, regionContentPath } from 'shared'
+import { CATEGORIES_ROUTE, CategoriesRouteType, getSlugFromPath, regionContentPath } from 'shared'
 import { ErrorCodes } from 'shared/api'
 import { config } from 'translations'
 
@@ -29,7 +29,12 @@ const CategoriesContainer = ({ navigation, route }: CategoriesContainerProps): R
   useLoadRegionContent({ regionCode, languageCode: config.sourceLanguage })
 
   const path = route.params.path ?? regionContentPath({ regionCode, languageCode })
-  const category = useMemo(() => data?.categories.findCategoryByPath(path), [data?.categories, path])
+  const category = useMemo(
+    () =>
+      data?.categories.findCategoryByPath(path) ??
+      data?.categories.toArray().find(category => category.slugHistory.includes(getSlugFromPath(path))),
+    [data?.categories, path],
+  )
   const availableLanguages =
     category && !category.isRoot() ? Object.keys(category.availableLanguages) : data?.languages.map(it => it.code)
 
@@ -37,7 +42,7 @@ const CategoriesContainer = ({ navigation, route }: CategoriesContainerProps): R
     route: CATEGORIES_ROUTE,
     languageCode,
     regionCode,
-    regionContentPath: path,
+    regionContentPath: category?.path ?? path,
   })
   useHeader({ navigation, route, availableLanguages, data, shareUrl })
   useSetRouteTitle({ navigation, title: category?.isRoot() ? data?.region.name : category?.title })

--- a/native/src/routes/__tests__/CategoriesContainer.spec.tsx
+++ b/native/src/routes/__tests__/CategoriesContainer.spec.tsx
@@ -1,0 +1,234 @@
+import { render } from '@testing-library/react-native'
+import React from 'react'
+
+import { CATEGORIES_ROUTE, CategoriesRouteType } from 'shared'
+import {
+  CategoriesMapModel,
+  CategoriesMapModelBuilder,
+  CategoryModel,
+  LanguageModelBuilder,
+  RegionModelBuilder,
+} from 'shared/api'
+
+import useHeader from '../../hooks/useHeader'
+import useLoadRegionContent from '../../hooks/useLoadRegionContent'
+import TestingAppContext from '../../testing/TestingAppContext'
+import createNavigationPropMock from '../../testing/createNavigationPropMock'
+import wrapWithTheme from '../../testing/wrapWithTheme'
+import urlFromRouteInformation from '../../utils/url'
+import CategoriesContainer from '../CategoriesContainer'
+
+jest.mock('@react-native-community/netinfo')
+jest.mock('../../utils/FetcherModule')
+jest.mock('../../hooks/useLoadRegionContent')
+jest.mock('../../hooks/useHeader')
+jest.mock('../../hooks/useSetRouteTitle')
+jest.mock('../../hooks/useNavigate', () => () => ({
+  navigateTo: jest.fn(),
+  navigation: { canGoBack: () => false, goBack: jest.fn() },
+}))
+jest.mock('../../utils/url', () => ({
+  __esModule: true,
+  default: jest.fn(() => 'https://example.com'),
+}))
+jest.mock('../../components/Categories', () => {
+  const { Text } = require('react-native')
+  return ({ category }: { category: { path: string; title: string; isRoot: () => boolean } }) => (
+    <Text>{`category:${category.path}`}</Text>
+  )
+})
+
+const { mocked } = jest
+
+const regionCode = 'augsburg'
+const languageCode = 'de'
+const region = new RegionModelBuilder(1).build()[0]!
+const languages = new LanguageModelBuilder(2).build()
+const categories = new CategoriesMapModelBuilder(regionCode, languageCode, 1, 1).build()
+
+const buildData = (categoriesMap: CategoriesMapModel = categories) => ({
+  regions: [region],
+  languages,
+  region,
+  language: languages[0]!,
+  categories: categoriesMap,
+  events: [],
+  places: [],
+  news: [],
+})
+
+const createRoute = (params: { path?: string } = {}) => ({
+  key: 'route-key',
+  name: CATEGORIES_ROUTE,
+  params,
+})
+
+const buildCategoryWithSlugHistory = (slugHistory: string[]): CategoryModel =>
+  new CategoryModel({
+    root: false,
+    path: `/${regionCode}/${languageCode}/current-slug`,
+    title: 'Renamed Category',
+    content: '',
+    thumbnail: '',
+    parentPath: `/${regionCode}/${languageCode}`,
+    order: 0,
+    availableLanguages: { en: `/${regionCode}/en/current-slug-en` },
+    lastUpdate: categories.toArray()[0]!.lastUpdate,
+    organization: null,
+    embeddedOffers: [],
+    slugHistory,
+  })
+
+describe('CategoriesContainer', () => {
+  const navigation = createNavigationPropMock<CategoriesRouteType>()
+
+  const renderContainer = (params: { path?: string } = {}, contextProps: { languageCode?: string } = {}) =>
+    render(
+      <TestingAppContext regionCode={regionCode} languageCode={languageCode} {...contextProps}>
+        <CategoriesContainer route={createRoute(params)} navigation={navigation} />
+      </TestingAppContext>,
+      { wrapper: wrapWithTheme },
+    )
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mocked(useLoadRegionContent).mockReturnValue({
+      data: buildData(),
+      loading: false,
+      error: null,
+      refresh: jest.fn(),
+    })
+  })
+
+  it('should render root category when no path is provided', () => {
+    const { getByText } = renderContainer()
+    expect(getByText(`category:/${regionCode}/${languageCode}`)).toBeTruthy()
+  })
+
+  it('should render category matched by path', () => {
+    const child = categories.toArray().find(it => !it.isRoot())!
+    const { getByText } = renderContainer({ path: child.path })
+    expect(getByText(`category:${child.path}`)).toBeTruthy()
+  })
+
+  it('should render category matched by slugHistory when path does not match directly', () => {
+    const previousSlug = 'legacy-slug'
+    const renamedCategory = buildCategoryWithSlugHistory([previousSlug])
+    const categoriesWithSlugHistory = new CategoriesMapModel([categories.toArray()[0]!, renamedCategory])
+    mocked(useLoadRegionContent).mockReturnValue({
+      data: buildData(categoriesWithSlugHistory),
+      loading: false,
+      error: null,
+      refresh: jest.fn(),
+    })
+
+    const { getByText } = renderContainer({ path: `/${regionCode}/${languageCode}/${previousSlug}` })
+
+    expect(getByText(`category:${renamedCategory.path}`)).toBeTruthy()
+  })
+
+  it('should show PageNotFound error when no category is found for the path', () => {
+    const { getByText, queryByText } = renderContainer({
+      path: `/${regionCode}/${languageCode}/does-not-exist`,
+    })
+
+    expect(queryByText(/^category:/)).toBeNull()
+    expect(getByText('error:pageNotFound')).toBeTruthy()
+  })
+
+  it('should pass the resolved category path as regionContentPath to the share url', () => {
+    const previousSlug = 'legacy-slug'
+    const renamedCategory = buildCategoryWithSlugHistory([previousSlug])
+    const categoriesWithSlugHistory = new CategoriesMapModel([categories.toArray()[0]!, renamedCategory])
+    mocked(useLoadRegionContent).mockReturnValue({
+      data: buildData(categoriesWithSlugHistory),
+      loading: false,
+      error: null,
+      refresh: jest.fn(),
+    })
+
+    renderContainer({ path: `/${regionCode}/${languageCode}/${previousSlug}` })
+
+    expect(urlFromRouteInformation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        route: CATEGORIES_ROUTE,
+        regionCode,
+        languageCode,
+        regionContentPath: renamedCategory.path,
+      }),
+    )
+  })
+
+  it('should fall back to the requested path in the share url when no category is found', () => {
+    const path = `/${regionCode}/${languageCode}/unknown-slug`
+    renderContainer({ path })
+
+    expect(urlFromRouteInformation).toHaveBeenCalledWith(expect.objectContaining({ regionContentPath: path }))
+  })
+
+  it('should pass all region languages to the header when viewing the root category', () => {
+    renderContainer()
+
+    expect(useHeader).toHaveBeenCalledWith(
+      expect.objectContaining({ availableLanguages: languages.map(it => it.code) }),
+    )
+  })
+
+  it('should pass the category available languages to the header when viewing a specific category', () => {
+    const renamedCategory = buildCategoryWithSlugHistory([])
+    const categoriesWithLanguages = new CategoriesMapModel([categories.toArray()[0]!, renamedCategory])
+    mocked(useLoadRegionContent).mockReturnValue({
+      data: buildData(categoriesWithLanguages),
+      loading: false,
+      error: null,
+      refresh: jest.fn(),
+    })
+
+    renderContainer({ path: renamedCategory.path })
+
+    expect(useHeader).toHaveBeenCalledWith(
+      expect.objectContaining({
+        availableLanguages: Object.keys(renamedCategory.availableLanguages),
+      }),
+    )
+  })
+
+  it('should update the route path via navigation.setParams when the language changes', () => {
+    const renamedCategory = buildCategoryWithSlugHistory([])
+    const categoriesWithLanguages = new CategoriesMapModel([categories.toArray()[0]!, renamedCategory])
+    mocked(useLoadRegionContent).mockReturnValue({
+      data: buildData(categoriesWithLanguages),
+      loading: false,
+      error: null,
+      refresh: jest.fn(),
+    })
+
+    const fixedRoute = createRoute({ path: renamedCategory.path })
+    const { rerender } = render(
+      <TestingAppContext regionCode={regionCode} languageCode='de'>
+        <CategoriesContainer route={fixedRoute} navigation={navigation} />
+      </TestingAppContext>,
+      { wrapper: wrapWithTheme },
+    )
+
+    rerender(
+      <TestingAppContext regionCode={regionCode} languageCode='en'>
+        <CategoriesContainer route={fixedRoute} navigation={navigation} />
+      </TestingAppContext>,
+    )
+
+    expect(navigation.setParams).toHaveBeenCalledWith({ path: renamedCategory.availableLanguages.en })
+  })
+
+  it('should not render categories while loading', () => {
+    mocked(useLoadRegionContent).mockReturnValue({
+      data: null,
+      loading: true,
+      error: null,
+      refresh: jest.fn(),
+    })
+
+    const { queryByText } = renderContainer()
+    expect(queryByText('category', { exact: false })).toBeNull()
+  })
+})

--- a/native/src/utils/DatabaseConnector.ts
+++ b/native/src/utils/DatabaseConnector.ts
@@ -56,6 +56,7 @@ type ContentCategoryJsonType = {
   order: number
   organization: OrganizationJsonType | null
   embeddedOffers: OfferJsonType[]
+  slugHistory: string[]
 }
 
 type OfferJsonType = {
@@ -454,6 +455,7 @@ class DatabaseConnector {
         thumbnail: offer.thumbnail,
         path: offer.path,
       })),
+      slugHistory: category.slugHistory,
     }))
     await this.writeFile(this.getContentPath('categories', context), JSON.stringify(jsonModels))
   }
@@ -491,6 +493,7 @@ class DatabaseConnector {
                     path: jsonOffer.path,
                   }),
               ),
+              slugHistory: jsonObject.slugHistory,
             }),
         ),
       )

--- a/shared/src/api/endpoints/__tests__/createCategoriesEndpoint.spec.ts
+++ b/shared/src/api/endpoints/__tests__/createCategoriesEndpoint.spec.ts
@@ -34,6 +34,7 @@ describe('createCategoriesEndpoint', () => {
     lastUpdate: DateTime.fromMillis(0),
     organization: null,
     embeddedOffers: [],
+    slugHistory: [],
   })
   const endpoint = createCategoriesEndpoint(baseUrl)
 

--- a/shared/src/api/endpoints/__tests__/createCategoryParentsEndpoint.spec.ts
+++ b/shared/src/api/endpoints/__tests__/createCategoryParentsEndpoint.spec.ts
@@ -34,6 +34,7 @@ describe('createCategoryParentsEndpoint', () => {
     lastUpdate: DateTime.fromMillis(0),
     organization: null,
     embeddedOffers: [],
+    slugHistory: [],
   })
   const endpoint = createCategoryParentsEndpoint(baseUrl)
 

--- a/shared/src/api/endpoints/createCategoriesEndpoint.ts
+++ b/shared/src/api/endpoints/createCategoriesEndpoint.ts
@@ -34,6 +34,7 @@ export default (baseUrl: string): Endpoint<ParamsType, CategoriesMapModel> =>
           lastUpdate: DateTime.fromMillis(0),
           organization: null,
           embeddedOffers: [],
+          slugHistory: [],
         }),
       )
       return new CategoriesMapModel(categories)

--- a/shared/src/api/endpoints/createCategoryParentsEndpoint.ts
+++ b/shared/src/api/endpoints/createCategoryParentsEndpoint.ts
@@ -41,6 +41,7 @@ export default (baseUrl: string): Endpoint<ParamsType, CategoryModel[]> =>
           lastUpdate: DateTime.fromMillis(0),
           organization: null,
           embeddedOffers: [],
+          slugHistory: [],
         }),
       )
       return parents

--- a/shared/src/api/endpoints/testing/CategoriesMapModelBuilder.ts
+++ b/shared/src/api/endpoints/testing/CategoriesMapModelBuilder.ts
@@ -88,6 +88,7 @@ class CategoriesMapModelBuilder {
           logo: 'https://example.com/my-icon',
           url: 'https://example.com',
         }),
+        slugHistory: [`category_${i}`],
         embeddedOffers:
           id === 1
             ? [
@@ -146,6 +147,7 @@ class CategoriesMapModelBuilder {
         lastUpdate: DateTime.fromISO('2017-11-18T19:30:00.000Z'),
         organization: null,
         embeddedOffers: [],
+        slugHistory: [],
       }),
       0,
     )

--- a/shared/src/api/mapping/__tests__/mapCategoryJson.spec.ts
+++ b/shared/src/api/mapping/__tests__/mapCategoryJson.spec.ts
@@ -31,6 +31,7 @@ describe('categories', () => {
     last_updated: '2017-01-01T05:10:05+02:00',
     organization: null,
     embedded_offers: [],
+    slug_history: ['anlaufstellen-old', 'anlaufstellen'],
   }
   const categoryJson2 = {
     id: 404,
@@ -63,6 +64,7 @@ describe('categories', () => {
       logo: 'https://example.com/my-icon',
       website: 'https://example.com',
     },
+    slug_history: ['نقشه-شهر'],
     embedded_offers: [
       {
         alias: 'serlo-abc',
@@ -119,6 +121,7 @@ describe('categories', () => {
     lastUpdate: DateTime.fromISO('2017-01-01T05:10:05+02:00'),
     organization: null,
     embeddedOffers: [],
+    slugHistory: ['anlaufstellen-old', 'anlaufstellen'],
   })
   const categoryModel2 = new CategoryModel({
     root: false,
@@ -136,6 +139,7 @@ describe('categories', () => {
       url: 'https://example.com',
     }),
     embeddedOffers: offerModels,
+    slugHistory: ['نقشه-شهر'],
   })
 
   it('should map json correctly', () => {

--- a/shared/src/api/mapping/mapCategoryJson.ts
+++ b/shared/src/api/mapping/mapCategoryJson.ts
@@ -33,6 +33,7 @@ const mapCategoryJson = (json: JsonCategoryType, basePath: string): CategoryMode
           thumbnail: offer.thumbnail,
         }),
     ),
+    slugHistory: json.slug_history,
   })
 
 export default mapCategoryJson

--- a/shared/src/api/models/CategoryModel.ts
+++ b/shared/src/api/models/CategoryModel.ts
@@ -12,7 +12,6 @@ class CategoryModel extends ExtendedDocumentModel {
   _order: number
   _organization: OrganizationModel | null
   _embeddedOffers: OfferModel[]
-
   constructor(params: {
     root: boolean
     path: string
@@ -25,15 +24,19 @@ class CategoryModel extends ExtendedDocumentModel {
     lastUpdate: DateTime
     organization: OrganizationModel | null
     embeddedOffers: OfferModel[]
+    slugHistory: string[]
   }) {
-    const { order, parentPath, root, organization, embeddedOffers, ...other } = params
+    const { order, parentPath, root, organization, embeddedOffers, slugHistory, ...other } = params
     super(other)
     this._root = root
     this._parentPath = normalizePath(parentPath)
     this._order = order
     this._organization = organization
     this._embeddedOffers = embeddedOffers
+    this._slugHistory = slugHistory
   }
+
+  _slugHistory: string[]
 
   get embeddedOffers(): OfferModel[] {
     return this._embeddedOffers
@@ -53,6 +56,10 @@ class CategoryModel extends ExtendedDocumentModel {
 
   get organization(): OrganizationModel | null {
     return this._organization
+  }
+
+  get slugHistory(): string[] {
+    return this._slugHistory
   }
 
   isEqual(other: DocumentModel): boolean {

--- a/shared/src/api/models/__tests__/CategoriesMapModel.spec.ts
+++ b/shared/src/api/models/__tests__/CategoriesMapModel.spec.ts
@@ -16,6 +16,7 @@ describe('CategoriesMapModel', () => {
     lastUpdate: DateTime.fromISO('2016-01-07 10:36:24'),
     organization: null,
     embeddedOffers: [],
+    slugHistory: [],
   })
   const categories = [
     new CategoryModel({
@@ -30,6 +31,7 @@ describe('CategoriesMapModel', () => {
       thumbnail: 'thumb-nail',
       organization: null,
       embeddedOffers: [],
+      slugHistory: [],
     }),
     new CategoryModel({
       root: false,
@@ -43,6 +45,7 @@ describe('CategoriesMapModel', () => {
       thumbnail: 'thumb-nail',
       organization: null,
       embeddedOffers: [],
+      slugHistory: [],
     }),
     new CategoryModel({
       root: false,
@@ -56,6 +59,7 @@ describe('CategoriesMapModel', () => {
       thumbnail: 'thumb-nail',
       organization: null,
       embeddedOffers: [],
+      slugHistory: [],
     }),
     new CategoryModel({
       root: false,
@@ -69,6 +73,7 @@ describe('CategoriesMapModel', () => {
       thumbnail: 'thumb-nail',
       organization: null,
       embeddedOffers: [],
+      slugHistory: [],
     }),
   ]
   const categoriesMapModel = new CategoriesMapModel(categories)

--- a/shared/src/api/models/__tests__/CategoryModel.spec.ts
+++ b/shared/src/api/models/__tests__/CategoryModel.spec.ts
@@ -15,6 +15,7 @@ describe('CategoryModel', () => {
     lastUpdate: DateTime.fromISO('2016-01-07 10:36:24'),
     organization: null,
     embeddedOffers: [],
+    slugHistory: [],
   })
   const category = new CategoryModel({
     root: false,
@@ -28,6 +29,7 @@ describe('CategoryModel', () => {
     lastUpdate: DateTime.fromISO('2016-01-07 10:36:24'),
     organization: null,
     embeddedOffers: [],
+    slugHistory: [],
   })
 
   it('should be conscious about being a root', () => {
@@ -48,6 +50,7 @@ describe('CategoryModel', () => {
       lastUpdate: DateTime.fromISO('2016-01-07 10:36:24'),
       organization: null,
       embeddedOffers: [],
+      slugHistory: [],
     })
     expect(normalizedCategory.path).toBe('/augsburg/fa/erste-schritte/نقشه-شهر')
     expect(normalizedCategory.parentPath).toBe('/augsburg/fa/erste-schritte')

--- a/shared/src/api/types.ts
+++ b/shared/src/api/types.ts
@@ -82,6 +82,7 @@ export type JsonCategoryType = {
   order: number
   organization: OrganizationType
   embedded_offers: JsonOfferType[]
+  slug_history: string[]
 }
 
 export type JsonChatMessageType = {

--- a/shared/src/utils/__tests__/index.spec.ts
+++ b/shared/src/utils/__tests__/index.spec.ts
@@ -84,6 +84,7 @@ describe('getCategoryTiles', () => {
         path: 'https://termine.malteapp.de/',
       }),
     ],
+    slugHistory: [],
   }
 
   it('should get category tiles', () => {

--- a/web/src/components/__tests__/CategoryListItem.spec.tsx
+++ b/web/src/components/__tests__/CategoryListItem.spec.tsx
@@ -22,6 +22,7 @@ const categoryParams = {
   lastUpdate: DateTime.fromISO('2017-11-18T19:30:00.000Z'),
   organization: null,
   embeddedOffers: [],
+  slugHistory: [],
 }
 
 const category = new CategoryModel(categoryParams)

--- a/web/src/components/__tests__/EmbeddedOffers.spec.tsx
+++ b/web/src/components/__tests__/EmbeddedOffers.spec.tsx
@@ -29,6 +29,7 @@ describe('EmbeddedOffers', () => {
       lastUpdate: DateTime.fromISO('2024-08-15T10:47:34+02:00'),
       organization: null,
       embeddedOffers: [offer],
+      slugHistory: [],
     })
 
   const renderEmbeddedOffers = (category: CategoryModel) =>

--- a/web/src/components/__tests__/PdfMenuItem.spec.tsx
+++ b/web/src/components/__tests__/PdfMenuItem.spec.tsx
@@ -23,6 +23,7 @@ const rootCategory = new CategoryModel({
   lastUpdate: DateTime.fromMillis(0),
   organization: null,
   embeddedOffers: [],
+  slugHistory: [],
 })
 
 const childCategory = new CategoryModel({
@@ -37,6 +38,7 @@ const childCategory = new CategoryModel({
   lastUpdate: DateTime.fromISO('2017-01-01T05:10:05+02:00'),
   organization: null,
   embeddedOffers: [],
+  slugHistory: [],
 })
 
 describe('PdfMenuItem', () => {

--- a/web/src/routes/CategoriesPage.tsx
+++ b/web/src/routes/CategoriesPage.tsx
@@ -97,6 +97,7 @@ const useCategoryData = (
               lastUpdate: DateTime.fromMillis(0),
               organization: null,
               embeddedOffers: [],
+              slugHistory: [],
             }),
           ]
         : rawCategories,


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
<!-- Make sure to correctly set PR labels if necessary: `Native`/`Web` for native/web only PRs and `maintenance` for non-user-facing changes. -->
Add support for opening categories with their legacy URLs after renaming/moving of a category in the CMS.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Fallback to the slug history for finding categories if matching by path fails
- Set the share url to the found categories URL (i.e. the new URL)
- Add new property `slugHistory` to the `CategoryModel`
- Bump the storage version to `v14`

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Checklist

- [x] Followed the [contributing guidelines](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md) and [conventions](https://github.com/digitalfabrik/integreat-app/blob/main/docs/conventions.md)
- [ ] Considered accessibility impacts and made the necessary adjustments
- [x] Added or updated unit tests (if applicable)
- [ ] Added or updated documentation (if applicable)
- [ ] Added a [release note](https://github.com/digitalfabrik/integreat-app/tree/main/release-notes) for native (if [applicable](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes))

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
1. Go to testumgebung > en (use the test CMS, not the production CMS)
2. Open the deeplink https://integreat.app/testumgebung/en/welcome-to in the native app (e.g. with `npx uri-scheme open "https://integreat.app/testumgebung/en/welcome-to" --android` or just opening the URL in the browser and then pressing open in app)
3. See that the `Welcome` category is opened
4. Share the URL via the menu and see that the share url is https://integreat.app/testumgebung/en/welcome (mind the missing `-to` in the end of the URL)

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2004

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
