### PR TITLE
4298: Fix chip outline on focus

### DIFF
--- a/web/src/components/ThemeContainer.tsx
+++ b/web/src/components/ThemeContainer.tsx
@@ -88,9 +88,11 @@ const createTheme = (themeType: ThemeType, contentDirection: UiDirectionType): O
                 ':hover': {
                   backgroundColor: theme.palette.background.default,
                 },
-                [`&.${chipClasses.focusVisible}`]: {
-                  backgroundColor: theme.palette.background.default,
-                },
+              },
+              [`&.${chipClasses.focusVisible}`]: {
+                outline: `2px solid ${isContrast ? theme.palette.background.accent : theme.palette.text.primary}`,
+                outlineOffset: 2,
+                backgroundColor: theme.palette.background.default,
               },
             },
           },

--- a/web/src/components/ThemeContainer.tsx
+++ b/web/src/components/ThemeContainer.tsx
@@ -90,7 +90,7 @@ const createTheme = (themeType: ThemeType, contentDirection: UiDirectionType): O
                 },
               },
               [`&.${chipClasses.focusVisible}`]: {
-                outline: `2px solid ${isContrast ? theme.palette.background.accent : theme.palette.text.primary}`,
+                outline: `2px solid ${theme.palette.tertiary.dark}`,
                 outlineOffset: 2,
                 backgroundColor: theme.palette.background.default,
               },


### PR DESCRIPTION
### Short Description

This is an additional fix PR for #4298 which re-adds outline border on focus with keyboard. Otherwise it makes it difficult to see that it is really focus on filter chip

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Add outline style and take the focus visible outside of clickable styling

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Checklist

- [x] Followed the [contributing guidelines](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md) and [conventions](https://github.com/digitalfabrik/integreat-app/blob/main/docs/conventions.md)
- [ ] Considered accessibility impacts and made the necessary adjustments
- [ ] Added or updated unit tests (if applicable)
- [ ] Added or updated documentation (if applicable)
- [ ] Added a [release note](https://github.com/digitalfabrik/integreat-app/tree/main/release-notes) for native (if [applicable](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes))

### Testing

1. Go to Maps
2. Navigate with keyboard on`Filter locations` (Also try to add a filter chip)
3. See the outline on focus

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4298

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
