### PR TITLE
4207: Fix for PrivacyCheckbox's accessibilityLabel at iOS

### DIFF
--- a/native/src/components/PrivacyCheckbox.tsx
+++ b/native/src/components/PrivacyCheckbox.tsx
@@ -1,7 +1,9 @@
 import React, { ReactElement } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
-import { StyleSheet, Platform } from 'react-native'
+import { StyleSheet } from 'react-native'
 import { Checkbox, TouchableRipple } from 'react-native-paper'
+
+import { parseHTML } from 'shared'
 
 import buildConfig from '../constants/buildConfig'
 import Link from './Link'
@@ -26,12 +28,17 @@ const PrivacyCheckbox = ({ language, checked, setChecked }: PrivacyCheckboxProps
   const { privacyUrls } = buildConfig()
   const privacyUrl = privacyUrls[language] || privacyUrls.default
   const { t } = useTranslation()
+  const accessibilityLabel = parseHTML(
+    t($ => $.common.privacyPolicy),
+    false,
+    { xmlMode: true },
+  )
   return (
     <TouchableRipple
       borderless
       onPress={() => setChecked(!checked)}
       role='checkbox'
-      accessibilityLabel={Platform.OS === 'ios' ? t($ => $.common.privacyPolicy) : undefined}
+      accessibilityLabel={accessibilityLabel}
       accessibilityState={{ checked }}
       style={styles.TouchableRippleStyle}>
       <>


### PR DESCRIPTION
### Short Description

This is a follow up PR to 4207 to fix the translations <1> tags that appears at the accessibilityLabel.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Used `parseHTML` to strip HTML tags.

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Checklist

- [X] Followed the [contributing guidelines](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md) and [conventions](https://github.com/digitalfabrik/integreat-app/blob/main/docs/conventions.md)
- [X] Considered accessibility impacts and made the necessary adjustments
- [X] Added or updated unit tests (if applicable)
- [X] Added or updated documentation (if applicable)
- [X] Added a [release note](https://github.com/digitalfabrik/integreat-app/tree/main/release-notes) for native (if [applicable](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes))

### Testing

- launch malte app.
- Activate screen reader (VoiceOver/talkback)
- Go to malte -> Malte Rostock -> LSBTIQ*
- Move focus to the checkbox (“Ich habe die Datenschutzerklärung…”)

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4207

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
