### PR TITLE
4346: Fix safe area for filter

### DIFF
--- a/native/src/components/Modal.tsx
+++ b/native/src/components/Modal.tsx
@@ -1,6 +1,6 @@
 import { ThemeProvider as NavigationThemeProvider } from '@react-navigation/native'
 import React, { ReactElement, ReactNode } from 'react'
-import { ScrollView, StyleSheet, View, Modal as RNModal, Platform } from 'react-native'
+import { ScrollView, StyleSheet, View, Modal as RNModal } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useTheme } from 'styled-components/native'
 
@@ -49,7 +49,7 @@ const Modal = ({
 
   return (
     <RNModal visible={modalVisible} transparent onRequestClose={closeModal} style={styles.modalStyle}>
-      <View style={{ flex: 1, paddingTop: Platform.OS === 'ios' ? insets.top : 0 }}>
+      <View style={{ flex: 1, paddingTop: insets.top }}>
         <NavigationThemeProvider value={navigationTheme}>
           <View style={{ flex: 1, backgroundColor: theme.colors.background }}>
             <View style={styles.header}>


### PR DESCRIPTION
### Short Description

This PR fixes status bar overlay with modal by setting safe area insets for android as well.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Add safe area insets for android

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Checklist

- [ ] Followed the [contributing guidelines](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md) and [conventions](https://github.com/digitalfabrik/integreat-app/blob/main/docs/conventions.md)
- [ ] Considered accessibility impacts and made the necessary adjustments
- [ ] Added or updated unit tests (if applicable)
- [ ] Added or updated documentation (if applicable)
- [ ] Added a [release note](https://github.com/digitalfabrik/integreat-app/tree/main/release-notes) for native (if [applicable](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes))

### Testing

1. Go to Maps
2. Press on `Adjust filter`
3. See the status bar

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4346 

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
