### PR TITLE
4332: Fix jumping bottom sheet in details overview in ios

### DIFF
--- a/native/src/components/PlacesBottomSheet.tsx
+++ b/native/src/components/PlacesBottomSheet.tsx
@@ -158,7 +158,6 @@ const PlacesBottomSheet = ({
       index={snapPointIndex}
       isFullscreen={isFullscreen}
       snapPoints={snapPoints}
-      enableContentPanningGesture={Platform.OS !== 'ios'}
       enableDynamicSizing={false}
       animateOnMount
       backgroundStyle={{ backgroundColor: theme.colors.background }}


### PR DESCRIPTION
### Short Description

This PR fixes not properly scrolling and jumping details overview in bottom sheet in maps by removing `enableContentPanningGesture` completely as it was before intended to fix the flickering issue on android (see the fix #4082 ) Seems like there is no flickering anymore, could the version upgrade of `@gorhom/bottom-sheet` to `5.2.14` be the reason :thinking:

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Remove `enableContentPanningGesture` completely 

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Checklist

- [ ] Followed the [contributing guidelines](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md) and [conventions](https://github.com/digitalfabrik/integreat-app/blob/main/docs/conventions.md)
- [ ] Considered accessibility impacts and made the necessary adjustments
- [ ] Added or updated unit tests (if applicable)
- [ ] Added or updated documentation (if applicable)
- [ ] Added a [release note](https://github.com/digitalfabrik/integreat-app/tree/main/release-notes) for native (if [applicable](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes))

### Testing

- Go to maps in iOS (also check android)
- Choose any place which has full information e.g. description, contacts from the bottom sheet list and open it
- Scroll to the bottom (it should immediately expand to show the rest of the view)

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4332

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
