### PR TITLE
4359: Fix failing tests for dependabot updates

### DIFF
--- a/native/jest.config.ts
+++ b/native/jest.config.ts
@@ -17,6 +17,13 @@ const transformNodeModules = [
   '@mhpdev/react-native-speech',
   'uuid',
   'qr',
+  'sanitize-html',
+  'htmlparser2',
+  'domhandler',
+  'domutils',
+  'dom-serializer',
+  'domelementtype',
+  'entities',
 ]
 process.env.TZ = 'Europe/Berlin'
 export default {

--- a/shared/jest.config.ts
+++ b/shared/jest.config.ts
@@ -9,7 +9,9 @@ export default {
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },
   testPathIgnorePatterns: ['<rootDir>/dist/', '<rootDir>/node_modules/'],
-  transformIgnorePatterns: ['node_modules/(?!(qr|uuid)/)'],
+  transformIgnorePatterns: [
+    'node_modules/(?!(qr|uuid|sanitize-html|htmlparser2|domhandler|domutils|dom-serializer|domelementtype|entities)/)',
+  ],
   transform: {
     '^.+\\.(t|j)sx?$': [
       'ts-jest',

--- a/web/jest.config.ts
+++ b/web/jest.config.ts
@@ -1,7 +1,20 @@
 /** @jest-config-loader ts-node */
 import { type JestConfigWithTsJest, createDefaultEsmPreset } from 'ts-jest'
 
-const transformNodeModules = ['shared', 'build-configs', 'translations', 'qr', 'uuid']
+const transformNodeModules = [
+  'shared',
+  'build-configs',
+  'translations',
+  'qr',
+  'uuid',
+  'sanitize-html',
+  'htmlparser2',
+  'domhandler',
+  'domutils',
+  'dom-serializer',
+  'domelementtype',
+  'entities',
+]
 process.env.TZ = 'Europe/Berlin'
 const config: JestConfigWithTsJest = {
   ...createDefaultEsmPreset(),


### PR DESCRIPTION
### Short Description

Currently dependabot can't upgrade sanitize-html due to failing tests. See the discussion: https://github.com/digitalfabrik/integreat-app/pull/4352#issuecomment-5524835001

### Proposed Changes

<!-- Describe this PR in more detail. -->

- htmlparser2 is ESM-only from version 11 onward so I adjusted jest's `transformIgnorePatterns` at web, native and shared to include these packages so jest will skip transforming them.

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Checklist

- [X] Followed the [contributing guidelines](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md) and [conventions](https://github.com/digitalfabrik/integreat-app/blob/main/docs/conventions.md)
- [X] Considered accessibility impacts and made the necessary adjustments
- [X] Added or updated unit tests (if applicable)
- [X] Added or updated documentation (if applicable)
- [X] Added a [release note](https://github.com/digitalfabrik/integreat-app/tree/main/release-notes) for native (if [applicable](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes))

### Testing

- Smoke test web and native after updating these packages.
- For this PR just run `yarn test` at root.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4359

---

<!--
DOR:
- [Release notes](https://github.com/digitalfabrik/integreat-app/blob/main/docs/contributing.md#release-notes) have been added for user visible changes
- Linting: `yarn lint`
- Typescript: `yarn ts:check`
- Prettier: `yarn prettier`
- Unit tests: `yarn test`
-->
